### PR TITLE
Add dark mode logo support for BBB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right-to-left (RTL) locale support ([#2065])
 - Translation to locale selector ([#2079])
 - Transition and animation for dark mode toggle ([#2082])
+- Logo for dark mode in BBB ([#1399])
 
 ### Fixed
 
@@ -382,6 +383,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1204]: https://github.com/THM-Health/PILOS/pull/1204
 [#1216]: https://github.com/THM-Health/PILOS/issues/1216
 [#1332]: https://github.com/THM-Health/PILOS/pull/1332
+[#1399]: https://github.com/THM-Health/PILOS/pull/1399
 [#1420]: https://github.com/THM-Health/PILOS/issues/1420
 [#1435]: https://github.com/THM-Health/PILOS/issues/1435
 [#1440]: https://github.com/THM-Health/PILOS/pull/1440

--- a/app/Http/Controllers/api/v1/SettingsController.php
+++ b/app/Http/Controllers/api/v1/SettingsController.php
@@ -114,6 +114,17 @@ class SettingsController extends Controller
             $bigBlueButtonSettings->logo = null;
         }
 
+        // Dark version Logo for BBB
+        if ($request->has('bbb_logo_dark_file')) {
+            $path = $request->file('bbb_logo_dark_file')->store('images', 'public');
+            $url = Storage::url($path);
+            $bigBlueButtonSettings->logo_dark = url($url);
+        } elseif ($request->has('bbb_logo_dark') && trim($request->input('bbb_logo_dark') != '')) {
+            $bigBlueButtonSettings->logo_dark = $request->input('bbb_logo_dark');
+        } else {
+            $bigBlueButtonSettings->logo_dark = null;
+        }
+
         // Custom style file for BBB
         if ($request->has('bbb_style')) {
             if (! empty($request->file('bbb_style'))) {

--- a/app/Http/Requests/UpdateSettings.php
+++ b/app/Http/Requests/UpdateSettings.php
@@ -79,6 +79,9 @@ class UpdateSettings extends FormRequest
 
             'bbb_logo' => ['nullable', 'string', 'max:255'],
             'bbb_logo_file' => ['image:allow_svg', 'max:500'],
+            'bbb_logo_dark' => ['nullable', 'string', 'max:255'],
+            'bbb_logo_dark_file' => ['image:allow_svg', 'max:500'],
+
             'bbb_style' => ['nullable', 'file', 'max:500'],
             'bbb_default_presentation' => ['nullable', 'file', 'max:'.(config('bigbluebutton.max_filesize') * 1000), 'mimes:'.config('bigbluebutton.allowed_file_mimes')],
         ];

--- a/app/Http/Resources/Settings.php
+++ b/app/Http/Resources/Settings.php
@@ -71,6 +71,7 @@ class Settings extends JsonResource
             'recording_attendance_retention_period' => $recordingSettings->attendance_retention_period,
             'recording_recording_retention_period' => $recordingSettings->recording_retention_period,
             'bbb_logo' => $bigBlueButtonSettings->logo,
+            'bbb_logo_dark' => $bigBlueButtonSettings->logo_dark,
             'bbb_style' => $bigBlueButtonSettings->style,
             'bbb_default_presentation' => $bigBlueButtonSettings->default_presentation,
         ];

--- a/app/Services/MeetingService.php
+++ b/app/Services/MeetingService.php
@@ -130,6 +130,11 @@ class MeetingService
             $meetingParams->setLogo(app(BigBlueButtonSettings::class)->logo);
         }
 
+        // if a dark logo is defined, set dark logo
+        if (app(BigBlueButtonSettings::class)->logo_dark) {
+            $meetingParams->setDarklogo(app(BigBlueButtonSettings::class)->logo_dark);
+        }
+
         // Try to start meeting
         try {
             $result = $this->serverService->getBigBlueButton()->createMeeting($meetingParams);

--- a/app/Settings/BigBlueButtonSettings.php
+++ b/app/Settings/BigBlueButtonSettings.php
@@ -8,6 +8,8 @@ class BigBlueButtonSettings extends Settings
 {
     public ?string $logo;
 
+    public ?string $logo_dark;
+
     public ?string $style;
 
     public ?string $default_presentation;

--- a/database/settings/2024_12_13_133315_add_dark_mode_logo_to_big_blue_button_settings.php
+++ b/database/settings/2024_12_13_133315_add_dark_mode_logo_to_big_blue_button_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('bbb.logo_dark');
+    }
+};

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -35,6 +35,8 @@ return [
         'base_url' => 'API endpoint',
         'bbb_default_presentation' => 'Default presentation',
         'bbb_logo' => 'Logo',
+        'bbb_logo_dark' => 'Dark version logo',
+        'bbb_logo_dark_file' => 'Dark version logo file',
         'bbb_logo_file' => 'Logo file',
         'bbb_skip_check_audio' => 'Disable echo audio test',
         'bbb_style' => 'CSS style file',

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1305,6 +1305,34 @@
               data-test="bbb-style-field"
             >
               <legend
+                id="bbb-logo-dark-label"
+                class="col-span-12 md:col-span-4 md:mb-0"
+              >
+                {{ $t("admin.settings.logo_dark.title") }}
+              </legend>
+              <div class="col-span-12 md:col-span-8">
+                <SettingsImageSelector
+                  v-model:image-url="settings.bbb_logo_dark"
+                  v-model:image="uploadBBBLogoDarkFile"
+                  v-model:image-deleted="bbbLogoDarkDeleted"
+                  :disabled="disabled"
+                  :readonly="viewOnly"
+                  :max-file-size="500000"
+                  preview-width="150"
+                  preview-bg-class="bg-surface-900"
+                  show-delete
+                  :preview-alt="$t('admin.settings.bbb.logo.alt')"
+                  :allowed-extensions="['jpg', 'jpeg', 'png', 'gif', 'svg']"
+                  input-id="bbb-logo"
+                  :url-invalid="formErrors.fieldInvalid('bbb_logo_dark')"
+                  :file-invalid="formErrors.fieldInvalid('bbb_logo_dark_file')"
+                  :url-error="formErrors.fieldError('bbb_logo_dark')"
+                  :file-error="formErrors.fieldError('bbb_logo_dark_file')"
+                />
+              </div>
+            </fieldset>
+            <fieldset class="grid grid-cols-12 gap-4">
+              <legend
                 id="bbb-style-label"
                 class="col-span-12 md:col-span-4 md:mb-0"
               >
@@ -1400,6 +1428,8 @@ const uploadFaviconDarkFile = ref(null);
 const uploadLogoDarkFile = ref(null);
 const uploadBBBLogoFile = ref(null);
 const bbbLogoDeleted = ref(false);
+const uploadBBBLogoDarkFile = ref(null);
+const bbbLogoDarkDeleted = ref(false);
 const defaultPresentation = ref(null);
 const defaultPresentationDeleted = ref(false);
 const bbbStyle = ref(null);
@@ -1500,6 +1530,14 @@ function updateSettings() {
     formData.append("bbb_logo", settings.value.bbb_logo);
   }
 
+  if (uploadBBBLogoDarkFile.value) {
+    formData.append("bbb_logo_dark_file", uploadBBBLogoDarkFile.value);
+  } else if (bbbLogoDarkDeleted.value) {
+    formData.append("bbb_logo_dark", "");
+  } else if (settings.value.bbb_logo_dark !== null) {
+    formData.append("bbb_logo_dark", settings.value.bbb_logo_dark);
+  }
+
   if (bbbStyle.value !== null) {
     formData.append("bbb_style", bbbStyle.value);
   } else if (bbbStyleDeleted.value) {
@@ -1518,6 +1556,7 @@ function updateSettings() {
     "theme_favicon",
     "theme_favicon_dark",
     "bbb_logo",
+    "bbb_logo_dark",
     "bbb_style",
     "bbb_default_presentation",
   ];
@@ -1557,9 +1596,11 @@ function updateSettings() {
       defaultPresentation.value = null;
       defaultPresentationDeleted.value = false;
       uploadBBBLogoFile.value = null;
+      uploadBBBLogoDarkFile.value = null;
       bbbStyle.value = null;
       bbbStyleDeleted.value = false;
       bbbLogoDeleted.value = false;
+      bbbLogoDarkDeleted.value = false;
 
       // update form input
       settings.value = response.data.data;

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1302,7 +1302,7 @@
             </fieldset>
             <fieldset
               class="grid grid-cols-12 gap-4"
-              data-test="bbb-style-field"
+              data-test="bbb-logo-dark-field"
             >
               <legend
                 id="bbb-logo-dark-label"
@@ -1323,7 +1323,7 @@
                   show-delete
                   :preview-alt="$t('admin.settings.bbb.logo.alt')"
                   :allowed-extensions="['jpg', 'jpeg', 'png', 'gif', 'svg']"
-                  input-id="bbb-logo"
+                  input-id="bbb-logo-dark"
                   :url-invalid="formErrors.fieldInvalid('bbb_logo_dark')"
                   :file-invalid="formErrors.fieldInvalid('bbb_logo_dark_file')"
                   :url-error="formErrors.fieldError('bbb_logo_dark')"
@@ -1331,7 +1331,10 @@
                 />
               </div>
             </fieldset>
-            <fieldset class="grid grid-cols-12 gap-4">
+            <fieldset
+              class="grid grid-cols-12 gap-4"
+              data-test="bbb-style-field"
+            >
               <legend
                 id="bbb-style-label"
                 class="col-span-12 md:col-span-4 md:mb-0"

--- a/tests/Backend/Unit/MeetingTest.php
+++ b/tests/Backend/Unit/MeetingTest.php
@@ -195,6 +195,23 @@ class MeetingTest extends TestCase
         $this->assertEquals('application/xml', $request->header('Content-Type')[0]);
 
         $this->assertEquals(url('logo.png'), $data['logo']);
+
+        // Check dark logo missing
+        $this->assertArrayNotHasKey('darklogo', $data);
+
+        // Add dark logo
+        $this->bigBlueButtonSettings->logo_dark = url('logo_dark.png');
+        $this->bigBlueButtonSettings->save();
+
+        $meetingService->setServerService($serverService)->start();
+
+        $request = Http::recorded()[1][0];
+        $data = $request->data();
+
+        // Check logo and dark logo
+        $this->assertEquals(url('logo.png'), $data['logo']);
+        $this->assertEquals(url('logo_dark.png'), $data['darklogo']);
+
     }
 
     /**

--- a/tests/Frontend/e2e/AdminSettingsEdit.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsEdit.cy.js
@@ -2183,6 +2183,17 @@ describe("Admin settings with edit permission", function () {
         cy.checkSettingsImageSelector("/images/logo.svg", "logo.svg", true);
       });
 
+    cy.get('[data-test="bbb-logo-dark-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.logo_dark.title")
+      .within(() => {
+        cy.checkSettingsImageSelector(
+          "/images/logo-dark.svg",
+          "logo-dark.svg",
+          true,
+        );
+      });
+
     cy.get('[data-test="bbb-style-field"]')
       .should("be.visible")
       .and("include.text", "admin.settings.bbb.style.title")
@@ -2200,6 +2211,7 @@ describe("Admin settings with edit permission", function () {
     // Save changes
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = "/images/logo.svg";
+      settings.data.bbb_logo_dark = "/images/logo-dark.svg";
       settings.data.bbb_style = "/files/bbb_style.css";
       settings.data.bbb_default_presentation = "/files/testFile.txt";
 
@@ -2244,6 +2256,18 @@ describe("Admin settings with edit permission", function () {
 
       expect(formData.get("bbb_logo")).to.equal(null);
 
+      const uploadedBBBLogoDark = formData.get("bbb_logo_dark_file");
+      expect(uploadedBBBLogoDark.name).to.eql("logo-dark.svg");
+      expect(uploadedBBBLogoDark.type).to.eql("image/svg+xml");
+      cy.fixture("files/logo-dark.svg", "base64").then((content) => {
+        uploadedBBBLogoDark.arrayBuffer().then((arrayBuffer) => {
+          const base64 = _arrayBufferToBase64(arrayBuffer);
+          expect(content).to.eql(base64);
+        });
+      });
+
+      expect(formData.get("bbb_logo_dark")).to.equal(null);
+
       const uploadedBBBStyle = formData.get("bbb_style");
       expect(uploadedBBBStyle.name).to.eql("bbb_style.css");
       expect(uploadedBBBStyle.type).to.eql("text/css");
@@ -2278,6 +2302,15 @@ describe("Admin settings with edit permission", function () {
       cy.get('[data-test="settings-image-url-input"]').should(
         "have.value",
         "/images/logo.svg",
+      );
+
+      cy.get('[data-test="settings-image-delete-button"]').should("be.visible");
+    });
+
+    cy.get('[data-test="bbb-logo-dark-field"]').within(() => {
+      cy.get('[data-test="settings-image-url-input"]').should(
+        "have.value",
+        "/images/logo-dark.svg",
       );
 
       cy.get('[data-test="settings-image-delete-button"]').should("be.visible");
@@ -2326,6 +2359,27 @@ describe("Admin settings with edit permission", function () {
       cy.get('[data-test="settings-image-url-input"]').should(
         "have.value",
         "/images/logo.svg",
+      );
+
+      cy.get('[data-test="settings-image-delete-button"]')
+        .should("be.visible")
+        .click();
+    });
+
+    cy.get('[data-test="bbb-logo-dark-field"]').within(() => {
+      cy.get('[data-test="settings-image-delete-button"]').click();
+
+      cy.get('[data-test="settings-image-url-input"]').should("not.exist");
+      cy.get('[data-test="file-input-button"]').should("not.exist");
+      cy.get('[data-test="settings-image-delete-button"]').should("not.exist");
+      cy.get('[data-test="settings-image-undo-delete-button"]')
+        .should("be.visible")
+        .and("have.text", "app.undo_delete")
+        .click();
+
+      cy.get('[data-test="settings-image-url-input"]').should(
+        "have.value",
+        "/images/logo-dark.svg",
       );
 
       cy.get('[data-test="settings-image-delete-button"]')
@@ -2388,6 +2442,7 @@ describe("Admin settings with edit permission", function () {
     // Save changes
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = null;
+      settings.data.bbb_logo_dark = null;
       settings.data.bbb_style = null;
       settings.data.bbb_default_presentation = null;
 
@@ -2409,12 +2464,24 @@ describe("Admin settings with edit permission", function () {
 
       expect(formData.get("bbb_logo_file")).to.eql(null);
       expect(formData.get("bbb_logo")).to.eql("");
+      expect(formData.get("bbb_logo_dark")).to.eql("");
       expect(formData.get("bbb_style")).to.eql("");
       expect(formData.get("bbb_default_presentation")).to.be.eql("");
     });
 
     // Check that settings are shown correctly
     cy.get('[data-test="bbb-logo-field"]').within(() => {
+      cy.get('[data-test="settings-image-url-input"]')
+        .should("be.visible")
+        .and("have.value", "");
+      cy.get('[data-test="file-input-button"]').should("be.visible");
+      cy.get('[data-test="settings-image-delete-button"]').should("not.exist");
+      cy.get('[data-test="settings-image-undo-delete-button"]').should(
+        "not.exist",
+      );
+    });
+
+    cy.get('[data-test="bbb-logo-dark-field"]').within(() => {
       cy.get('[data-test="settings-image-url-input"]')
         .should("be.visible")
         .and("have.value", "");
@@ -2446,6 +2513,7 @@ describe("Admin settings with edit permission", function () {
     // Save settings again
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = null;
+      settings.data.bbb_logo_dark = null;
       settings.data.bbb_style = null;
       settings.data.bbb_default_presentation = null;
 
@@ -2467,6 +2535,8 @@ describe("Admin settings with edit permission", function () {
 
       expect(formData.get("bbb_logo_file")).to.eql(null);
       expect(formData.get("bbb_logo")).to.eql(null);
+      expect(formData.get("bbb_logo_dark_file")).to.eql(null);
+      expect(formData.get("bbb_logo_dark")).to.eql(null);
       expect(formData.get("bbb_style")).to.eql(null);
       expect(formData.get("bbb_default_presentation")).to.be.eql(null);
     });
@@ -2564,8 +2634,10 @@ describe("Admin settings with edit permission", function () {
           recording_recording_retention_period: [
             "The selected recording recording retention period is invalid.",
           ],
-          bbb_logo: ["The bbb logo field is required."],
-          bbb_logo_file: ["The bbb logo file field is required."],
+          bbb_logo: ["The logo field is required."],
+          bbb_logo_file: ["The logo file field is required."],
+          bbb_logo_dark: ["The dark version logo field is required."],
+          bbb_logo_dark_file: ["The dark version logo file field is required."],
           bbb_style: ["The bbb style field is required."],
           bbb_default_presentation: [
             "The bbb default presentation field is required.",
@@ -2730,8 +2802,11 @@ describe("Admin settings with edit permission", function () {
     );
 
     cy.get('[data-test="bbb-logo-field"]')
-      .should("include.text", "The bbb logo field is required.")
-      .and("include.text", "The bbb logo file field is required.");
+      .should("include.text", "The logo field is required.")
+      .and("include.text", "The logo file field is required.");
+    cy.get('[data-test="bbb-logo-dark-field"]')
+      .should("include.text", "The dark version logo field is required.")
+      .and("include.text", "The dark version logo file field is required.");
     cy.get('[data-test="bbb-style-field"]').should(
       "include.text",
       "The bbb style field is required.",
@@ -2914,6 +2989,9 @@ describe("Admin settings with edit permission", function () {
     );
 
     cy.get('[data-test="bbb-logo-field"]')
+      .should("not.include.text", "The bbb logo field is required.")
+      .and("not.include.text", "The bbb logo file field is required.");
+    cy.get('[data-test="bbb-logo-dark-field"]')
       .should("not.include.text", "The bbb logo field is required.")
       .and("not.include.text", "The bbb logo file field is required.");
     cy.get('[data-test="bbb-style-field"]').should(

--- a/tests/Frontend/e2e/AdminSettingsView.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsView.cy.js
@@ -817,6 +817,13 @@ describe("Admin settings with edit permission", function () {
         cy.checkSettingsImageSelectorOnlyView("/images/logo.svg");
       });
 
+    cy.get('[data-test="bbb-logo-dark-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.logo_dark.title")
+      .within(() => {
+        cy.checkSettingsImageSelectorOnlyView("/images/logo-dark.svg");
+      });
+
     cy.get('[data-test="bbb-style-field"]')
       .should("be.visible")
       .and("include.text", "admin.settings.bbb.style.title")
@@ -834,6 +841,7 @@ describe("Admin settings with edit permission", function () {
     // Reload with different settings
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = null;
+      settings.data.bbb_logo_dark = null;
       settings.data.bbb_style = "/files/bbb_style.css";
       settings.data.bbb_default_presentation = "/files/testFile.txt";
 
@@ -850,6 +858,13 @@ describe("Admin settings with edit permission", function () {
     cy.get('[data-test="bbb-logo-field"]')
       .should("be.visible")
       .and("include.text", "admin.settings.logo.title")
+      .within(() => {
+        cy.checkSettingsImageSelectorOnlyView("");
+      });
+
+    cy.get('[data-test="bbb-logo-dark-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.logo_dark.title")
       .within(() => {
         cy.checkSettingsImageSelectorOnlyView("");
       });

--- a/tests/Frontend/fixtures/settings.json
+++ b/tests/Frontend/fixtures/settings.json
@@ -38,6 +38,7 @@
     "recording_attendance_retention_period": -1,
     "recording_recording_retention_period": -1,
     "bbb_logo": "/images/logo.svg",
+    "bbb_logo_dark": "/images/logo-dark.svg",
     "bbb_style": null,
     "bbb_default_presentation": null
   },


### PR DESCRIPTION
# Fixes #1399 

**Do not merge until BBB 3.0 is released**

## Type (Highlight the corresponding type)

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Add dark mode logo support for BBB

## Other information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading and managing a dark mode logo for BigBlueButton (BBB) in admin settings, including image upload, preview, and deletion.
  - The dark mode logo is now used in meeting parameters if configured.
- **Bug Fixes**
  - Improved validation and error messages for BBB logo fields, including the new dark mode logo.
- **Documentation**
  - Updated changelog to reflect the addition of the dark mode logo feature.
- **Tests**
  - Extended backend and frontend tests to cover the new dark mode logo functionality and its UI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->