### PR TITLE
59 fix room limit calculation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,9 @@ module.exports = {
   ],
   rules: {
     '@intlify/vue-i18n/no-html-messages': 'error',
-    '@intlify/vue-i18n/no-raw-text': 'error',
+    '@intlify/vue-i18n/no-raw-text': ['error', {
+      ignoreNodes: ['raw-text']
+    }],
     '@intlify/vue-i18n/no-v-html': 'warn',
     semi: ['error', 'always']
   }

--- a/app/User.php
+++ b/app/User.php
@@ -74,8 +74,11 @@ class User extends Authenticatable
         if ($role_limits->contains(-1)) {
             return -1;
         }
+
         // otherwise try to find highest room limit, if none defined (=null) use global limit
-        return intval($role_limits->max() ?: setting('room_limit'));
+        $max = $role_limits->max();
+
+        return intval($max === null ? setting('room_limit') : $max);
     }
 
     /**

--- a/database/seeds/RolesAndPermissionsSeeder.php
+++ b/database/seeds/RolesAndPermissionsSeeder.php
@@ -28,7 +28,7 @@ class RolesAndPermissionsSeeder extends Seeder
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.delete' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'users.viewAny' ])->id;
 
-        $adminRole = Role::firstOrCreate([ 'name' => 'admin', 'default' => true ]);
+        $adminRole = Role::firstOrCreate([ 'name' => 'admin', 'default' => true, 'role_limit' => -1 ]);
         $adminRole->permissions()->syncWithoutDetaching($adminPermissions);
     }
 }

--- a/database/seeds/RolesAndPermissionsSeeder.php
+++ b/database/seeds/RolesAndPermissionsSeeder.php
@@ -17,25 +17,18 @@ class RolesAndPermissionsSeeder extends Seeder
     public function run()
     {
         $adminPermissions = [];
-        $userPermissions = [];
 
-        $adminPermissions[] = $userPermissions[] = Permission::firstOrCreate([ 'name' => 'rooms.create' ])->id;
+        $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'rooms.create' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'rooms.delete' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'settings.manage' ])->id;
-
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.viewAny' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.view' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.create' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.update' ])->id;
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'roles.delete' ])->id;
-
         $adminPermissions[] = Permission::firstOrCreate([ 'name' => 'users.viewAny' ])->id;
 
-        $userRole = Role::firstOrCreate([ 'name' => 'user', 'default' => true ]);
         $adminRole = Role::firstOrCreate([ 'name' => 'admin', 'default' => true ]);
-
-        $userRole->permissions()->syncWithoutDetaching($userPermissions);
         $adminRole->permissions()->syncWithoutDetaching($adminPermissions);
-        $userRole->users()->syncWithoutDetaching(User::has('roles', '=', 0)->pluck('id'));
     }
 }

--- a/resources/js/components/RawText.vue
+++ b/resources/js/components/RawText.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <slot></slot>
+  </div>
+</template>

--- a/resources/js/components/RawText.vue
+++ b/resources/js/components/RawText.vue
@@ -1,5 +1,12 @@
 <template>
-  <div>
+  <fragment>
     <slot></slot>
-  </div>
+  </fragment>
 </template>
+
+<script>
+import { Fragment } from 'vue-fragment';
+export default {
+  components: { Fragment }
+};
+</script>

--- a/resources/js/lang/de/settings.js
+++ b/resources/js/lang/de/settings.js
@@ -17,7 +17,17 @@ export default {
       label: 'Max. Anzahl an Räumen',
       default: 'Systemstandard ({value})',
       unlimited: 'Unbegrenzt',
-      custom: 'Benutzerdefinierter Wert'
+      custom: 'Benutzerdefinierter Wert',
+      helpModal: {
+        title: 'Max. Anzahl an Räumen',
+        info: 'Die max. Anzahl an eigenen Räumen ergibt sich aus dem Maximum der Begrenzungen der Rollen, welchen ein Benutzer angehört.',
+        examples: 'Beispiele',
+        systemDefault: 'Systemstandard',
+        roleA: 'Rolle A',
+        roleB: 'Rolle B',
+        maxAmount: 'Max. Anzahl',
+        note: 'X: Nutzer ist nicht Mitglied dieser Rolle'
+      }
     },
 
     default: 'Standard',

--- a/resources/js/lang/en/settings.js
+++ b/resources/js/lang/en/settings.js
@@ -17,7 +17,17 @@ export default {
       label: 'Room limit',
       default: 'System default ({value})',
       unlimited: 'Unlimited',
-      custom: 'Custom amount'
+      custom: 'Custom amount',
+      helpModal: {
+        title: 'Room limit',
+        info: 'The room limit of a user results from the maximum of the room limits of the roles a user belongs to.',
+        examples: 'Examples',
+        systemDefault: 'System default',
+        roleA: 'Role A',
+        roleB: 'Role B',
+        maxAmount: 'Room limit',
+        note: 'X: User is not member of this role'
+      }
     },
     default: 'Default',
     actions: 'Actions',

--- a/resources/js/views/settings/roles/View.vue
+++ b/resources/js/views/settings/roles/View.vue
@@ -11,7 +11,7 @@
     <b-form @submit='saveRole'>
       <b-container fluid>
         <b-form-group
-          label-cols-sm='3'
+          label-cols-sm='4'
           :label="$t('settings.roles.name')"
           label-for='name'
           :state='fieldState("name")'
@@ -19,12 +19,77 @@
           <b-form-input id='name' type='text' v-model='model.name' :state='fieldState("name")' :disabled='isBusy || viewOnly'></b-form-input>
           <template slot='invalid-feedback'><div v-html="fieldError('name')"></div></template>
         </b-form-group>
+
+        <b-modal id="modal-help-roomlimit" :hide-footer="true">
+          <template v-slot:modal-title>
+            <b-icon-info-circle></b-icon-info-circle> {{ $t('settings.roles.roomLimit.helpModal.title') }}
+          </template>
+          <p>{{ $t('settings.roles.roomLimit.helpModal.info') }}</p>
+
+          <strong>{{ $t('settings.roles.roomLimit.helpModal.examples') }}</strong>
+          <table class="table">
+            <thead>
+            <tr>
+              <th scope="col">{{ $t('settings.roles.roomLimit.helpModal.systemDefault') }}</th>
+              <th scope="col">{{ $t('settings.roles.roomLimit.helpModal.roleA') }}</th>
+              <th scope="col">{{ $t('settings.roles.roomLimit.helpModal.roleB') }}</th>
+              <th scope="col">{{ $t('settings.roles.roomLimit.helpModal.maxAmount') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td><raw-text>X</raw-text></td>
+              <td><raw-text>X</raw-text></td>
+              <td><raw-text>5</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>1</raw-text></td>
+              <td><raw-text>5</raw-text></td>
+              <td><raw-text>X</raw-text></td>
+              <td><raw-text>5</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td><raw-text>1</raw-text></td>
+              <td><raw-text>X</raw-text></td>
+              <td><raw-text>1</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td><raw-text>1</raw-text></td>
+              <td><raw-text>2</raw-text></td>
+              <td><raw-text>2</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td>{{ $t('settings.roles.roomLimit.helpModal.systemDefault') }}</td>
+              <td><raw-text>2</raw-text></td>
+              <td><raw-text>5</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td>{{ $t('settings.roles.roomLimit.helpModal.systemDefault') }}</td>
+              <td><raw-text>10</raw-text></td>
+              <td><raw-text>10</raw-text></td>
+            </tr>
+            <tr>
+              <td><raw-text>5</raw-text></td>
+              <td>{{ $t('settings.roles.roomLimit.unlimited') }}</td>
+              <td><raw-text>2</raw-text></td>
+              <td>{{ $t('settings.roles.roomLimit.unlimited') }}</td>
+            </tr>
+            </tbody>
+          </table>
+          <p>{{ $t('settings.roles.roomLimit.helpModal.note') }}</p>
+        </b-modal>
+
         <b-form-group
-          label-cols-sm='3'
-          :label="$t('settings.roles.roomLimit.label')"
+          label-cols-sm='4'
           label-for='room-limit'
           :state='fieldState("room_limit")'
         >
+          <template slot='label'>{{ $t('settings.roles.roomLimit.label') }}  <b-button variant="link" class="text-dark" v-b-modal.modal-help-roomlimit><b-icon-info-circle></b-icon-info-circle></b-button></template>
           <b-form-radio-group
             class='mb-2'
             v-model='roomLimitMode'
@@ -32,6 +97,7 @@
             :disabled='isBusy || viewOnly'
             :state='fieldState("room_limit")'
             @change="roomLimitModeChanged"
+            stacked
           ></b-form-radio-group>
           <b-form-input
             id='room-limit'
@@ -137,10 +203,13 @@ import Base from '../../../api/base';
 import FieldErrors from '../../../mixins/FieldErrors';
 import { mapGetters } from 'vuex';
 import env from '../../../env';
+import RawText from '../../../components/RawText';
 
 export default {
   mixins: [FieldErrors],
-
+  components: {
+    RawText
+  },
   props: {
     id: {
       type: [String, Number],

--- a/tests/Frontend/App.spec.js
+++ b/tests/Frontend/App.spec.js
@@ -52,7 +52,7 @@ describe('App', function () {
       data () {
         return {
           availableLocales: []
-        }
+        };
       }
     });
 

--- a/tests/Frontend/App.spec.js
+++ b/tests/Frontend/App.spec.js
@@ -48,6 +48,11 @@ describe('App', function () {
         FlashMessage: true,
         RouterView: true,
         LocaleSelector: true
+      },
+      data () {
+        return {
+          availableLocales: []
+        }
       }
     });
 

--- a/tests/Frontend/views/settings/roles/View.spec.js
+++ b/tests/Frontend/views/settings/roles/View.spec.js
@@ -444,7 +444,7 @@ describe('RolesView', function () {
       view.findComponent(BForm).trigger('submit');
 
       moxios.wait(function () {
-        const staleModelModal = view.findComponent(BModal);
+        const staleModelModal = view.findComponent({ ref: 'stale-role-modal' });
         expect(staleModelModal.vm.$data.isVisible).toBe(true);
 
         restoreRoleResponse();
@@ -509,7 +509,7 @@ describe('RolesView', function () {
       view.findComponent(BForm).trigger('submit');
 
       moxios.wait(function () {
-        const staleModelModal = view.findComponent(BModal);
+        const staleModelModal = view.findComponent({ ref: 'stale-role-modal' });
         expect(staleModelModal.vm.$data.isVisible).toBe(true);
         expect(view.findComponent(BFormInput).element.value).toBe('admin');
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -154,28 +154,76 @@ class UserTest extends TestCase
         $roleB->save();
         $this->assertEquals(10, $user->room_limit);
 
-        // Lower limit on one group, other has none, global unlimited
+        // Limit on one group, other has none, global unlimited
         setting(['room_limit' => '-1']);
         $roleA->room_limit = 1;
         $roleA->save();
-        $this->assertEquals(1, $user->room_limit);
+        $roleB->room_limit = null;
+        $roleB->save();
+        $this->assertEquals(-1, $user->room_limit);
 
-        // Lower limit on one group, other has none, global limit
+        // Limit on one group, other has none, global limit
         setting(['room_limit' => '10']);
         $roleA->room_limit = 1;
         $roleA->save();
-        $this->assertEquals(1, $user->room_limit);
+        $roleB->room_limit = null;
+        $roleB->save();
+        $this->assertEquals(10, $user->room_limit);
 
-        // Lower limit of zero on one group, other has none, global limit
+        // Limit of zero on one group, other has none, global limit
         setting(['room_limit' => '10']);
         $roleA->room_limit = 0;
         $roleA->save();
+        $roleB->room_limit = null;
+        $roleB->save();
+        $this->assertEquals(10, $user->room_limit);
+
+        // Limit of zero on one group, other has none, global unlimited
+        setting(['room_limit' => '-1']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $roleB->room_limit = null;
+        $roleB->save();
+        $this->assertEquals(-1, $user->room_limit);
+
+        // Limit of zero on both, global limit
+        setting(['room_limit' => '10']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $roleB->room_limit = 0;
+        $roleB->save();
         $this->assertEquals(0, $user->room_limit);
+
+        // Limit of zero on both, global unlimited
+        setting(['room_limit' => '-1']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $roleB->room_limit = 0;
+        $roleB->save();
+        $this->assertEquals(0, $user->room_limit);
+
+        // Limit of zero in one group, other has higher, global limit
+        setting(['room_limit' => '10']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $roleB->room_limit = 5;
+        $roleB->save();
+        $this->assertEquals(5, $user->room_limit);
 
         // Global limit, unlimited one group
         setting(['room_limit' => '10']);
         $roleA->room_limit = -1;
         $roleA->save();
+        $roleB->room_limit = null;
+        $roleB->save();
+        $this->assertEquals(-1, $user->room_limit);
+
+        // Global limit, unlimited one group
+        setting(['room_limit' => '10']);
+        $roleA->room_limit = -1;
+        $roleA->save();
+        $roleB->room_limit = 5;
+        $roleB->save();
         $this->assertEquals(-1, $user->room_limit);
 
         // Different high limits
@@ -185,13 +233,5 @@ class UserTest extends TestCase
         $roleB->room_limit = 30;
         $roleB->save();
         $this->assertEquals(30, $user->room_limit);
-
-        // Limit of zero in one group, other has higher, global limit
-        setting(['room_limit' => '10']);
-        $roleA->room_limit = 0;
-        $roleA->save();
-        $roleB->room_limit = 5;
-        $roleB->save();
-        $this->assertEquals(5, $user->room_limit);
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -166,6 +166,12 @@ class UserTest extends TestCase
         $roleA->save();
         $this->assertEquals(1, $user->room_limit);
 
+        // Lower limit of zero on one group, other has none, global limit
+        setting(['room_limit' => '10']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $this->assertEquals(0, $user->room_limit);
+
         // Global limit, unlimited one group
         setting(['room_limit' => '10']);
         $roleA->room_limit = -1;
@@ -179,5 +185,13 @@ class UserTest extends TestCase
         $roleB->room_limit = 30;
         $roleB->save();
         $this->assertEquals(30, $user->room_limit);
+
+        // Limit of zero in one group, other has higher, global limit
+        setting(['room_limit' => '10']);
+        $roleA->room_limit = 0;
+        $roleA->save();
+        $roleB->room_limit = 5;
+        $roleB->save();
+        $this->assertEquals(5, $user->room_limit);
     }
 }


### PR DESCRIPTION
# Fixes \#

## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Changed room limit calculation to a simpler algorithm
- Added room limit calculation help modal to role settings
- Added raw-text component, to bypass no-raw-text rule of eslint in special cases where a translation isn't needed
- Removed unnecessary user default role and added unlimited room limit to admin role
- Fix tests