### PR TITLE
Remove the deprecated Docker « links » statement for phpmyadmin/phpldapadmin

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -67,7 +67,7 @@ services:
       ports:
         - '${FORWARD_PHPLDAPADMIN_PORT:-6680}:80'
       environment:
-        PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'openldap': [{'server': []},{'login': [{'bind_id': 'cn=admin,dc=university,dc=org', 'bind_pass': 'admin'}]}]}]"
+        PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'Local LDAP': [{'server': [{'host': 'openldap'}]},{'login': [{'bind_id': 'cn=admin,dc=university,dc=org'},{'bind_pass': 'admin'},{'auth_type': 'config'}]}]}]"
         PHPLDAPADMIN_HTTPS: 'false'
 volumes:
   mariadb:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -67,7 +67,7 @@ services:
       ports:
         - '${FORWARD_PHPLDAPADMIN_PORT:-6680}:80'
       environment:
-        PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'ldap-host': [{'server': []},{'login': [{'bind_id': 'cn=admin,dc=university,dc=org', 'bind_pass': 'admin'}]}]}]"
+        PHPLDAPADMIN_LDAP_HOSTS: "#PYTHON2BASH:[{'openldap': [{'server': []},{'login': [{'bind_id': 'cn=admin,dc=university,dc=org', 'bind_pass': 'admin'}]}]}]"
         PHPLDAPADMIN_HTTPS: 'false'
 volumes:
   mariadb:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -44,8 +44,6 @@ services:
         - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
     phpmyadmin:
       image: phpmyadmin/phpmyadmin
-      links:
-        - db:db
       ports:
         - '${FORWARD_PHPMYADMIN_PORT:-8080}:80'
       environment:
@@ -66,8 +64,6 @@ services:
       command: --copy-service
     phpldapadmin:
       image: osixia/phpldapadmin
-      links:
-        - openldap:ldap-host
       ports:
         - '${FORWARD_PHPLDAPADMIN_PORT:-6680}:80'
       environment:


### PR DESCRIPTION
# Fixes \#

## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [X] Code updated to current masters head
- [X] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- The statement « links » is deprecated since at least 5 or 6 years ago and seems useless is this specific development case ( https://docs.docker.com/network/links/ )

## Other information

- This also permit to developers that uses podman rather than docker to work on this project, because podman doesn't support this very old deprecated statement ( https://github.com/containers/podman/issues/11717 )
