### PR TITLE
Hide bulk edit/delte room member checkboxes if user does not have permission to manage room

### DIFF
--- a/resources/js/components/RoomTabMembers.vue
+++ b/resources/js/components/RoomTabMembers.vue
@@ -88,7 +88,7 @@
           </div>
         </template>
 
-        <template #header v-if="selectableMembers.length > 0">
+        <template #header v-if="selectableMembers.length > 0 && userPermissions.can('manageSettings', props.room)">
           <div class="flex justify-between mb-2">
              <Checkbox
                 :model-value="selectedMembers.length === selectableMembers.length"
@@ -120,7 +120,7 @@
             <div v-for="(item, index) in slotProps.items" :key="index">
               <div class="flex flex-col md:flex-row justify-between gap-4 py-4" :class="{ 'border-t border-surface': index !== 0 }">
                 <div class="flex flex-row gap-6">
-                  <div class="flex items-center">
+                  <div class="flex items-center" v-if="userPermissions.can('manageSettings', props.room)">
                     <Checkbox
                       :disabled="authStore.currentUser && authStore.currentUser.id === item.id"
                       :model-value="isMemberSelected(item.id)"


### PR DESCRIPTION
# Fixes #1302

## Type (Highlight the corresponding type)
- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist
- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Hide bulk edit/delte room member checkboxes if user does not have permission to manage room
