### PR TITLE
Fix greenlight room redirects for users with two letter firstnames

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,7 @@ if (config('greenlight.compatibility')) {
         // room urls
         Route::get('/{id}', function ($id) {
             return redirect('/rooms/'.$id);
-        })->where('id', '([A-Za-z0-9]{3}-[A-Za-z0-9]{3}-[A-Za-z0-9]{3}(-[A-Za-z0-9]{3})?)');
+        })->where('id', '([A-Za-z0-9-]{3}-[A-Za-z0-9]{3}-[A-Za-z0-9]{3}(-[A-Za-z0-9]{3})?)');
         // login
         Route::redirect('/ldap_signin', '/login');
         Route::redirect('/signin', '/login');


### PR DESCRIPTION
When users only have two letters as firstname (which is the case in our user base and occurrs more frequently when the title 'Dr.' is part of the name) the regex fails for the room. These rooms have a format like: `dr--asd-wer-qwe`.

This commit fixes the regex.

## Type (Highlight the corresponding type)
- **Bugfix**


## Checklist
- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

