### PR TITLE
Adjust docs and command for localisation workflow with POEditor in v4

### DIFF
--- a/.github/workflows/pull-locales.yml
+++ b/.github/workflows/pull-locales.yml
@@ -2,6 +2,8 @@ name: Pull locales from POEditor
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
 jobs:
   pull-locales:
     name: Pull locales from POEditor

--- a/.github/workflows/pull-locales.yml
+++ b/.github/workflows/pull-locales.yml
@@ -2,6 +2,11 @@ name: Pull locales from POEditor
 
 on:
   workflow_dispatch:
+    inputs:
+      poeditor_project_id:
+        required: true
+        description: 'POEditor Project ID'
+        type: number
   schedule:
     - cron: "0 * * * *"
 jobs:
@@ -75,7 +80,7 @@ jobs:
         DB_USERNAME: root
         DB_PASSWORD: password
         POEDITOR_TOKEN: ${{ secrets.POEDITOR_TOKEN }}
-        POEDITOR_PROJECT: ${{ secrets.POEDITOR_PROJECT }}
+        POEDITOR_PROJECT: ${{ github.event.inputs.poeditor_project_id || secrets.POEDITOR_PROJECT}}
       run: php artisan locales:import
 
     - name: Create Pull Request

--- a/.github/workflows/upload-locales.yml
+++ b/.github/workflows/upload-locales.yml
@@ -2,6 +2,14 @@ name: Upload locales to POEditor
 
 on:
   workflow_dispatch:
+    inputs:
+      poeditor_project_id:
+        required: true
+        description: 'POEditor Project ID'
+        type: number
+  push:
+    branches:
+      - 'develop'
 jobs:
   pull-locales:
     name: Upload locales to POEditor
@@ -73,5 +81,5 @@ jobs:
         DB_USERNAME: root
         DB_PASSWORD: password
         POEDITOR_TOKEN: ${{ secrets.POEDITOR_TOKEN }}
-        POEDITOR_PROJECT: ${{ secrets.POEDITOR_PROJECT }}
+        POEDITOR_PROJECT: ${{ github.event.inputs.poeditor_project_id || secrets.POEDITOR_PROJECT}}
       run: php artisan locales:upload

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Please check our [development documentation](https://thm-health.github.io/PILOS/
 
 ## Localization
 
-The localization is managed in our [POEditor](https://poeditor.com/join/project/UGpZY4JAnz) project.
+The localization is managed in our [POEditor](https://poeditor.com/join/project/gWkaFBI8OH) project.
 Feel free to join and help us translate PILOS into your language or improve the existing translations.
 
 ## License

--- a/app/Console/Commands/UploadLocalesCommand.php
+++ b/app/Console/Commands/UploadLocalesCommand.php
@@ -13,7 +13,7 @@ class UploadLocalesCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'locales:upload';
+    protected $signature = 'locales:upload {--overwrite}';
 
     /**
      * The console command description.
@@ -27,39 +27,73 @@ class UploadLocalesCommand extends Command
      */
     public function handle(LocaleService $localeService): void
     {
-        $locales = config('app.default_locales');
-        foreach ($locales as $locale => $metadata) {
-            $this->info('Processing locale '.$metadata['name'].' ('.$locale.')');
+        $overwrite = $this->option('overwrite');
+        if ($overwrite) {
+            $this->info('Overwriting existing translations');
 
-            $localeJson = $localeService->buildJsonLocale($locale, false, false);
+            $locales = config('app.default_locales');
+            foreach ($locales as $locale => $metadata) {
+                $this->info('Processing locale '.$metadata['name'].' ('.$locale.')');
 
-            $delay = config('services.poeditor.upload_delay');
-            $this->info('Waiting '.$delay.' seconds before upload');
-            sleep($delay);
+                $localeJson = $localeService->buildJsonLocale($locale, false, false);
 
-            $this->info('Uploading locale '.$metadata['name'].' ('.$locale.')');
+                $delay = config('services.poeditor.upload_delay');
+                $this->info('Waiting '.$delay.' seconds before upload');
+                sleep($delay);
 
-            $response = Http::attach(
-                'file',
-                $localeJson,
-                $locale.'.json'
-            )->post('https://api.poeditor.com/v2/projects/upload', [
-                'api_token' => config('services.poeditor.token'),
-                'id' => config('services.poeditor.project'),
-                'updating' => 'terms_translations',
-                'overwrite' => 1,
-                'sync_terms' => config('app.fallback_locale') == $locale ? 1 : 0,
-                'fuzzy_trigger' => 1,
-                'language' => $locale,
-            ]);
+                $this->info('Uploading locale '.$metadata['name'].' ('.$locale.')');
 
-            $apiResponse = $response->json('response');
-            if ($apiResponse['status'] == 'success') {
-                $this->info('Locale '.$metadata['name'].' ('.$locale.') uploaded successfully');
-            } else {
-                $this->error('Error uploading locale '.$metadata['name'].' ('.$locale.')');
-                $this->error('Error code: '.$apiResponse['code'].', message: '.$apiResponse['message']);
+                $response = Http::attach(
+                    'file',
+                    $localeJson,
+                    $locale.'.json'
+                )->post('https://api.poeditor.com/v2/projects/upload', [
+                    'api_token' => config('services.poeditor.token'),
+                    'id' => config('services.poeditor.project'),
+                    'updating' => 'terms_translations',
+                    'overwrite' => 1,
+                    'sync_terms' => config('app.locale') == $locale ? 1 : 0,
+                    'fuzzy_trigger' => 1,
+                    'language' => $locale,
+                ]);
+
+                $apiResponse = $response->json('response');
+                if ($apiResponse['status'] == 'success') {
+                    $this->info('Locale '.$metadata['name'].' ('.$locale.') uploaded successfully');
+                } else {
+                    $this->error('Error uploading locale '.$metadata['name'].' ('.$locale.')');
+                    $this->error('Error code: '.$apiResponse['code'].', message: '.$apiResponse['message']);
+                }
             }
+
+            return;
         }
+
+        $this->info('Sync terms and default locale');
+        $locale = config('app.locale');
+        $localeJson = $localeService->buildJsonLocale($locale, false, false);
+
+        $response = Http::attach(
+            'file',
+            $localeJson,
+            $locale.'.json'
+        )->post('https://api.poeditor.com/v2/projects/upload', [
+            'api_token' => config('services.poeditor.token'),
+            'id' => config('services.poeditor.project'),
+            'updating' => 'terms_translations',
+            'overwrite' => 1,
+            'sync_terms' => 1,
+            'fuzzy_trigger' => 1,
+            'language' => $locale,
+        ]);
+
+        $apiResponse = $response->json('response');
+        if ($apiResponse['status'] == 'success') {
+            $this->info('Uploaded successfully');
+        } else {
+            $this->error('Error uploading');
+            $this->error('Error code: '.$apiResponse['code'].', message: '.$apiResponse['message']);
+        }
+
     }
 }

--- a/docs/docs/administration/08-customisation/02-locales.md
+++ b/docs/docs/administration/08-customisation/02-locales.md
@@ -4,7 +4,7 @@ description: Contribute to the translation of PILOS and add custom locales
 ---
 
 PILOS is available in multiple languages. By default, PILOS comes with English and German translations.
-Other locales are maintained by the community using [PoEditor](https://poeditor.com/join/project/UGpZY4JAnz).
+Other locales are maintained by the community using [PoEditor](https://poeditor.com/join/project/gWkaFBI8OH).
 
 ## Locale structure
 Locales are stored as php arrays in the `lang` folder.

--- a/tests/Backend/Unit/Console/UploadLocalesTest.php
+++ b/tests/Backend/Unit/Console/UploadLocalesTest.php
@@ -14,9 +14,86 @@ class UploadLocalesTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * Test if locales are uploaded correctly
+     * Test if locales terms and english default locale are uploaded
      */
-    public function testLocaleUpload()
+    public function testLocaleSync()
+    {
+        Http::fake([
+            'api.poeditor.com/v2/projects/upload' => Http::sequence()
+                ->push([
+                    'response' => [
+                        'status' => 'success',
+                        'code' => '200',
+                        'message' => 'OK',
+                    ],
+                    'result' => [
+                        'terms' => [
+                            'parsed' => 1,
+                            'added' => 1,
+                            'deleted' => 0,
+                        ],
+                        'translations' => [
+                            'parsed' => 1,
+                            'added' => 1,
+                            'updated' => 0,
+                        ],
+                    ],
+                ], 200)
+                ->push([
+                    'response' => [
+                        'status' => 'fail',
+                        'code' => '4048',
+                        'message' => 'Too many upload requests in a short period of time',
+                    ],
+                ], 200),
+
+        ]);
+
+        config([
+            'services.poeditor.token' => 'token123',
+            'services.poeditor.project' => 'project123',
+            'services.poeditor.upload_delay' => 0,
+        ]);
+
+        $mock = $this
+            ->mock(LocaleService::class);
+
+        $mock->shouldReceive('buildJsonLocale')
+            ->twice()
+            ->with('en', false, false)
+            ->andReturn('{"key_1":"value_1"}');
+
+        $this->artisan('locales:upload')
+            ->expectsOutput('Sync terms and default locale')
+            ->expectsOutput('Uploaded successfully');
+
+        Http::assertSent(function (Request $request) {
+            $data = [];
+            foreach ($request->data() as $entry) {
+                $data[$entry['name']] = $entry['contents'];
+            }
+
+            return $request->url() == 'https://api.poeditor.com/v2/projects/upload' &&
+                $data['api_token'] == 'token123' &&
+                $data['id'] == 'project123' &&
+                $data['updating'] == 'terms_translations' &&
+                $data['overwrite'] == 1 &&
+                $data['sync_terms'] == 1 &&
+                $data['fuzzy_trigger'] == 1 &&
+                $data['language'] == 'en' &&
+                $data['file'] == '{"key_1":"value_1"}';
+        });
+
+        $this->artisan('locales:upload')
+            ->expectsOutput('Sync terms and default locale')
+            ->expectsOutput('Error uploading')
+            ->expectsOutput('Error code: 4048, message: Too many upload requests in a short period of time');
+    }
+
+    /**
+     * Test if all translations are uploaded
+     */
+    public function testLocaleOverwrite()
     {
         Http::fake([
             'api.poeditor.com/v2/projects/upload' => Http::sequence()
@@ -69,7 +146,7 @@ class UploadLocalesTest extends TestCase
             ->with('en', false, false)
             ->andReturn('{"key_1":"value_1"}');
 
-        $this->artisan('locales:upload')
+        $this->artisan('locales:upload --overwrite')
             ->expectsOutput('Processing locale Deutsch (de)')
             ->expectsOutput('Waiting 0 seconds before upload')
             ->expectsOutput('Uploading locale Deutsch (de)')


### PR DESCRIPTION
## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **Localisation**

## Checklist
- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Adjust link to PoEditor Project for v4
- Adjust artisan command to only upload terms and english locale by default
- Change github workflows to auto pull locales