### PR TITLE
Change node source repository

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -3,7 +3,7 @@ FROM php:8.1-fpm-bullseye
 LABEL maintainer="Samuel Weirich"
 LABEL description="Development container for PILOS, compatible with laravel sail; heavily inspired by offical image"
 
-ARG NODE_VERSION=16
+ARG NODE_VERSION=18
 ARG WWWGROUP=33
 ARG WWWUSER=33
 
@@ -15,6 +15,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
+    && mkdir -p /etc/apt/keyrings \
     && apt-get install -y gnupg gosu curl ca-certificates zip unzip pv libzip-dev git supervisor libcap2-bin libpng-dev python2 \
     && apt-get install -y nginx \
     && apt-get install -y default-mysql-client libpq-dev \
@@ -25,7 +26,9 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) bcmath pdo_mysql pdo_pgsql pgsql ldap zip gd opcache \
     && pecl install xdebug-3.1.5 \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
-    && curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && apt-get -y autoremove \


### PR DESCRIPTION
This remove the wait time of 60s while building the image due to script deprecation. This follows instruction linked at 'https://github.com/nodesource/distributions'

See laravel sail: https://github.com/laravel/sail/pull/613/commits/eeb652ddffb60809b031d6a01cf909d9f51038ff