### PR TITLE
Allow more chars for role name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow more characters for role names ([#535], [#536])
 
 ## [v2.2.0] - 2023-08-28
 ### Added
@@ -634,6 +636,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#505]: https://github.com/THM-Health/PILOS/issues/505
 [#506]: https://github.com/THM-Health/PILOS/pull/506
 [#509]: https://github.com/THM-Health/PILOS/pull/509
+[#535]: https://github.com/THM-Health/PILOS/issues/535
+[#536]: https://github.com/THM-Health/PILOS/pull/536
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v2.2.0...HEAD
 [v1.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v1.0.0

--- a/app/Http/Requests/RoleRequest.php
+++ b/app/Http/Requests/RoleRequest.php
@@ -15,14 +15,14 @@ class RoleRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'name'          => ['required', 'string', 'alpha_dash', 'max:255', Rule::unique('roles', 'name')],
+            'name'          => ['required', 'string', 'max:255', Rule::unique('roles', 'name')],
             'room_limit'    => 'nullable|int|min:-1',
             'permissions'   => 'present|array',
             'permissions.*' => 'distinct|exists:App\Models\Permission,id'
         ];
 
         if ($this->role) {
-            $rules['name']       = ['required', 'string', 'alpha_dash', 'max:255', Rule::unique('roles', 'name')->ignore($this->role->id)];
+            $rules['name']       = ['required', 'string', 'max:255', Rule::unique('roles', 'name')->ignore($this->role->id)];
             $rules['updated_at'] = 'required|date';
         }
 

--- a/tests/Feature/api/v1/RoleTest.php
+++ b/tests/Feature/api/v1/RoleTest.php
@@ -85,11 +85,11 @@ class RoleTest extends TestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors(['name', 'permissions.0']);
 
-        $role['name']        = '**';
+        $role['name']        = 'Test';
         $role['permissions'] = [self::INVALID_ID];
         $this->postJson(route('api.v1.roles.store', $role))
             ->assertStatus(422)
-            ->assertJsonValidationErrors(['name', 'permissions.0']);
+            ->assertJsonValidationErrors(['permissions.0']);
 
         $role['name']        = 'Test';
         $role['permissions'] = [$permission_id];


### PR DESCRIPTION
# Fixes #535 

## Type (Highlight the corresponding type)
- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current masters head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Allow more different characters for role names

## Other information

Previously only alphanumeric characters, hyphens and underscores were allowed


