### PR TITLE
Fix wrong number of rooms shown on initial load of rooms index page

### DIFF
--- a/resources/js/views/RoomsIndex.vue
+++ b/resources/js/views/RoomsIndex.vue
@@ -313,8 +313,6 @@ const sortingTypes = computed(() => {
 const breakpoints = useBreakpoints(breakpointsTailwind);
 
 onMounted(() => {
-  reload();
-
   switch (breakpoints.active().value) {
     case 'md':
       perPage.value = 8;
@@ -329,6 +327,8 @@ onMounted(() => {
     default:
       perPage.value = 6;
   }
+
+  reload();
 });
 
 /**


### PR DESCRIPTION
# Fixes \#1292

## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Fixes wrong numer of rooms shown on initial load of rooms index page
