### PR TITLE
Add env variable to disable shib session checking middleware

### DIFF
--- a/app/Auth/Shibboleth/ShibbolethSessionMiddleware.php
+++ b/app/Auth/Shibboleth/ShibbolethSessionMiddleware.php
@@ -23,7 +23,7 @@ class ShibbolethSessionMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         // check if user is logged in via shibboleth
-        if (\Auth::user()?->authenticator == 'shibboleth') {
+        if (\Auth::user()?->authenticator == 'shibboleth' && config('services.shibboleth.session_check_middleware_enabled')) {
             // check if user still has a valid shibboleth session and that it didn't change in the meantime
             $headerName = config('services.shibboleth.session_id_header');
             if (! $request->hasHeader($headerName) || session('shibboleth_session_id') != $this->provider->hashShibbolethSessionId($request->header($headerName))) {

--- a/config/services.php
+++ b/config/services.php
@@ -44,6 +44,7 @@ return [
         'mapping' => $shibbolethEnabled ? json_decode(file_get_contents(app_path('Auth/config/shibboleth_mapping.json'))) : null,
         'session_id_header' => env('SHIBBOLETH_SESSION_ID_HEADER', 'shib-session-id'),
         'session_expires_header' => env('SHIBBOLETH_SESSION_EXPIRES_HEADER', 'shib-session-expires'),
+        'session_check_middleware_enabled' => (bool) env('SHIBBOLETH_SESSION_CHECK_ENABLED', true),
         'logout' => env('SHIBBOLETH_LOGOUT_URL', '/Shibboleth.sso/Logout'),
     ],
 ];

--- a/docs/docs/administration/07-advanced/01-external-authentication.md
+++ b/docs/docs/administration/07-advanced/01-external-authentication.md
@@ -97,6 +97,15 @@ To enable Shibboleth, you need to enable it in the  `.env` file.
 SHIBBOLETH_ENABLED=true
 ```
 
+When Shibboleth authentication is enabled and a user is logged in via Shibboleth, the session validity is checked in every request. If the check fails the user is automatically logged out.
+To disable this behavior you can set the following `.env` variable:
+
+```bash
+# Disable checking Shibboleth session in every request
+SHIBBOLETH_SESSION_CHECK_ENABLED=false
+```
+
+
 ## Configure mapping
 
 For each external authenticator the attribute and role mapping needs to be configured.


### PR DESCRIPTION
# Allows Shibboleth authentication in setups where not every request is routed through Apache

## Type (Highlight the corresponding type)
- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Adds a new environment variable `SHIBBOLETH_SESSION_CHECK_ENABLED` defaulting to `true`. If set to `false` checking shibboleth session validity on every request is disabled. This is necessary for setups where not every request is routed through Apache.

## Other information


