### PR TITLE
Add meeting starting status and atomic lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Rooms can be started simultaneously which leads to users being in different bbb rooms ([#172])
+- Rooms can be closed directly after being created by a failed join request or cronjob, if the bbb api response is slow ([#170], [#172])
+
 ## [1.6.0] - 2021-11-01
 ### Added
 - Personalized room tokens ([#72], [#145])
@@ -196,6 +200,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#165]: https://github.com/THM-Health/PILOS/pull/165
 [#166]: https://github.com/THM-Health/PILOS/issues/166
 [#167]: https://github.com/THM-Health/PILOS/pull/167
+[#170]: https://github.com/THM-Health/PILOS/issues/170
+[#172]: https://github.com/THM-Health/PILOS/pull/172
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v1.6.0...HEAD
 [1.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v1.0.0

--- a/app/Http/Controllers/api/v1/MeetingController.php
+++ b/app/Http/Controllers/api/v1/MeetingController.php
@@ -37,7 +37,7 @@ class MeetingController extends Controller
             ->select('meetings.*');
 
         // Filter only running meetings
-        $resource = $resource->whereNull('end');
+        $resource = $resource->whereNull('end')->whereNotNull('start');
 
         // And-search, sub queries split by space
         if ($request->has('search') && trim($request->search) != '') {

--- a/app/Http/Controllers/api/v1/RoomController.php
+++ b/app/Http/Controllers/api/v1/RoomController.php
@@ -155,11 +155,11 @@ class RoomController extends Controller
 
         // Atomic lock for room start to prevent users from simultaneously starting the same room
         // Maximum waiting time 45sec before failing
-        $lock = Cache::lock('startroom-'.$room->id, 45);
+        $lock = Cache::lock('startroom-'.$room->id, config('bigbluebutton.server_timeout'));
 
         try {
             // Block the lock for a max. of 45sec
-            $lock->block(45);
+            $lock->block(config('bigbluebutton.server_timeout'));
 
             $meeting = $room->runningMeeting();
             if (!$meeting) {

--- a/app/Http/Controllers/api/v1/RoomController.php
+++ b/app/Http/Controllers/api/v1/RoomController.php
@@ -230,7 +230,6 @@ class RoomController extends Controller
                 $meeting->save();
                 $lock->release();
             } else {
-                \Log::info('meeting running');
                 // meeting in still starting
                 if ($meeting->start == null) {
                     $lock->release();

--- a/app/Http/Controllers/api/v1/RoomController.php
+++ b/app/Http/Controllers/api/v1/RoomController.php
@@ -12,7 +12,9 @@ use App\Meeting;
 use App\Room;
 use App\RoomType;
 use Auth;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 class RoomController extends Controller
 {
@@ -151,65 +153,105 @@ class RoomController extends Controller
         }
         $id   = Auth::guest() ? 's' . session()->getId() : 'u' . Auth::user()->id;
 
-        $meeting = $room->runningMeeting();
-        if (!$meeting) {
-            if ($room->roomTypeInvalid) {
-                abort(CustomStatusCodes::ROOM_TYPE_INVALID, __('app.errors.room_type_invalid'));
-            }
+        // Atomic lock for room start to prevent users from simultaneously starting the same room
+        // Maximum waiting time 45sec before failing
+        $lock = Cache::lock('startroom-'.$room->id, 45);
 
-            // Check if user didn't see the attendance recording note, but the attendance is recorded
-            if (setting('attendance.enabled') && $room->record_attendance && !$request->record_attendance) {
-                abort(CustomStatusCodes::ATTENDANCE_AGREEMENT_MISSING, __('app.errors.attendance_agreement_missing'));
-            }
+        try {
+            // Block the lock for a max. of 45sec
+            $lock->block(45);
 
-            // Create new meeting
-            $meeting                    = new Meeting();
-            $meeting->start             = date('Y-m-d H:i:s');
-            $meeting->attendeePW        = bin2hex(random_bytes(5));
-            $meeting->moderatorPW       = bin2hex(random_bytes(5));
-            $meeting->record_attendance = setting('attendance.enabled') && $room->record_attendance;
-
-            // Basic load balancing, get server with lowest usage
-            $server =  $room->roomType->serverPool->lowestUsage();
-
-            // If no server found, throw error
-            if ($server == null) {
-                abort(CustomStatusCodes::NO_SERVER_AVAILABLE, __('app.errors.no_server_available'));
-            }
-
-            $meeting->server()->associate($server);
-            $meeting->room()->associate($room);
-            $meeting->save();
-
-            // Try to start meeting
-            try {
-                $result = $meeting->startMeeting();
-            } // Catch exceptions, e.g. network connection issues
-            catch (\Exception $exception) {
-                // Remove meeting and set server to offline
-                $meeting->forceDelete();
-                $server->apiCallFailed();
-                abort(CustomStatusCodes::ROOM_START_FAILED, __('app.errors.room_start'));
-            }
-
-            // Check server response for meeting creation
-            if (!$result->success()) {
-                // Meeting creation failed, remove meeting
-                $meeting->forceDelete();
-                // Check for some errors
-                switch ($result->getMessageKey()) {
-                    // checksum error, api token invalid, set server to offline, try to create on other server
-                    case 'checksumError':
-                        $server->apiCallFailed();
-
-                        break;
-                    // for other unknown reasons, just respond, that room creation failed
-                    // the error is probably server independent
-                    default:
-                        break;
+            $meeting = $room->runningMeeting();
+            if (!$meeting) {
+                if ($room->roomTypeInvalid) {
+                    $lock->release();
+                    abort(CustomStatusCodes::ROOM_TYPE_INVALID, __('app.errors.room_type_invalid'));
                 }
-                abort(CustomStatusCodes::ROOM_START_FAILED, __('app.errors.room_start'));
+
+                // Check if user didn't see the attendance recording note, but the attendance is recorded
+                if (setting('attendance.enabled') && $room->record_attendance && !$request->record_attendance) {
+                    $lock->release();
+                    abort(CustomStatusCodes::ATTENDANCE_AGREEMENT_MISSING, __('app.errors.attendance_agreement_missing'));
+                }
+
+                // Create new meeting
+                $meeting                    = new Meeting();
+                $meeting->attendeePW        = bin2hex(random_bytes(5));
+                $meeting->moderatorPW       = bin2hex(random_bytes(5));
+                $meeting->record_attendance = setting('attendance.enabled') && $room->record_attendance;
+
+                // Basic load balancing, get server with lowest usage
+                $server = $room->roomType->serverPool->lowestUsage();
+
+                // If no server found, throw error
+                if ($server == null) {
+                    $lock->release();
+                    abort(CustomStatusCodes::NO_SERVER_AVAILABLE, __('app.errors.no_server_available'));
+                }
+
+                $meeting->server()->associate($server);
+                $meeting->room()->associate($room);
+                $meeting->save();
+
+                // Try to start meeting
+                try {
+                    $result = $meeting->startMeeting();
+                } // Catch exceptions, e.g. network connection issues
+                catch (\Exception $exception) {
+                    // Remove meeting and set server to offline
+                    $meeting->forceDelete();
+                    $server->apiCallFailed();
+                    $lock->release();
+                    abort(CustomStatusCodes::ROOM_START_FAILED, __('app.errors.room_start'));
+                }
+
+                // Check server response for meeting creation
+                if (!$result->success()) {
+                    // Meeting creation failed, remove meeting
+                    $meeting->forceDelete();
+                    // Check for some errors
+                    switch ($result->getMessageKey()) {
+                        // checksum error, api token invalid, set server to offline, try to create on other server
+                        case 'checksumError':
+                            $server->apiCallFailed();
+
+                            break;
+                        // for other unknown reasons, just respond, that room creation failed
+                        // the error is probably server independent
+                        default:
+                            break;
+                    }
+                    $lock->release();
+                    abort(CustomStatusCodes::ROOM_START_FAILED, __('app.errors.room_start'));
+                }
+
+                // Set start time after successful api call, prevents user from tying to join this meeting before it is ready
+                $meeting->start = date('Y-m-d H:i:s');
+                $meeting->save();
+                $lock->release();
+            } else {
+                \Log::info('meeting running');
+                // meeting in still starting
+                if ($meeting->start == null) {
+                    $lock->release();
+                    abort(CustomStatusCodes::MEETING_NOT_RUNNING, __('app.errors.not_running'));
+                }
+                // Check if the meeting is actually running on the server
+                if (!$meeting->isRunning()) {
+                    $meeting->setEnd();
+                    $lock->release();
+                    abort(CustomStatusCodes::MEETING_NOT_RUNNING, __('app.errors.not_running'));
+                }
+
+                // Check if user didn't see the attendance recording note, but the attendance is recorded
+                if (setting('attendance.enabled') && $meeting->record_attendance && !$request->record_attendance) {
+                    $lock->release();
+                    abort(CustomStatusCodes::ATTENDANCE_AGREEMENT_MISSING, __('app.errors.attendance_agreement_missing'));
+                }
+                $lock->release();
             }
+        } catch (LockTimeoutException $e) {
+            abort(CustomStatusCodes::ROOM_START_FAILED, __('app.errors.room_start'));
         }
 
         return response()->json([
@@ -242,7 +284,12 @@ class RoomController extends Controller
 
         // Check if there is a meeting running for this room, accordingly to the local database
         $meeting = $room->runningMeeting();
+        // no meeting found
         if ($meeting == null) {
+            abort(CustomStatusCodes::MEETING_NOT_RUNNING, __('app.errors.not_running'));
+        }
+        // meeting in still starting
+        if ($meeting->start == null) {
             abort(CustomStatusCodes::MEETING_NOT_RUNNING, __('app.errors.not_running'));
         }
 
@@ -332,6 +379,6 @@ class RoomController extends Controller
     {
         $this->authorize('viewStatistics', $room);
 
-        return \App\Http\Resources\Meeting::collection($room->meetings()->orderByDesc('start')->paginate(setting('pagination_page_size')));
+        return \App\Http\Resources\Meeting::collection($room->meetings()->orderByDesc('start')->whereNotNull('start')->paginate(setting('pagination_page_size')));
     }
 }

--- a/app/Room.php
+++ b/app/Room.php
@@ -153,7 +153,7 @@ class Room extends Model
      */
     public function runningMeeting()
     {
-        return $this->meetings()->whereNull('end')->orderByDesc('start')->first();
+        return $this->meetings()->whereNull('end')->orderByDesc('created_at')->first();
     }
 
     /** Check if user is moderator of this room

--- a/app/Server.php
+++ b/app/Server.php
@@ -213,7 +213,7 @@ class Server extends Model
     {
         // Get list with all meetings marked in the db as running and collect meetings
         // that are currently running on the server
-        $allRunningMeetingsInDb      = $this->meetings()->whereNull('end')->pluck('id');
+        $allRunningMeetingsInDb      = $this->meetings()->whereNull('end')->whereNotNull('start')->pluck('id');
         $allRunningMeetingsOnServers = new Collection();
 
         if ($this->status != ServerStatus::DISABLED) {

--- a/app/Server.php
+++ b/app/Server.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Enums\ServerStatus;
 use App\Traits\AddsModelNameTrait;
 use BigBlueButton\BigBlueButton;
+use BigBlueButton\Http\Transport\CurlTransport;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -70,7 +71,8 @@ class Server extends Model
     public function bbb()
     {
         if ($this->bbb == null) {
-            $this->setBBB(new BigBlueButton($this->base_url, $this->salt));
+            $transport  = CurlTransport::createWithDefaultOptions([CURLOPT_TIMEOUT => config('bigbluebutton.server_timeout')]);
+            $this->setBBB(new BigBlueButton($this->base_url, $this->salt, $transport));
         }
 
         return $this->bbb;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "littleredbutton/bigbluebutton-api-php": "^4.0.0",
-        "maatwebsite/excel": "^3.1"
+        "maatwebsite/excel": "^3.1",
+      "ext-curl": "*"
     },
     "require-dev": {
         "ext-simplexml": "*",

--- a/config/bigbluebutton.php
+++ b/config/bigbluebutton.php
@@ -9,4 +9,5 @@ return [
     'room_name_limit' => env('MIX_ROOM_NAME_LIMIT',50),
     'room_id_max_tries' =>  env('BBB_ROOM_ID_MAX_TRIES',1000),
     'user_search_limit' =>  env('USER_SEARCH_LIMIT',10),
+    'server_timeout' => env('BBB_SERVER_TIMEOUT', 30)
 ];

--- a/tests/Feature/api/v1/MeetingTest.php
+++ b/tests/Feature/api/v1/MeetingTest.php
@@ -41,17 +41,18 @@ class MeetingTest extends TestCase
         $page_size = 5;
         setting(['pagination_page_size' => $page_size]);
 
-        $oldMeeting      = Meeting::factory()->create();
-        $runningMeetings = Meeting::factory()->count(7)->create(['end'=>null]);
-        $server          = Server::factory()->create(['name'=>'Testserver']);
-        $user1           = User::factory()->create(['firstname'=>'John','lastname'=>'Doe']);
-        $user2           = User::factory()->create(['firstname'=>'Max','lastname'=>'Doe']);
-        $room1           = Room::factory()->create(['name'=>'Test room 1','user_id'=>$user1->id,'participant_count'=>5]);
-        $room2           = Room::factory()->create(['name'=>'Test room 2','user_id'=>$user1->id,'participant_count'=>4]);
-        $room3           = Room::factory()->create(['name'=>'Test room 3','user_id'=>$user2->id,'participant_count'=>1]);
-        $meeting1        = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room1->id,'start'=>'2021-01-12 8:40:20','end'=>null]);
-        $meeting2        = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room2->id,'start'=>'2021-01-12 8:42:30','end'=>null]);
-        $meeting3        = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room3->id,'start'=>'2021-01-12 8:42:55','end'=>null]);
+        $oldMeeting       = Meeting::factory()->create();
+        $startingMeetings = Meeting::factory()->count(7)->create(['start'=>null, 'end'=>null]);
+        $runningMeetings  = Meeting::factory()->count(7)->create(['end'=>null]);
+        $server           = Server::factory()->create(['name'=>'Testserver']);
+        $user1            = User::factory()->create(['firstname'=>'John','lastname'=>'Doe']);
+        $user2            = User::factory()->create(['firstname'=>'Max','lastname'=>'Doe']);
+        $room1            = Room::factory()->create(['name'=>'Test room 1','user_id'=>$user1->id,'participant_count'=>5]);
+        $room2            = Room::factory()->create(['name'=>'Test room 2','user_id'=>$user1->id,'participant_count'=>4]);
+        $room3            = Room::factory()->create(['name'=>'Test room 3','user_id'=>$user2->id,'participant_count'=>1]);
+        $meeting1         = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room1->id,'start'=>'2021-01-12 8:40:20','end'=>null]);
+        $meeting2         = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room2->id,'start'=>'2021-01-12 8:42:30','end'=>null]);
+        $meeting3         = Meeting::factory()->create(['server_id'=>$server->id,'room_id'=>$room3->id,'start'=>'2021-01-12 8:42:55','end'=>null]);
 
         // Test guests
         $this->getJson(route('api.v1.meetings.index'))

--- a/tests/Feature/api/v1/Room/RoomStatisticTest.php
+++ b/tests/Feature/api/v1/Room/RoomStatisticTest.php
@@ -61,6 +61,7 @@ class RoomStatisticTest extends TestCase
         $meetings[] = new Meeting(['start' => '2020-10-09 17:12:23', 'end' => '2020-10-09 17:45:11']);
         $meetings[] = new Meeting(['start' => '2020-12-03 10:54:34', 'end' => '2020-12-03 11:09:53']);
         $meetings[] = new Meeting(['start' => '2021-01-07 19:32:54', 'end' => null]);
+        $meetings[] = new Meeting(['start' => null, 'end' => null]);
         $room->meetings()->saveMany($meetings);
 
         // create meetings for room

--- a/tests/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Feature/api/v1/Room/RoomTest.php
@@ -6,6 +6,7 @@ use App\Enums\CustomStatusCodes;
 use App\Enums\RoomLobby;
 use App\Enums\RoomUserRole;
 use App\Enums\ServerStatus;
+use App\Meeting;
 use App\Permission;
 use App\Role;
 use App\Room;
@@ -1092,6 +1093,41 @@ class RoomTest extends TestCase
     }
 
     /**
+     * Tests starting new meeting with a running bbb server
+     */
+    public function testStartWithServerMeetingRunning()
+    {
+        // Add room, real servers and a fake meeting
+        $room = Room::factory()->create();
+        $this->seed(ServerSeeder::class);
+        $meeting = Meeting::factory()->create(['room_id'=> $room->id, 'start' => null, 'end' => null, 'server_id' => Server::all()->first()]);
+
+        // Start room that is currently starting but not ready yet
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.start', ['room' => $room, 'record_attendance' => 0]))
+            ->assertStatus(460);
+        $meeting->refresh();
+        $this->assertNull($meeting->end);
+
+        // Start room that should run on the server but isn't
+        $meeting->start = now();
+        $meeting->save();
+        // Start room that is currently starting but not ready yet
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.start', ['room' => $room, 'record_attendance' => 0]))
+            ->assertStatus(460);
+        $meeting->refresh();
+        $this->assertNotNull($meeting->end);
+
+        // Start room without recording acceptance, but a room with attendance recording is already running
+        setting(['attendance.enabled' => true]);
+        $room->record_attendance = true;
+        $room->save();
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.start', ['room' => $room, 'record_attendance' => 1]))
+            ->assertSuccessful();
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.start', ['room' => $room, 'record_attendance' => 0]))
+            ->assertStatus(470);
+    }
+
+    /**
      * Tests if record attendance is set on start
      */
     public function testRecordAttendanceStatus()
@@ -1209,6 +1245,16 @@ class RoomTest extends TestCase
         // Testing join with meeting not running
         $this->actingAs($room->owner)->getJson(route('api.v1.rooms.join', ['room'=>$room,'record_attendance' => 1]))
             ->assertStatus(CustomStatusCodes::MEETING_NOT_RUNNING);
+
+        // Testing join with meeting that is starting, but not ready yet
+        $meeting              = $room->meetings()->create();
+        $meeting->attendeePW  = bin2hex(random_bytes(5));
+        $meeting->moderatorPW = bin2hex(random_bytes(5));
+        $meeting->server()->associate(Server::where('status', ServerStatus::ONLINE)->get()->random());
+        $meeting->save();
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.join', ['room'=>$room,'record_attendance' => 1]))
+            ->assertStatus(CustomStatusCodes::MEETING_NOT_RUNNING);
+        $meeting->delete();
 
         // Test to join a meeting marked in the db as running, but isn't running on the server
         $meeting              = $room->meetings()->create();


### PR DESCRIPTION
# Fixes #170

## Type (Highlight the corresponding type)
- **Bugfix**
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [ ] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Refactoring the creation of meetings when starting a new room to prevent users from joining a meeting that is not yet ready and to prevent the cronjob from checking these meetings, which could lead to them being deleted immediately
- Add atomic locks for starting a room to prevent users from simultaneously starting the same room, which could lead to two meeting beeing opend

## Other information


