### PR TITLE
Show meeting status in overview and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved change of base url, welcome message limit, room name limit, room refresh rate ([#243],[#244])
 - Override welcome page, feature component and footer with custom code ([#234],[#235],[#249])
 - OpenLDAP and phpLDAPadmin to local dev environment ([#225],[#250])
+- Meeting running indicator to own rooms page and find room / all rooms list ([#253],[#258])
 
 ### Changed
 - Upgrade to Laravel 9 ([#226],[#227])
@@ -332,9 +333,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#249]: https://github.com/THM-Health/PILOS/pull/249
 [#250]: https://github.com/THM-Health/PILOS/pull/250
 [#252]: https://github.com/THM-Health/PILOS/issues/252
+[#253]: https://github.com/THM-Health/PILOS/issues/253
 [#254]: https://github.com/THM-Health/PILOS/pull/254
 [#255]: https://github.com/THM-Health/PILOS/pull/255
 [#256]: https://github.com/THM-Health/PILOS/pull/256
+[#258]: https://github.com/THM-Health/PILOS/pull/258
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v1.9.5...HEAD
 [1.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v1.0.0

--- a/app/Http/Resources/Room.php
+++ b/app/Http/Resources/Room.php
@@ -48,6 +48,7 @@ class Room extends JsonResource
                 'id'   => $this->owner->id,
                 'name' => $this->owner->fullname,
             ],
+            'running'           => $runningMeeting != null,
             'type'              => new RoomType($this->roomType),
             'model_name'        => $this->model_name,
             $this->mergeWhen($this->details, [
@@ -60,7 +61,6 @@ class Room extends JsonResource
                 'canStart'          => Gate::inspect('start', [$this->resource, $this->token])->allowed(),
                 'accessCode'        => $this->when(Gate::inspect('viewAccessCode', [$this->resource])->allowed(), $this->accessCode),
                 'roomTypeInvalid'   => $this->roomTypeInvalid,
-                'running'           => $runningMeeting != null,
                 'record_attendance' => !setting('attendance.enabled') ? false : ($runningMeeting != null ? $runningMeeting->record_attendance : $this->resource->record_attendance),
                 'current_user'      => (new UserResource(\Illuminate\Support\Facades\Auth::user()))->withPermissions()->withoutRoles()
             ])

--- a/resources/js/components/Room/RoomComponent.vue
+++ b/resources/js/components/Room/RoomComponent.vue
@@ -3,6 +3,7 @@
     <b-overlay :show="loading" rounded="sm">
     <b-card no-body bg-variant="white" class="room-card" @click="open()">
       <b-card-body class="p-3">
+        <room-status-component :running="running"></room-status-component>
         <b-row>
           <b-col cols="3" sm="3"><div v-if="type" v-b-tooltip.hover :title="type.description" class="room-icon" :style="{ 'background-color': type.color}">{{type.short}}</div></b-col>
           <b-col col><h5 class="mt-2 text-break " style="width: 100%">{{name}}</h5></b-col>
@@ -16,7 +17,9 @@
   </div>
 </template>
 <script>
+import RoomStatusComponent from './RoomStatusComponent';
 export default {
+  components: { RoomStatusComponent },
   data () {
     return {
       loading: false
@@ -25,6 +28,10 @@ export default {
   props: {
     id: String,
     name: String,
+    running: {
+      type: Boolean,
+      default: false
+    },
     shared: {
       type: Boolean,
       default: false

--- a/resources/js/components/Room/RoomStatusComponent.vue
+++ b/resources/js/components/Room/RoomStatusComponent.vue
@@ -1,0 +1,21 @@
+<template>
+  <div
+    v-bind:class="{running: running}"
+    v-b-tooltip.hover
+    :title="running ? $t('rooms.status.running') : $t('rooms.status.notRunning')"
+    class="room-status"
+  >
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RoomStatusComponent',
+  props: {
+    running: {
+      type: Boolean,
+      default: false
+    }
+  }
+};
+</script>

--- a/resources/js/lang/de/rooms.js
+++ b/resources/js/lang/de/rooms.js
@@ -11,6 +11,10 @@ export default {
   sharedRooms: 'Mit mir geteilte Räume',
   start: 'Starten',
   notRunning: 'Der Raum ist noch nicht gestartet.',
+  status: {
+    running: 'Meeting läuft',
+    notRunning: 'Kein laufendes Meeting'
+  },
   tryAgain: 'Erneut versuchen',
   join: 'Teilnehmen',
   recordingAttendanceInfo: 'Die Anwesenheit in diesem Raum wird protokolliert.',

--- a/resources/js/lang/en/rooms.js
+++ b/resources/js/lang/en/rooms.js
@@ -11,6 +11,10 @@ export default {
   sharedRooms: 'Rooms shared with me',
   start: 'Start',
   notRunning: 'This room is not started yet.',
+  status: {
+    running: 'Meeting running',
+    notRunning: 'No running meeting'
+  },
   tryAgain: 'Try again',
   join: 'Join',
   recordingAttendanceInfo: 'The attendance in this room is logged.',

--- a/resources/js/views/rooms/Index.vue
+++ b/resources/js/views/rooms/Index.vue
@@ -74,6 +74,7 @@
           <b-list-group>
             <b-list-group-item button :disabled="openRoom" v-for="room in rooms" :key="room.id" @click="open(room)" class="flex-column align-items-start">
               <div class="d-flex w-100 justify-content-between">
+                <room-status-component :running="room.running"></room-status-component>
                 <div>
                   <h5 class="mb-0">{{ room.name }}</h5>
                   <small>
@@ -106,9 +107,10 @@ import Base from '../../api/base';
 import Can from '../../components/Permissions/Can';
 import Cannot from '../../components/Permissions/Cannot';
 import PermissionService from '../../services/PermissionService';
+import RoomStatusComponent from '../../components/Room/RoomStatusComponent';
 
 export default {
-  components: { Can, Cannot },
+  components: { RoomStatusComponent, Can, Cannot },
 
   data () {
     return {

--- a/resources/js/views/rooms/OwnIndex.vue
+++ b/resources/js/views/rooms/OwnIndex.vue
@@ -49,7 +49,7 @@
           </b-row>
           <b-pagination
             class="mt-4"
-            v-if="sharedRooms.meta.last_page != 1"
+            v-if="sharedRooms.meta.last_page !== 1"
             v-model="sharedRooms.meta.current_page"
             :total-rows="sharedRooms.meta.total"
             :per-page="sharedRooms.meta.per_page"

--- a/resources/js/views/rooms/OwnIndex.vue
+++ b/resources/js/views/rooms/OwnIndex.vue
@@ -18,7 +18,7 @@
           <em v-else-if="!ownRooms.data.length">{{ $t('rooms.noRoomsAvailableSearch') }}</em>
           <b-row cols="1" cols-sm="2" cols-md="2" cols-lg="3">
             <b-col v-for="room in ownRooms.data" :key="room.id" class="pt-2">
-              <room-component :id="room.id" :name="room.name" :type="room.type"></room-component>
+              <room-component :id="room.id" :name="room.name" :type="room.type" :running="room.running"></room-component>
             </b-col>
             <can method="create" policy="RoomPolicy" v-if="!limitReached">
             <b-col class="pt-2">
@@ -44,7 +44,7 @@
           <em v-else-if="!sharedRooms.data.length">{{ $t('rooms.noRoomsAvailableSearch') }}</em>
           <b-row cols="1" cols-sm="2" cols-md="2" cols-lg="3">
             <b-col v-for="room in sharedRooms.data" :key="room.id" class="pt-2">
-              <room-component :id="room.id" :name="room.name" v-bind:shared="true"  :shared-by="room.owner" :type="room.type"></room-component>
+              <room-component :id="room.id" :name="room.name" v-bind:shared="true" :running="room.running" :shared-by="room.owner" :type="room.type"></room-component>
             </b-col>
           </b-row>
           <b-pagination

--- a/resources/sass/app/_room.scss
+++ b/resources/sass/app/_room.scss
@@ -20,3 +20,25 @@
 .room-card:hover{
     background-color: darken(#FFF, 7.5%) !important;
 }
+
+.room-status {
+    content: '';
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    @if($showRoomClosedIndicator) {
+        display: block;
+        background-color: $red;
+    }
+    @else {
+        display: none;
+    }
+}
+
+.room-status.running {
+    display: block;
+    background-color: $green;
+}

--- a/resources/sass/theme/default/_variables.scss
+++ b/resources/sass/theme/default/_variables.scss
@@ -32,3 +32,6 @@ $background-text-color: ("primary": null, "secondary": null, "success": null, "i
 
 // Elements to have rounded edges
 $enable-rounded: true;
+
+// Show red indicator if room is closed/not running
+$showRoomClosedIndicator: false;

--- a/resources/sass/theme/thm/_variables.scss
+++ b/resources/sass/theme/thm/_variables.scss
@@ -30,5 +30,8 @@ $background-text-color: ("primary": #FFF, "success": #FFF, "warning": #FFF);
 // Elements to have rounded edges
 $enable-rounded: false;
 
+// Show red indicator if room is closed/not running
+$showRoomClosedIndicator: false;
+
 // Typography
 $font-family-sans-serif: 'Source Sans Pro', sans-serif;

--- a/tests/Frontend/components/Room/RoomStatus.spec.js
+++ b/tests/Frontend/components/Room/RoomStatus.spec.js
@@ -1,0 +1,81 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import { createContainer } from '../../helper';
+import RoomStatusComponent from '../../../../resources/js/components/Room/RoomStatusComponent';
+import BootstrapVue from 'bootstrap-vue';
+
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+describe('RoomStatus', () => {
+  it('empty status', async () => {
+    const view = mount(RoomStatusComponent, {
+      localVue,
+      mocks: {
+        $t: (key, values) => key + (values !== undefined ? ':' + JSON.stringify(values) : '')
+      },
+      attachTo: createContainer()
+    });
+
+    const status = view.find('div');
+    expect(status.attributes('title')).toBe('rooms.status.notRunning');
+    expect(status.classes()).toEqual(['room-status']);
+  });
+  it('offline status', async () => {
+    const view = mount(RoomStatusComponent, {
+      localVue,
+      propsData: {
+        running: false
+      },
+      mocks: {
+        $t: (key, values) => key + (values !== undefined ? ':' + JSON.stringify(values) : '')
+      },
+      attachTo: createContainer()
+    });
+
+    const status = view.find('div');
+    expect(status.attributes('title')).toBe('rooms.status.notRunning');
+    expect(status.classes()).toEqual(['room-status']);
+  });
+  it('online status', async () => {
+    const view = mount(RoomStatusComponent, {
+      localVue,
+      propsData: {
+        running: true
+      },
+      mocks: {
+        $t: (key, values) => key + (values !== undefined ? ':' + JSON.stringify(values) : '')
+      },
+      attachTo: createContainer()
+    });
+
+    const status = view.find('div');
+    expect(status.attributes('title')).toBe('rooms.status.running');
+    expect(status.classes()).toEqual(['room-status', 'running']);
+  });
+  it('status change', async () => {
+    const view = mount(RoomStatusComponent, {
+      localVue,
+      propsData: {
+        running: true
+      },
+      mocks: {
+        $t: (key, values) => key + (values !== undefined ? ':' + JSON.stringify(values) : '')
+      },
+      attachTo: createContainer()
+    });
+
+    const status = view.find('div');
+    expect(status.attributes('title')).toBe('rooms.status.running');
+    expect(status.classes()).toEqual(['room-status', 'running']);
+
+    await view.setProps({ running: false });
+    await view.vm.$nextTick();
+    expect(status.attributes('title')).toBe('rooms.status.notRunning');
+    expect(status.classes()).toEqual(['room-status']);
+
+    await view.setProps({ running: true });
+    await view.vm.$nextTick();
+    expect(status.attributes('title')).toBe('rooms.status.running');
+    expect(status.classes()).toEqual(['room-status', 'running']);
+  });
+});

--- a/tests/Frontend/views/rooms/Index.spec.js
+++ b/tests/Frontend/views/rooms/Index.spec.js
@@ -15,6 +15,7 @@ import Vuex from 'vuex';
 import PermissionService from '../../../../resources/js/services/PermissionService';
 import Base from '../../../../resources/js/api/base';
 import { waitMoxios, overrideStub, createContainer } from '../../helper';
+import RoomStatusComponent from '../../../../resources/js/components/Room/RoomStatusComponent';
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
@@ -68,6 +69,7 @@ describe('Room Index', () => {
           id: 1,
           name: 'John Doe'
         },
+        running: false,
         type: {
           id: 2,
           short: 'ME',
@@ -83,6 +85,7 @@ describe('Room Index', () => {
           id: 2,
           name: 'Max Doe'
         },
+        running: true,
         type: {
           id: 1,
           short: 'VL',
@@ -193,10 +196,12 @@ describe('Room Index', () => {
     expect(rooms.at(0).get('h5').text()).toEqual('Meeting One');
     expect(rooms.at(0).get('small').text()).toEqual('John Doe');
     expect(rooms.at(0).get('.room-icon').text()).toEqual('ME');
+    expect(rooms.at(0).findComponent(RoomStatusComponent).props('running')).toBeFalsy();
 
     expect(rooms.at(1).get('h5').text()).toEqual('Meeting Two');
     expect(rooms.at(1).get('small').text()).toEqual('Max Doe');
     expect(rooms.at(1).get('.room-icon').text()).toEqual('VL');
+    expect(rooms.at(1).findComponent(RoomStatusComponent).props('running')).toBeTruthy();
 
     // check if all room types are shown
     const roomTypes = view.findAll('[name="room-types-checkbox"]');

--- a/tests/Frontend/views/rooms/OwnIndex.spec.js
+++ b/tests/Frontend/views/rooms/OwnIndex.spec.js
@@ -62,6 +62,7 @@ describe('Own Room Index', () => {
           id: 1,
           name: 'John Doe'
         },
+        running: false,
         type: {
           id: 2,
           short: 'ME',
@@ -90,6 +91,7 @@ describe('Own Room Index', () => {
           id: 1,
           name: 'John Doe'
         },
+        running: true,
         type: {
           id: 2,
           short: 'ME',
@@ -105,6 +107,7 @@ describe('Own Room Index', () => {
           id: 1,
           name: 'John Doe'
         },
+        running: false,
         type: {
           id: 2,
           short: 'ME',
@@ -133,7 +136,7 @@ describe('Own Room Index', () => {
     ]
   };
 
-  it('check list of rooms', async () => {
+  it('check list of rooms and attribute bindings', async () => {
     moxios.stubRequest('/api/v1/rooms?filter=own&page=1', {
       status: 200,
       response: exampleOwnRoomResponse
@@ -163,8 +166,26 @@ describe('Own Room Index', () => {
     expect(view.vm.sharedRooms).toEqual(exampleSharedRoomResponse);
     const rooms = view.findAllComponents(RoomComponent);
 
-    expect(rooms.filter(room => room.vm.shared === false).length).toBe(1);
-    expect(rooms.filter(room => room.vm.shared === true).length).toBe(2);
+    expect(rooms.at(0).vm.id).toBe('abc-def-123');
+    expect(rooms.at(0).vm.name).toBe('Meeting One');
+    expect(rooms.at(0).vm.shared).toBe(false);
+    expect(rooms.at(0).vm.type).toEqual({ id: 2, short: 'ME', description: 'Meeting', color: '#4a5c66', default: false });
+    expect(rooms.at(0).vm.running).toBe(false);
+    expect(rooms.at(0).vm.sharedBy).toBeUndefined();
+
+    expect(rooms.at(1).vm.id).toBe('def-abc-123');
+    expect(rooms.at(1).vm.name).toBe('Meeting Two');
+    expect(rooms.at(1).vm.shared).toBe(true);
+    expect(rooms.at(1).vm.type).toEqual({ id: 2, short: 'ME', description: 'Meeting', color: '#4a5c66', default: false });
+    expect(rooms.at(1).vm.running).toBe(true);
+    expect(rooms.at(1).vm.sharedBy).toEqual({ id: 1, name: 'John Doe' });
+
+    expect(rooms.at(2).vm.id).toBe('def-abc-456');
+    expect(rooms.at(2).vm.name).toBe('Meeting Three');
+    expect(rooms.at(2).vm.shared).toBe(true);
+    expect(rooms.at(2).vm.type).toEqual({ id: 2, short: 'ME', description: 'Meeting', color: '#4a5c66', default: false });
+    expect(rooms.at(2).vm.running).toBe(false);
+    expect(rooms.at(2).vm.sharedBy).toEqual({ id: 1, name: 'John Doe' });
 
     view.destroy();
   });
@@ -180,6 +201,7 @@ describe('Own Room Index', () => {
         id: 1,
         name: 'John Doe'
       },
+      running: false,
       type: {
         id: 2,
         short: 'ME',
@@ -258,6 +280,7 @@ describe('Own Room Index', () => {
               id: 1,
               name: 'John Doe'
             },
+            running: false,
             type: {
               id: 2,
               short: 'ME',
@@ -273,6 +296,7 @@ describe('Own Room Index', () => {
               id: 1,
               name: 'John Doe'
             },
+            running: false,
             type: {
               id: 2,
               short: 'ME',


### PR DESCRIPTION
# Fixes #253

## Type (Highlight the corresponding type)
- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Add meeting status to general room attributes
- Show meeting running status on own rooms page and in find room / all rooms list
- Add option in theme to show a red dot if meeting not running ($showRoomClosedIndicator in resources/sass/theme/{THEME}/_variables.scss)