### PR TITLE
Add custom directive to close tooltip on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Tooltip covering view and edit button in server pool overview ([#245],[#246])
+- Tooltip not hiding ([#252],[#256])
 
 ### Removed
 - **Breaking:** .env setting MIX_FRONTEND_BASE_URL ([#243],[#244])
@@ -330,8 +331,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#246]: https://github.com/THM-Health/PILOS/pull/246
 [#249]: https://github.com/THM-Health/PILOS/pull/249
 [#250]: https://github.com/THM-Health/PILOS/pull/250
+[#252]: https://github.com/THM-Health/PILOS/issues/252
 [#254]: https://github.com/THM-Health/PILOS/pull/254
 [#255]: https://github.com/THM-Health/PILOS/pull/255
+[#256]: https://github.com/THM-Health/PILOS/pull/256
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v1.9.5...HEAD
 [1.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v1.0.0

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     '.*\\.(vue)$': '@vue/vue2-jest',
     '^.+\\.js$': 'babel-jest'
   },
+  collectCoverageFrom: ['<rootDir>/resources/js/**/*.{js,vue}'],
   // (optional) with that you can import your components like
   // "import Counter from '@/Counter.vue'"
   // (no need for a full path)

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@ import i18n from './i18n';
 import FlashMessage from '@smartweb/vue-flash-message';
 import Clipboard from 'v-clipboard';
 import Base from './api/base';
+import HideTooltip from './directives/hide-tooltip';
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
@@ -32,6 +33,8 @@ if (process.env.ENABLE_AXE && process.env.NODE_ENV === 'development') {
 }
 
 Vue.config.errorHandler = Base.error;
+
+Vue.directive('tooltip-hide-click', HideTooltip);
 
 export default new Vue({
   el: '#app',

--- a/resources/js/components/Room/DeleteRoomComponent.vue
+++ b/resources/js/components/Room/DeleteRoomComponent.vue
@@ -7,6 +7,7 @@
       :title="$t('rooms.modals.delete.title')"
       ref="deleteButton"
       v-b-tooltip.hover
+      v-tooltip-hide-click
       @click="$bvModal.show('remove-modal')"
       :disabled="disabled"
     >

--- a/resources/js/components/Room/FileComponent.vue
+++ b/resources/js/components/Room/FileComponent.vue
@@ -48,6 +48,7 @@
           @click="reload"
           :title="$t('app.reload')"
           v-b-tooltip.hover
+          v-tooltip-hide-click
         >
           <i class="fa-solid fa-sync"></i>
         </b-button>
@@ -89,6 +90,7 @@
                 @click="showDeleteFileModal(data.item)"
                 :title="$t('rooms.files.delete')"
                 v-b-tooltip.hover
+                v-tooltip-hide-click
               >
                 <i class="fa-solid fa-trash"></i>
               </b-button>
@@ -101,6 +103,7 @@
               target="_blank"
               :title="$t('rooms.files.view')"
               v-b-tooltip.hover
+              v-tooltip-hide-click
             >
               <b-spinner small v-if="loadingDownload===data.item.id"></b-spinner> <i v-else class="fa-solid fa-eye"></i>
             </b-button>

--- a/resources/js/components/Room/HistoryComponent.vue
+++ b/resources/js/components/Room/HistoryComponent.vue
@@ -24,6 +24,7 @@
             @click="$root.$emit('bv::refresh::table', 'meetings-table')"
             :title="$t('app.reload')"
             v-b-tooltip.hover
+            v-tooltip-hide-click
           >
             <i class="fa-solid fa-sync"></i>
           </b-button>
@@ -66,6 +67,7 @@
             <template v-slot:cell(actions)="data">
               <b-button
                 v-b-tooltip.hover
+                v-tooltip-hide-click
                 :title="$t('meetings.viewMeetingStats')"
                 :disabled='meetingsLoading || statsLoading || attendanceLoading'
                 v-if="data.item.statistical"
@@ -76,6 +78,7 @@
               </b-button>
               <b-button
                 v-b-tooltip.hover
+                v-tooltip-hide-click
                 :title="$t('meetings.viewMeetingAttendance')"
                 :disabled='meetingsLoading || statsLoading || attendanceLoading'
                 v-if="data.item.attendance && data.item.end != null"

--- a/resources/js/components/Room/MembersComponent.vue
+++ b/resources/js/components/Room/MembersComponent.vue
@@ -24,6 +24,7 @@
             :disabled="isBusy"
             :title="$t('app.reload')"
             v-b-tooltip.hover
+            v-tooltip-hide-click
           >
             <i class="fa-solid fa-sync"></i>
           </b-button>
@@ -63,6 +64,7 @@
                 variant="secondary"
                 @click="showEditMemberModal(data.item)"
                 v-b-tooltip.hover
+                v-tooltip-hide-click
                 :title="$t('rooms.members.editUser')"
               >
                 <i class="fa-solid fa-user-edit"></i>
@@ -73,6 +75,7 @@
                 variant="danger"
                 @click="showRemoveMemberModal(data.item)"
                 v-b-tooltip.hover
+                v-tooltip-hide-click
                 :title="$t('rooms.members.deleteUser')"
               >
                 <i class="fa-solid fa-trash"></i>

--- a/resources/js/components/Room/SettingsComponent.vue
+++ b/resources/js/components/Room/SettingsComponent.vue
@@ -78,6 +78,7 @@
                     variant="outline-secondary"
                     :title="$t('rooms.settings.general.resetDuration')"
                     v-b-tooltip.hover
+                    v-tooltip-hide-click
                   ><i class="fa-solid fa-trash"></i
                   ></b-button>
                 </b-input-group-append>
@@ -100,6 +101,7 @@
                     variant="outline-secondary"
                     :title="$t('rooms.settings.security.generateAccessCode')"
                     v-b-tooltip.hover
+                    v-tooltip-hide-click
                   ><i class="fa-solid fa-dice"></i
                   ></b-button>
                 </b-input-group-prepend>
@@ -120,6 +122,7 @@
                     variant="outline-secondary"
                     :title="$t('rooms.settings.security.deleteAccessCode')"
                     v-b-tooltip.hover
+                    v-tooltip-hide-click
                   ><i class="fa-solid fa-trash"></i
                   ></b-button>
                 </b-input-group-append>
@@ -192,6 +195,7 @@
                       variant="outline-secondary"
                       :title="$t('rooms.settings.participants.clearMaxParticipants')"
                       v-b-tooltip.hover
+                      v-tooltip-hide-click
                     ><i class="fa-solid fa-trash"></i
                     ></b-button>
                   </b-input-group-append>

--- a/resources/js/components/Room/TokensComponent.vue
+++ b/resources/js/components/Room/TokensComponent.vue
@@ -21,6 +21,7 @@
               :disabled="isBusy"
               :title="$t('app.reload')"
               v-b-tooltip.hover
+              v-tooltip-hide-click
             >
               <i class="fa-solid fa-sync"></i>
             </b-button>
@@ -69,6 +70,7 @@
                   @click="copyPersonalizedRoomLink(data.item)"
                   :title="$t('rooms.tokens.copy')"
                   v-b-tooltip.hover
+                  v-tooltip-hide-click
                 >
                   <i class="fa-solid fa-link"></i>
                 </b-button>
@@ -79,6 +81,7 @@
                     @click="showTokenEditModal(data.item)"
                     :title="$t('rooms.tokens.edit')"
                     v-b-tooltip.hover
+                    v-tooltip-hide-click
                   >
                     <i class="fa-solid fa-pen-square"></i>
                   </b-button>
@@ -88,6 +91,7 @@
                     @click="showTokenDeleteModal(data.item)"
                     :title="$t('rooms.tokens.delete')"
                     v-b-tooltip.hover
+                    v-tooltip-hide-click
                   >
                     <i class="fa-solid fa-trash"></i>
                   </b-button>

--- a/resources/js/components/RoomType/RoomTypeSelect.vue
+++ b/resources/js/components/RoomType/RoomTypeSelect.vue
@@ -16,6 +16,7 @@
         variant="outline-secondary"
         :title="$t('rooms.roomTypes.reload')"
         v-b-tooltip.hover
+        v-tooltip-hide-click
       ><i class="fa-solid fa-sync"  v-bind:class="{ 'fa-spin': isLoadingAction  }"></i
       ></b-button>
     </b-input-group-append>

--- a/resources/js/directives/hide-tooltip.js
+++ b/resources/js/directives/hide-tooltip.js
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+
+// Hide tooltip on click
+const hideTooltip = (element, vnode) => {
+  vnode.context.$root.$emit('bv::hide::tooltip', element.getAttribute('id'));
+};
+
+// Directive to close tooltip on click
+// usage: add to component with: v-tooltip-hide-click
+export default {
+  bind (element, binding, vnode) {
+    // If element doesn't have an id, create a random id to close tooltip later
+    if (element.getAttribute('id') == null) {
+      element.setAttribute('id', _.uniqueId('randid-'));
+    }
+
+    element.addEventListener('click', () => {
+      hideTooltip(element, vnode);
+    });
+  },
+  unbind (element, binding, vnode) {
+    element.removeEventListener('click', () => {
+      hideTooltip(element, vnode);
+    });
+  }
+};

--- a/resources/js/views/meetings/Index.vue
+++ b/resources/js/views/meetings/Index.vue
@@ -122,6 +122,7 @@
       <template v-slot:cell(actions)="data">
         <b-button
           v-b-tooltip.hover
+          v-tooltip-hide-click
           :title="$t('meetings.viewRoom', { name: data.item.room.name })"
           :disabled='isBusy'
           variant='info'

--- a/resources/js/views/rooms/Index.vue
+++ b/resources/js/views/rooms/Index.vue
@@ -15,7 +15,7 @@
         <b-input-group>
           <b-form-input @change="loadRooms" :disabled="isBusy || loadingError" ref="search" :placeholder="$t('app.search')" v-model="filter"></b-form-input>
           <b-input-group-append>
-            <b-button @click="loadRooms" :disabled="isBusy || loadingError" variant="primary" v-b-tooltip.hover :title="$t('app.toSearch')"><i class="fa-solid fa-magnifying-glass"></i></b-button>
+            <b-button @click="loadRooms" :disabled="isBusy || loadingError" variant="primary" v-tooltip-hide-click v-b-tooltip.hover :title="$t('app.toSearch')"><i class="fa-solid fa-magnifying-glass"></i></b-button>
           </b-input-group-append>
         </b-input-group>
       </b-col>

--- a/resources/js/views/rooms/OwnIndex.vue
+++ b/resources/js/views/rooms/OwnIndex.vue
@@ -5,7 +5,7 @@
           <b-input-group>
             <b-form-input @change="search" :disabled="loadingOwn || loadingShared" ref="search" :placeholder="$t('app.search')" v-model="rawSearchQuery"></b-form-input>
             <b-input-group-append>
-              <b-button @click="search" :disabled="loadingOwn || loadingShared" variant="primary" v-b-tooltip.hover :title="$t('app.toSearch')"><i class="fa-solid fa-magnifying-glass"></i></b-button>
+              <b-button @click="search" :disabled="loadingOwn || loadingShared" variant="primary" v-tooltip-hide-click v-b-tooltip.hover :title="$t('app.toSearch')"><i class="fa-solid fa-magnifying-glass"></i></b-button>
             </b-input-group-append>
           </b-input-group>
         </b-col>

--- a/resources/js/views/rooms/View.vue
+++ b/resources/js/views/rooms/View.vue
@@ -45,6 +45,7 @@
           :title="$t('app.reload')"
           ref="reloadButton"
           v-b-tooltip.hover
+          v-tooltip-hide-click
           v-on:click="reload"
           :disabled="loading"
         >

--- a/resources/js/views/settings/roles/Index.vue
+++ b/resources/js/views/settings/roles/Index.vue
@@ -6,6 +6,7 @@
         <b-button
           class='float-right'
           v-b-tooltip.hover
+          v-tooltip-hide-click
           variant='success'
           :title="$t('settings.roles.new')"
           :to="{ name: 'settings.roles.view', params: { id: 'new' } }"
@@ -51,6 +52,7 @@
           <can method='view' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.roles.view', { name: data.item.id })"
               :disabled='isBusy'
               variant='info'
@@ -62,6 +64,7 @@
           <can method='update' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.roles.edit', { name: data.item.id })"
               :disabled='isBusy'
               variant='secondary'
@@ -73,6 +76,7 @@
           <can method='delete' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.roles.delete.item', { id: data.item.id })"
               :disabled='isBusy'
               variant='danger'

--- a/resources/js/views/settings/roomTypes/Index.vue
+++ b/resources/js/views/settings/roomTypes/Index.vue
@@ -6,6 +6,7 @@
         <b-button
           class='float-right'
           v-b-tooltip.hover
+          v-tooltip-hide-click
           variant='success'
           :title="$t('settings.roomTypes.new')"
           :to="{ name: 'settings.room_types.view', params: { id: 'new' } }"
@@ -52,6 +53,7 @@
         <can method='view' :policy='data.item'>
           <b-button
             v-b-tooltip.hover
+            v-tooltip-hide-click
             :title="$t('settings.roomTypes.view', { name: data.item.description })"
             :disabled='isBusy'
             variant='info'
@@ -63,6 +65,7 @@
         <can method='update' :policy='data.item'>
           <b-button
             v-b-tooltip.hover
+            v-tooltip-hide-click
             :title="$t('settings.roomTypes.edit', { name: data.item.description })"
             :disabled='isBusy'
             variant='secondary'
@@ -74,6 +77,7 @@
         <can method='delete' :policy='data.item'>
           <b-button
             v-b-tooltip.hover
+            v-tooltip-hide-click
             :title="$t('settings.roomTypes.delete.item', { id: data.item.description })"
             :disabled='isBusy'
             variant='danger'

--- a/resources/js/views/settings/serverPools/Index.vue
+++ b/resources/js/views/settings/serverPools/Index.vue
@@ -9,6 +9,7 @@
             <b-button
               class='ml-2 float-right'
               v-b-tooltip.hover
+              v-tooltip-hide-click
               variant='success'
               ref="newServerPool"
               :title="$t('settings.serverPools.new')"
@@ -64,6 +65,7 @@
           <can method='view' :policy='data.item'>
             <b-button
               v-b-tooltip.hover.bottom
+              v-tooltip-hide-click
               :title="$t('settings.serverPools.view', { name: data.item.name })"
               :disabled='isBusy'
               variant='info'
@@ -75,6 +77,7 @@
           <can method='update' :policy='data.item'>
             <b-button
               v-b-tooltip.hover.bottom
+              v-tooltip-hide-click
               :title="$t('settings.serverPools.edit', { name: data.item.name })"
               :disabled='isBusy'
               variant='secondary'
@@ -86,6 +89,7 @@
           <can method='delete' :policy='data.item'>
             <b-button
               v-b-tooltip.hover.bottom
+              v-tooltip-hide-click
               :title="$t('settings.serverPools.delete.item', { name: data.item.name })"
               :disabled='isBusy'
               variant='danger'

--- a/resources/js/views/settings/servers/Index.vue
+++ b/resources/js/views/settings/servers/Index.vue
@@ -9,6 +9,7 @@
             <b-button
               class='ml-2 float-right'
               v-b-tooltip.hover
+              v-tooltip-hide-click
               variant='success'
               ref="newServer"
               :title="$t('settings.servers.new')"
@@ -96,6 +97,7 @@
           <can method='view' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.servers.view', { name: data.item.name })"
               :disabled='isBusy'
               variant='info'
@@ -107,6 +109,7 @@
           <can method='update' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.servers.edit', { name: data.item.name })"
               :disabled='isBusy'
               variant='secondary'
@@ -119,6 +122,7 @@
             <b-button
               v-if="data.item.status===-1"
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.servers.delete.item', { name: data.item.name })"
               :disabled='isBusy'
               variant='danger'
@@ -146,6 +150,7 @@
       <br><br>
       <b-button
         v-b-tooltip.hover
+        v-tooltip-hide-click
         size="sm"
         variant='info'
         :disabled="isBusy"

--- a/resources/js/views/settings/servers/View.vue
+++ b/resources/js/views/settings/servers/View.vue
@@ -67,7 +67,7 @@
             <b-input-group>
               <b-form-input id='salt' :type='hideSalt ? "password": "text"' v-model='model.salt' :state='fieldState("salt")' :disabled='isBusy || modelLoadingError || viewOnly'></b-form-input>
               <b-input-group-append>
-                <b-button @click="hideSalt = !hideSalt" :disabled='isBusy || modelLoadingError' v-b-tooltip.hover :title="hideSalt ? $t('settings.servers.showSalt') : $t('settings.servers.hideSalt')" variant="secondary"><i class="fa-solid fa-eye" v-if="hideSalt"></i><i class="fa-solid fa-eye-slash" v-else></i></b-button>
+                <b-button @click="hideSalt = !hideSalt" :disabled='isBusy || modelLoadingError' v-tooltip-hide-click v-b-tooltip.hover :title="hideSalt ? $t('settings.servers.showSalt') : $t('settings.servers.hideSalt')" variant="secondary"><i class="fa-solid fa-eye" v-if="hideSalt"></i><i class="fa-solid fa-eye-slash" v-else></i></b-button>
               </b-input-group-append>
             </b-input-group>
             <template slot='invalid-feedback'><div v-html="fieldError('salt')"></div></template>

--- a/resources/js/views/settings/users/Index.vue
+++ b/resources/js/views/settings/users/Index.vue
@@ -11,6 +11,7 @@
             <b-button
               class='float-right'
               v-b-tooltip.hover
+              v-tooltip-hide-click
               variant='success'
               :title="$t('settings.users.new')"
               :to="{ name: 'settings.users.view', params: { id: 'new' } }"
@@ -147,6 +148,7 @@
           <can method='view' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.users.view', { firstname: data.item.firstname, lastname: data.item.lastname })"
               :disabled='isBusy'
               variant='info'
@@ -159,6 +161,7 @@
           <can method='update' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.users.edit', { firstname: data.item.firstname, lastname: data.item.lastname })"
               :disabled='isBusy'
               variant='secondary'
@@ -172,6 +175,7 @@
             <b-button
               :id="'resetPassword' + data.item.id"
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.users.resetPassword.item', { firstname: data.item.firstname, lastname: data.item.lastname })"
               :disabled='isBusy'
               variant='warning'
@@ -184,6 +188,7 @@
           <can method='delete' :policy='data.item'>
             <b-button
               v-b-tooltip.hover
+              v-tooltip-hide-click
               :title="$t('settings.users.delete.item', { firstname: data.item.firstname, lastname: data.item.lastname })"
               :disabled='isBusy'
               variant='danger'

--- a/tests/Frontend/directives/HideTooltip.spec.js
+++ b/tests/Frontend/directives/HideTooltip.spec.js
@@ -9,11 +9,19 @@ localVue.directive('tooltip-hide-click', HideTooltip);
 
 const testComponent = {
   name: 'test-component',
+  props: {
+    hideButtons: {
+      type: Boolean,
+      default: false,
+      required: false
+    }
+  },
   /* eslint-disable @intlify/vue-i18n/no-raw-text */
   template: '<div>' +
-    '<b-button title="test" v-b-tooltip.hover v-tooltip-hide-click>button1</b-button>' +
-    '<b-button title="test" v-b-tooltip.hover v-tooltip-hide-click>button2</b-button>' +
-    '<b-button title="test" id="demo" v-b-tooltip.hover v-tooltip-hide-click>button3</b-button>' +
+    '<b-button title="test" v-if="!hideButtons" v-b-tooltip.hover >button1</b-button>' +
+    '<b-button title="test" v-if="!hideButtons" v-b-tooltip.hover v-tooltip-hide-click>button2</b-button>' +
+    '<b-button title="test" v-b-tooltip.hover v-tooltip-hide-click>button3</b-button>' +
+    '<b-button title="test" id="demo" v-b-tooltip.hover v-tooltip-hide-click>button4</b-button>' +
     '</div>'
 };
 
@@ -26,9 +34,12 @@ describe('HideTooltip', () => {
 
     const buttons = wrapper.findAllComponents(BButton);
 
-    expect(buttons.at(0).attributes('id')).toBe('randid-1');
-    expect(buttons.at(1).attributes('id')).toBe('randid-2');
-    expect(buttons.at(2).attributes('id')).toBe('demo');
+    expect(buttons.at(0).attributes('id')).toBeUndefined();
+    expect(buttons.at(1).attributes('id')).toBe('randid-1');
+    expect(buttons.at(2).attributes('id')).toBe('randid-2');
+    expect(buttons.at(3).attributes('id')).toBe('demo');
+
+    wrapper.destroy();
   });
 
   it('trigger click', async () => {
@@ -44,13 +55,46 @@ describe('HideTooltip', () => {
 
     await buttons.at(0).trigger('click');
     await wrapper.vm.$nextTick();
+    expect(emitted).toEqual({});
 
+    await buttons.at(1).trigger('click');
+    await wrapper.vm.$nextTick();
     expect(emitted['bv::hide::tooltip'].length).toBe(1);
-    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(0).attributes('id')]]);
+    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(1).attributes('id')]]);
 
-    await buttons.at(2).trigger('click');
+    await buttons.at(3).trigger('click');
     await wrapper.vm.$nextTick();
     expect(emitted['bv::hide::tooltip'].length).toBe(2);
-    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(0).attributes('id')], ['demo']]);
+    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(1).attributes('id')], ['demo']]);
+
+    wrapper.destroy();
+  });
+
+  it('test unbind', async () => {
+    const wrapper = mount(testComponent, {
+      localVue,
+      attachTo: createContainer()
+    });
+
+    let buttons = wrapper.findAllComponents(BButton);
+
+    // Spy on button with and without directive
+    const spy1 = jest.fn();
+    const spy2 = jest.fn();
+    wrapper.findAllComponents(BButton).at(0).element.removeEventListener = spy1;
+    wrapper.findAllComponents(BButton).at(1).element.removeEventListener = spy2;
+
+    expect(buttons.length).toBe(4);
+
+    await wrapper.setProps({ hideButtons: true });
+    await wrapper.vm.$nextTick();
+
+    buttons = wrapper.findAllComponents(BButton);
+    expect(buttons.length).toBe(2);
+
+    // check if button with directive has one more removeEventListener call
+    expect(spy2).toBeCalledTimes(spy1.mock.calls.length + 1);
+
+    wrapper.destroy();
   });
 });

--- a/tests/Frontend/directives/HideTooltip.spec.js
+++ b/tests/Frontend/directives/HideTooltip.spec.js
@@ -1,0 +1,56 @@
+import { createLocalVue, createWrapper, mount } from '@vue/test-utils';
+import { createContainer } from '../helper';
+import BootstrapVue, { BButton } from 'bootstrap-vue';
+import HideTooltip from '../../../resources/js/directives/hide-tooltip';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+localVue.directive('tooltip-hide-click', HideTooltip);
+
+const testComponent = {
+  name: 'test-component',
+  /* eslint-disable @intlify/vue-i18n/no-raw-text */
+  template: '<div>' +
+    '<b-button title="test" v-b-tooltip.hover v-tooltip-hide-click>button1</b-button>' +
+    '<b-button title="test" v-b-tooltip.hover v-tooltip-hide-click>button2</b-button>' +
+    '<b-button title="test" id="demo" v-b-tooltip.hover v-tooltip-hide-click>button3</b-button>' +
+    '</div>'
+};
+
+describe('HideTooltip', () => {
+  it('adding random id', async () => {
+    const wrapper = mount(testComponent, {
+      localVue,
+      attachTo: createContainer()
+    });
+
+    const buttons = wrapper.findAllComponents(BButton);
+
+    expect(buttons.at(0).attributes('id')).toBe('randid-1');
+    expect(buttons.at(1).attributes('id')).toBe('randid-2');
+    expect(buttons.at(2).attributes('id')).toBe('demo');
+  });
+
+  it('trigger click', async () => {
+    const wrapper = mount(testComponent, {
+      localVue,
+      attachTo: createContainer()
+    });
+    const rootWrapper = createWrapper(wrapper.vm.$root);
+
+    const buttons = wrapper.findAllComponents(BButton);
+
+    const emitted = rootWrapper.emitted();
+
+    await buttons.at(0).trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(emitted['bv::hide::tooltip'].length).toBe(1);
+    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(0).attributes('id')]]);
+
+    await buttons.at(2).trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(emitted['bv::hide::tooltip'].length).toBe(2);
+    expect(emitted['bv::hide::tooltip']).toStrictEqual([[buttons.at(0).attributes('id')], ['demo']]);
+  });
+});

--- a/tests/Frontend/setup.js
+++ b/tests/Frontend/setup.js
@@ -19,5 +19,7 @@ if (!process.env.MIX_DEFAULT_LOCALE) {
 }
 
 const Vue = require('vue');
+const HideTooltip = require('../../resources/js/directives/hide-tooltip');
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
+Vue.directive('tooltip-hide-click', HideTooltip);


### PR DESCRIPTION
# Fixes #252 

## Type (Highlight the corresponding type)
- **Bugfix**
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Add custom directive v-tooltip-hide-click to close tooltip on click

## Other information
Tooltip was not hidden if button was disabled. The disabling was mostly caused by user actions, so hiding the tooltip on a user-action resolves 99% of the occurrences. The issue only persists if the disabled attribute is caused by something else than a user-action (e.g. background reload)