### PR TITLE
Fix meeting start and server polling timing conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Logging for server health changes ([#1608])
+-   Logging for detached meeting handling ([#1608])
+-   Logging for meeting not running on BBB server ([#1608])
+
 ### Fixed
 
 -   Meeting retention cleanup not working with server retention set to unlimited ([878ce6b](https://github.com/THM-Health/PILOS/commit/878ce6b3a3aa596fb6cf228150ffe047a1c94641))
+-   Meeting marked as ended prematurely during starting phase of a new meeting ([#1607], [#1608])
 
 ## [v4.1.1] - 2024-11-20
 
@@ -258,6 +265,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1561]: https://github.com/THM-Health/PILOS/pull/1561
 [#1565]: https://github.com/THM-Health/PILOS/pull/1565
 [#1569]: https://github.com/THM-Health/PILOS/pull/1569
+[#1607]: https://github.com/THM-Health/PILOS/issues/1607
+[#1608]: https://github.com/THM-Health/PILOS/pull/1608
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.1.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -87,4 +87,9 @@ class Meeting extends Model
     {
         return $this->hasMany(MeetingAttendee::class);
     }
+
+    public function getLogLabel()
+    {
+        return $this->id;
+    }
 }

--- a/app/Services/RoomService.php
+++ b/app/Services/RoomService.php
@@ -75,7 +75,6 @@ class RoomService
 
             // Create new meeting
             $meeting = new Meeting;
-            $meeting->start = date('Y-m-d H:i:s');
             $meeting->record_attendance = $this->room->getRoomSetting('record_attendance');
             $meeting->record = $this->room->getRoomSetting('record');
             $meeting->server()->associate($server);
@@ -95,6 +94,12 @@ class RoomService
             }
 
             Log::info('Successfully started new meeting for room {room} on server {server}', ['room' => $this->room->getLogLabel(), 'server' => $server->getLogLabel()]);
+
+            // Set start time after successful api call, prevents server poller from ending a meeting that has been started
+            // but the api call has not been completed yet therefore the meeting will not be found on the server
+            // and the server poller will mark the meeting as ended immediately
+            $meeting->start = date('Y-m-d H:i:s');
+            $meeting->save();
 
             // Change latest meeting or the room to newly created meeting
             $this->room->latestMeeting()->associate($meeting);

--- a/app/Services/RoomService.php
+++ b/app/Services/RoomService.php
@@ -142,7 +142,7 @@ class RoomService
 
         $meetingService = new MeetingService($meeting);
 
-        Log::info('Check if meeting for room {room} is running on the BBB server', ['room' => $this->room->getLogLabel()]);
+        Log::info('Check if meeting {meeting} for room {room} is running on the BBB server', ['room' => $this->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
 
         try {
             // Check if meeting is running
@@ -155,11 +155,11 @@ class RoomService
         // Check if the meeting is actually running on the server
         if (! $meetingRunning) {
             $meetingService->setEnd();
-            Log::warning('Meeting for room {room} is not running on the BBB server', ['room' => $this->room->getLogLabel()]);
+            Log::warning('Meeting {meeting} for room {room} is not running on the BBB server', ['room' => $this->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
             abort(CustomStatusCodes::ROOM_NOT_RUNNING->value, __('app.errors.not_running'));
         }
 
-        Log::info('Meeting for room {room} is running on the BBB server', ['room' => $this->room->getLogLabel()]);
+        Log::info('Meeting {meeting} for room {room} is running on the BBB server', ['room' => $this->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
 
         return $meetingService;
     }

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -12,6 +12,7 @@ use App\Plugins\Contracts\ServerLoadCalculationPluginContract;
 use App\Services\BigBlueButton\LaravelHTTPClient;
 use BigBlueButton\BigBlueButton;
 use Illuminate\Support\Collection;
+use Log;
 
 class ServerService
 {
@@ -132,6 +133,7 @@ class ServerService
         foreach ($this->server->meetings()->whereNull('end')->whereNull('detached')->get() as $meeting) {
             $meeting->detached = now();
             $meeting->save();
+            Log::warning('Meeting {meeting} for room {room} detached', ['room' => $meeting->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
         }
     }
 
@@ -144,7 +146,9 @@ class ServerService
             $meetingService = new MeetingService($meeting);
             try {
                 $meetingService->end();
+                Log::notice('Ended detached meeting {meeting} for room {room}', ['room' => $meeting->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
             } catch (\Exception $e) {
+                Log::error('Failed to end detached meeting {meeting} for room {room}', ['room' => $meeting->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
             }
         }
     }
@@ -304,6 +308,8 @@ class ServerService
         foreach ($meetingsNotRunningOnServers as $meetingId) {
             $meeting = Meeting::find($meetingId);
             if ($meeting != null && $meeting->end == null) {
+                Log::warning('Meeting {meeting} for room {room} is not running on the BBB server', ['room' => $meeting->room->getLogLabel(), 'meeting' => $meeting->getLogLabel()]);
+
                 (new MeetingService($meeting))->setEnd();
             }
         }

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -129,7 +129,7 @@ class ServerService
      */
     private function setMeetingsDetached()
     {
-        foreach ($this->server->meetings()->whereNull('end')->get() as $meeting) {
+        foreach ($this->server->meetings()->whereNull('end')->whereNull('detached')->get() as $meeting) {
             $meeting->detached = now();
             $meeting->save();
         }

--- a/app/Services/ServerService.php
+++ b/app/Services/ServerService.php
@@ -186,7 +186,7 @@ class ServerService
 
         // Get list with all meetings marked in the db as running and collect meetings
         // that are currently running on the server
-        $allRunningMeetingsInDb = $this->server->meetings()->whereNull('end')->whereNotNull('start');
+        $allRunningMeetingsInDb = $this->server->meetings()->whereNull('end')->whereNotNull('start')->get();
         $allRunningMeetingsOnServers = new Collection;
 
         $bbbMeetings = $this->getMeetings();
@@ -212,7 +212,7 @@ class ServerService
                 $this->server->save();
 
                 // Clear current live room status
-                foreach ($allRunningMeetingsInDb->get() as $meeting) {
+                foreach ($allRunningMeetingsInDb as $meeting) {
                     // Double check if the meeting is the latest meeting in the room
                     if (! $meeting->is($meeting->room->latestMeeting)) {
                         continue;

--- a/tests/Backend/Fixtures/GetMeetings-Empty.xml
+++ b/tests/Backend/Fixtures/GetMeetings-Empty.xml
@@ -1,0 +1,6 @@
+<response>
+    <returncode>SUCCESS</returncode>
+    <messageKey>noMeetings</messageKey>
+    <message>no meetings were found on this server</message>
+    <meetings/>
+</response>

--- a/tests/Backend/Utils/BigBlueButtonServerFaker.php
+++ b/tests/Backend/Utils/BigBlueButtonServerFaker.php
@@ -97,9 +97,28 @@ class BigBlueButtonServerFaker
     public function addCreateMeetingRequest()
     {
         $response = function (Request $request) {
-            $uri = $request->toPsrRequest()->getUri();
-            parse_str($uri->getQuery(), $params);
-            $xml = '
+            return BigBlueButtonServerFaker::createCreateMeetingResponse($request);
+        };
+
+        $this->requests[] = ['request' => null, 'response' => $response];
+    }
+
+    /**
+     * Get the request data for a request
+     *
+     * @param  int  $id  Number of the request (starting with 0)
+     * @return mixed
+     */
+    public function getRequest(int $id)
+    {
+        return $this->requests[$id]['request'];
+    }
+
+    public static function createCreateMeetingResponse(Request $request): \GuzzleHttp\Promise\PromiseInterface
+    {
+        $uri = $request->toPsrRequest()->getUri();
+        parse_str($uri->getQuery(), $params);
+        $xml = '
                 <response>
                     <returncode>SUCCESS</returncode>
                     <meetingID>'.$params['meetingID'].'</meetingID>
@@ -116,20 +135,6 @@ class BigBlueButtonServerFaker
                     <message></message>
                 </response>';
 
-            return Http::response($xml);
-        };
-
-        $this->requests[] = ['request' => null, 'response' => $response];
-    }
-
-    /**
-     * Get the request data for a request
-     *
-     * @param  int  $id  Number of the request (starting with 0)
-     * @return mixed
-     */
-    public function getRequest(int $id)
-    {
-        return $this->requests[$id]['request'];
+        return Http::response($xml);
     }
 }


### PR DESCRIPTION
# Fixes #1607 

## Type (Highlight the corresponding type)

-   **Bugfix**
-   Feature
-   Documentation
-   Refactoring (e.g. Style updates, Test implementation, etc.)
-   Other (please describe):

## Checklist

-   [x] Code updated to current develop branch head
-   [x] Passes CI checks
-   [x] Is a part of an issue
-   [x] Tests added for the bugfix or newly implemented feature, describe below why if not
-   [x] Changelog is updated
-   [x] Documentation of code and features exists

## Changes

- Fix meeting marked as ended prematurely during starting phase of a new meeting
- Add logging for server health changes
- Add logging for detached meeting handling
- Add logging for meeting not running on BBB server