### PR TITLE
Don't close create room dialog on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The recording import task is now prevented from running until the previous run has finished ([#1484], [#1604])
 - Adjust frontend tests to better check the resetting of form errors ([#1679], [#1702])
+- Error handling in create room dialog ([#1704])
 
 ### Fixed
 
@@ -298,6 +299,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1618]: https://github.com/THM-Health/PILOS/pull/1618
 [#1679]: https://github.com/THM-Health/PILOS/issues/1679
 [#1702]: https://github.com/THM-Health/PILOS/pull/1702
+[#1704]: https://github.com/THM-Health/PILOS/pull/1704
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.1.2...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/components/RoomCreateComponent.vue
+++ b/resources/js/components/RoomCreateComponent.vue
@@ -181,9 +181,10 @@ function handleOk() {
         // room limit exceeded
         if (error.response.status === env.HTTP_ROOM_LIMIT_EXCEEDED) {
           emit("limitReached");
+          modalVisible.value = false;
         }
       }
-      modalVisible.value = false;
+
       api.error(error);
     });
 }

--- a/tests/Frontend/e2e/RoomsIndexCreateNewRoom.cy.js
+++ b/tests/Frontend/e2e/RoomsIndexCreateNewRoom.cy.js
@@ -511,17 +511,11 @@ describe("Rooms index create new room", function () {
 
     cy.wait("@createRoomRequest");
 
-    // Check that create room dialog is closed
-    cy.get('[data-test="room-create-dialog"]').should("not.exist");
-
     // Check if error message is shown
     cy.checkToastMessage([
       'app.flash.server_error.message_{"message":"Test"}',
       'app.flash.server_error.error_code_{"statusCode":500}',
     ]);
-
-    // Open dialog again
-    cy.get('[data-test="room-create-button"]').click();
 
     // Check that 422 error messages are hidden
     cy.get('[data-test="room-create-dialog"]')


### PR DESCRIPTION
## Type (Highlight the corresponding type)

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **UX**

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- The Create Room dialog will no longer close on errors that are not specifically handled (e.g.form validation errors). This allows the user to try again in the event of a server error etc.

## Other information
Similar to #1444