### PR TITLE
Rename env options for server health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to drain a server ([#911])
 - Show server connection status in server list ([#911])
 - End detached meetings after server failure ([#911])
-- Config options for server health `BBB_SERVER_HEALTHY_THRESHOLD` and `BBB_SERVER_UNHEALTHY_THRESHOLD` ([#911])
+- Config options for server health `BBB_SERVER_ONLINE_THRESHOLD` and `BBB_SERVER_OFFLINE_THRESHOLD` ([#911])
 - Config option for server load calculation `BBB_LOAD_MIN_USER_COUNT` and `BBB_LOAD_MIN_USER_INTERVAL` ([#956])
 - Plugin to customize the server load calculation ([#956])
 - Save selected room tab in url to preserve selection on reload ([#977])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to drain a server ([#911])
 - Show server connection status in server list ([#911])
 - End detached meetings after server failure ([#911])
-- Config options for server health `BBB_SERVER_ONLINE_THRESHOLD` and `BBB_SERVER_OFFLINE_THRESHOLD` ([#911])
+- Config options for server health `BBB_SERVER_ONLINE_THRESHOLD` and `BBB_SERVER_OFFLINE_THRESHOLD` ([#911], [#1076])
 - Config option for server load calculation `BBB_LOAD_MIN_USER_COUNT` and `BBB_LOAD_MIN_USER_INTERVAL` ([#956])
 - Plugin to customize the server load calculation ([#956])
 - Save selected room tab in url to preserve selection on reload ([#977])
@@ -120,6 +120,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1045]: https://github.com/THM-Health/PILOS/issues/1045
 [#1059]: https://github.com/THM-Health/PILOS/pull/1059
 [#1071]: https://github.com/THM-Health/PILOS/issues/1071
+[#1076]: https://github.com/THM-Health/PILOS/issues/1076
 
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v3.0.3...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/app/Http/Controllers/api/v1/ServerController.php
+++ b/app/Http/Controllers/api/v1/ServerController.php
@@ -89,7 +89,7 @@ class ServerController extends Controller
         $server->status = $request->status;
 
         $server->error_count = 0;
-        $server->recover_count = config('bigbluebutton.server_healthy_threshold');
+        $server->recover_count = config('bigbluebutton.server_online_threshold');
 
         // Check if server is online/offline and update usage data
         $serverService = new ServerService($server);
@@ -116,7 +116,7 @@ class ServerController extends Controller
         $server->status = $request->status;
 
         $server->error_count = 0;
-        $server->recover_count = config('bigbluebutton.server_healthy_threshold');
+        $server->recover_count = config('bigbluebutton.server_online_threshold');
 
         // Check if server is online/offline and update usage data
         $serverService = new ServerService($server);

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -110,10 +110,10 @@ class Server extends Model
             return null;
         }
 
-        if ($this->recover_count >= config('bigbluebutton.server_healthy_threshold')) {
+        if ($this->recover_count >= config('bigbluebutton.server_online_threshold')) {
             return ServerHealth::ONLINE;
         }
-        if ($this->error_count >= config('bigbluebutton.server_unhealthy_threshold')) {
+        if ($this->error_count >= config('bigbluebutton.server_offline_threshold')) {
             return ServerHealth::OFFLINE;
         }
 

--- a/app/Services/LoadBalancingService.php
+++ b/app/Services/LoadBalancingService.php
@@ -24,7 +24,7 @@ class LoadBalancingService
     {
         return $this->servers
             ->where('status', ServerStatus::ENABLED)
-            ->where('recover_count', '>=', config('bigbluebutton.server_healthy_threshold'))
+            ->where('recover_count', '>=', config('bigbluebutton.server_online_threshold'))
             ->where('error_count', '=', 0)
             ->whereNotNull('load')
             ->sortBy(function (Server $server) {

--- a/config/bigbluebutton.php
+++ b/config/bigbluebutton.php
@@ -11,8 +11,8 @@ return [
     'server_timeout' => (int) env('BBB_SERVER_TIMEOUT', 10),
     'server_connect_timeout' => (int) env('BBB_SERVER_CONNECT_TIMEOUT', 20),
     'room_refresh_rate' => (int) env('ROOM_REFRESH_RATE', 30),
-    'server_healthy_threshold' => (int) env('BBB_SERVER_HEALTHY_THRESHOLD', 3),
-    'server_unhealthy_threshold' => (int) env('BBB_SERVER_UNHEALTHY_THRESHOLD', 3),
+    'server_online_threshold' => (int) env('BBB_SERVER_ONLINE_THRESHOLD', 3),
+    'server_offline_threshold' => (int) env('BBB_SERVER_OFFLINE_THRESHOLD', 3),
 
     'load_new_meeting_min_user_count' => (int) env('BBB_LOAD_MIN_USER_COUNT', 15),
     'load_new_meeting_min_user_interval' => (int) env('BBB_LOAD_MIN_USER_INTERVAL', 15),

--- a/database/factories/ServerFactory.php
+++ b/database/factories/ServerFactory.php
@@ -27,7 +27,7 @@ class ServerFactory extends Factory
             'name' => $this->faker->unique()->word,
             'status' => \App\Enums\ServerStatus::ENABLED,
             'error_count' => 0,
-            'recover_count' => config('bigbluebutton.server_healthy_threshold'),
+            'recover_count' => config('bigbluebutton.server_online_threshold'),
             'version' => '2.4.5',
             'strength' => 1,
             'load' => 0,

--- a/database/migrations/2024_03_06_152142_add_health_counters_to_servers_table.php
+++ b/database/migrations/2024_03_06_152142_add_health_counters_to_servers_table.php
@@ -34,7 +34,7 @@ return new class extends Migration
                     // Online
                 case 1:
                     // Server is healthy
-                    $server->recover_count = config('bigbluebutton.server_healthy_threshold');
+                    $server->recover_count = config('bigbluebutton.server_online_threshold');
                     $server->error_count = 0;
                     $server->status = \App\Enums\ServerStatus::ENABLED;
                     break;

--- a/database/seeders/ServerSeeder.php
+++ b/database/seeders/ServerSeeder.php
@@ -27,7 +27,7 @@ class ServerSeeder extends Seeder
                 'name' => $faker->unique()->word,
                 'status' => ServerStatus::ENABLED,
                 'error_count' => 0,
-                'recover_count' => config('bigbluebutton.server_healthy_threshold'),
+                'recover_count' => config('bigbluebutton.server_online_threshold'),
                 'load' => 0,
             ]);
             foreach (ServerPool::all() as $serverPool) {

--- a/tests/Feature/api/v1/ServerTest.php
+++ b/tests/Feature/api/v1/ServerTest.php
@@ -47,13 +47,13 @@ class ServerTest extends TestCase
         ]);
 
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         $servers = Server::factory()->count(6)->create(['description' => 'test', 'version' => '2.4.5']);
         $serverOnline = Server::factory()->create(['name' => 'serverOnline', 'version' => '2.4.5']);
-        $serverOffline = Server::factory()->create(['name' => 'serverOffline', 'version' => '2.4.5', 'error_count' => config('bigbluebutton.server_unhealthy_threshold'), 'recover_count' => 0]);
+        $serverOffline = Server::factory()->create(['name' => 'serverOffline', 'version' => '2.4.5', 'error_count' => config('bigbluebutton.server_offline_threshold'), 'recover_count' => 0]);
         $serverUnhealthy = Server::factory()->create(['name' => 'serverUnhealthy', 'version' => '2.4.5', 'error_count' => 1, 'recover_count' => 0]);
         $serverDisabled = Server::factory()->create(['name' => 'serverDisabled', 'status' => ServerStatus::DISABLED, 'version' => null]);
         $serverDraining = Server::factory()->create(['name' => 'serverDraining', 'status' => ServerStatus::DRAINING, 'version' => null]);

--- a/tests/Unit/Console/PollServerTest.php
+++ b/tests/Unit/Console/PollServerTest.php
@@ -24,8 +24,8 @@ class PollServerTest extends TestCase
     public function testServerOffline()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 2,
-            'bigbluebutton.server_unhealthy_threshold' => 2,
+            'bigbluebutton.server_online_threshold' => 2,
+            'bigbluebutton.server_offline_threshold' => 2,
         ]);
 
         // Create new meeting with fake server

--- a/tests/Unit/ServerPoolTest.php
+++ b/tests/Unit/ServerPoolTest.php
@@ -19,8 +19,8 @@ class ServerPoolTest extends TestCase
     public function testLoadBalancing()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         $unhealthy = Server::factory()->create(['status' => ServerStatus::ENABLED]);

--- a/tests/Unit/ServerServiceTest.php
+++ b/tests/Unit/ServerServiceTest.php
@@ -254,8 +254,8 @@ class ServerServiceTest extends TestCase
     public function testServerHealthFailing()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         Http::fake([
@@ -298,8 +298,8 @@ class ServerServiceTest extends TestCase
     public function testServerHealthSingleFailure()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         Http::fake([
@@ -342,8 +342,8 @@ class ServerServiceTest extends TestCase
     public function testServerHealthRecovering()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         Http::fake([
@@ -356,7 +356,7 @@ class ServerServiceTest extends TestCase
         ]);
 
         // Create server
-        $server = Server::factory()->create(['error_count' => config('bigbluebutton.server_unhealthy_threshold'), 'recover_count' => 0]);
+        $server = Server::factory()->create(['error_count' => config('bigbluebutton.server_offline_threshold'), 'recover_count' => 0]);
         $serverService = new ServerService($server);
 
         // Recover (1 recover)
@@ -393,8 +393,8 @@ class ServerServiceTest extends TestCase
     public function testDetachMeetingOnOffline()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         Http::fake([
@@ -448,8 +448,8 @@ class ServerServiceTest extends TestCase
     public function testEndDetachedMeetingOnOnline()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         Http::fake([
@@ -460,7 +460,7 @@ class ServerServiceTest extends TestCase
         ]);
 
         // Create server
-        $server = Server::factory()->create(['error_count' => config('bigbluebutton.server_unhealthy_threshold'), 'recover_count' => 0]);
+        $server = Server::factory()->create(['error_count' => config('bigbluebutton.server_offline_threshold'), 'recover_count' => 0]);
         $serverService = new ServerService($server);
 
         // Create detached meeting

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -48,14 +48,14 @@ class ServerTest extends TestCase
     public function testServerHealth()
     {
         config([
-            'bigbluebutton.server_healthy_threshold' => 3,
-            'bigbluebutton.server_unhealthy_threshold' => 3,
+            'bigbluebutton.server_online_threshold' => 3,
+            'bigbluebutton.server_offline_threshold' => 3,
         ]);
 
         // Check online
         $server = Server::factory()->create();
         $server->error_count = 0;
-        $server->recover_count = config('bigbluebutton.server_healthy_threshold');
+        $server->recover_count = config('bigbluebutton.server_online_threshold');
         $server->save();
 
         $this->assertEquals(ServerHealth::ONLINE, $server->health);
@@ -68,7 +68,7 @@ class ServerTest extends TestCase
         $this->assertEquals(ServerHealth::UNHEALTHY, $server->health);
 
         // Check offline
-        $server->error_count = config('bigbluebutton.server_unhealthy_threshold');
+        $server->error_count = config('bigbluebutton.server_offline_threshold');
         $server->recover_count = 0;
         $server->save();
 


### PR DESCRIPTION
## Type (Highlight the corresponding type)
- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Rename env option `BBB_SERVER_HEALTHY_THRESHOLD`to `BBB_SERVER_ONLINE_THRESHOLD`
- Rename env option `BBB_SERVER_UNHEALTHY_THRESHOLD`to `BBB_SERVER_OFFLINE_THRESHOLD`

## Other information
Rename options to a less misleading name

