### PR TITLE
Bump minimal php version in ci to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.4', '8.0']
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
         npm ci
         npm run ci
     - name: Execute tests (Unit and Feature tests) via PHPUnit and upload coverage
-      if: matrix.php-versions == '7.3'
+      if: matrix.php-versions == '7.4'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         DB_PORT: ${{ job.services.mariadb.ports[3306] }}
@@ -94,7 +94,7 @@ jobs:
         vendor/bin/paratest --coverage-clover=coverage.xml
         bash <(curl -s https://codecov.io/bash)
     - name: Execute tests (Unit and Feature tests) via PHPUnit
-      if: matrix.php-versions != '7.3'
+      if: matrix.php-versions != '7.4'
       env:
         DB_PORT: ${{ job.services.mariadb.ports[3306] }}
         TESTING_BBB: ${{ secrets.TESTING_BBB }}


### PR DESCRIPTION
## Type (Highlight the corresponding type)
- Bugfix
- Feature
- Documentation
- **Refactoring** 
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Remove php 7.3 from CI
- Add php 8.0 to CI


