### PR TITLE
138 Hide room types from search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Not listable room types in room filter ([#138], [#140])
 
 ## [1.3.0] - 2021-05-05
 ### Added
@@ -135,6 +137,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#132]: https://github.com/THM-Health/PILOS/pull/132
 [#136]: https://github.com/THM-Health/PILOS/issues/136
 [#137]: https://github.com/THM-Health/PILOS/pull/137
+[#138]: https://github.com/THM-Health/PILOS/issues/138
+[#140]: https://github.com/THM-Health/PILOS/pull/140
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v1.3.0...HEAD
 [1.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v1.0.0

--- a/app/Http/Controllers/api/v1/RoomTypeController.php
+++ b/app/Http/Controllers/api/v1/RoomTypeController.php
@@ -9,6 +9,7 @@ use App\RoomType;
 use App\Http\Resources\RoomType as RoomTypeResource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
+use Illuminate\Http\Request;
 
 class RoomTypeController extends Controller
 {
@@ -23,9 +24,19 @@ class RoomTypeController extends Controller
      *
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
-    public function index()
+    public function index(Request $request)
     {
-        return RoomTypeResource::collection(RoomType::all());
+        $roomTypes = RoomType::query();
+
+        if ($request->has('filter')) {
+            $filter = $request->get('filter');
+
+            if ($filter === 'searchable') {
+                $roomTypes->where('allow_listing', '=', true);
+            }
+        }
+
+        return RoomTypeResource::collection($roomTypes->get());
     }
 
     /**

--- a/resources/js/views/rooms/Index.vue
+++ b/resources/js/views/rooms/Index.vue
@@ -105,6 +105,7 @@
 import Base from '../../api/base';
 import Can from '../../components/Permissions/Can';
 import Cannot from '../../components/Permissions/Cannot';
+import PermissionService from '../../services/PermissionService';
 
 export default {
   components: { Can, Cannot },
@@ -170,7 +171,18 @@ export default {
      */
     loadRoomTypes () {
       this.roomTypesBusy = true;
-      Base.call('roomTypes').then(response => {
+
+      let config;
+
+      if (PermissionService.cannot('viewAll', 'RoomPolicy')) {
+        config = {
+          params: {
+            filter: 'searchable'
+          }
+        };
+      }
+
+      Base.call('roomTypes', config).then(response => {
         this.roomTypes = response.data.data;
         this.roomTypesLoadingError = false;
       }).catch(error => {

--- a/tests/Frontend/views/rooms/Index.spec.js
+++ b/tests/Frontend/views/rooms/Index.spec.js
@@ -256,7 +256,7 @@ describe('Room Index', function () {
         message: 'Test'
       }
     });
-    moxios.stubRequest('/api/v1/roomTypes', {
+    moxios.stubRequest('/api/v1/roomTypes?filter=searchable', {
       status: 200,
       response: exampleRoomTypeResponse
     });
@@ -324,7 +324,7 @@ describe('Room Index', function () {
       status: 200,
       response: exampleRoomResponse
     });
-    moxios.stubRequest('/api/v1/roomTypes', {
+    moxios.stubRequest('/api/v1/roomTypes?filter=searchable', {
       status: 500,
       response: {
         message: 'Test'
@@ -352,7 +352,7 @@ describe('Room Index', function () {
       Base.error.restore();
 
       // restore valid response
-      const restoreRoomResponse = overrideStub('/api/v1/roomTypes', {
+      const restoreRoomResponse = overrideStub('/api/v1/roomTypes?filter=searchable', {
         status: 200,
         response: exampleRoomTypeResponse
       });


### PR DESCRIPTION
# Fixes \#138

## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Room types filter only shows searchable room types for users without permission *rooms.viewAll*
