### PR TITLE
Add LDAP_OPTIONS env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ MAIL_FROM_NAME="${APP_NAME}"
 # LDAP logging debugging only
 #LDAP_LOGGING=true
 
+# Optional comma separated list of additional options for LDAP authentication
+# See: https://ldaprecord.com/docs/core/v3/configuration and http://php.net/ldap_set_option
+# Note: ldap_set_option constants must be resolved to their integer values.
+# This example sets LDAP_OPT_X_TLS_REQUIRE_CERT to LDAP_OPT_X_TLS_NEVER to ignore missing and self-signed TLS certificates.
+#LDAP_OPTIONS="24582=0"
+
 # Enable Shibboleth authentication
 #SHIBBOLETH_ENABLED=false
 

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -1,9 +1,13 @@
 <?php
 
 $ldapEnabled = env('LDAP_ENABLED', false);
+$options = [];
+if ($ldapEnabled) {
+    $option_list = env('LDAP_OPTIONS', '');
+    parse_str(str_replace(',', '&', $option_list), $options);
+}
 
 return [
-
     'enabled' => $ldapEnabled,
 
     'connection' => [
@@ -15,6 +19,7 @@ return [
         'timeout' => env('LDAP_TIMEOUT', 5),
         'use_ssl' => env('LDAP_SSL', false),
         'use_tls' => env('LDAP_TLS', false),
+        'options' => $options,
     ],
 
     /*

--- a/docs/docs/administration/07-advanced/01-external-authentication.md
+++ b/docs/docs/administration/07-advanced/01-external-authentication.md
@@ -49,6 +49,12 @@ LDAP_OBJECT_CLASSES=top,person,organizationalperson,inetorgperson
 
 # Attribute by which the user should be found in the LDAP
 LDAP_LOGIN_ATTRIBUTE=uid
+
+# Optional comma separated list of additional options for LDAP authentication
+# See: https://ldaprecord.com/docs/core/v3/configuration and http://php.net/ldap_set_option
+# Note: ldap_set_option constants must be resolved to their integer values.
+# This example sets LDAP_OPT_X_TLS_REQUIRE_CERT to LDAP_OPT_X_TLS_NEVER to ignore missing and self-signed TLS certificates.
+#LDAP_OPTIONS="24582=0" 
 ```
 
 ### Shibboleth


### PR DESCRIPTION
# Allows specifying additional LDAP options

## Type (Highlight the corresponding type)
- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [x] Documentation of code and features exists

## Changes

- Adds a new environment variable `LDAP_OPTIONS` defaulting to empty string which is parsed and passed on to `LdapRecord::Connection`. This allows (for example) disabling TLS certificate checks, which is necessary for LDAP servers with a self-signed certificate.

## Other information


