### PR TITLE
Rename mariadb env vars

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -59,12 +59,12 @@ services:
   db:
     image: "mariadb:11"
     environment:
-      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
-      MYSQL_ROOT_HOST: "%"
-      MYSQL_DATABASE: "${DB_DATABASE}"
-      MYSQL_USER: "${DB_USERNAME}"
-      MYSQL_PASSWORD: "${DB_PASSWORD}"
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MARIADB_ROOT_PASSWORD: "${DB_PASSWORD}"
+      MARIADB_ROOT_HOST: "%"
+      MARIADB_DATABASE: "${DB_DATABASE}"
+      MARIADB_USER: "${DB_USERNAME}"
+      MARIADB_PASSWORD: "${DB_PASSWORD}"
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
     volumes:
       - "mariadb:/var/lib/mysql"
       - "./tests/Utils/create-mariadb-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,10 @@ services:
     image: "mariadb:11"
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: "${DB_DATABASE}"
-      MYSQL_USER: "${DB_USERNAME}"
-      MYSQL_PASSWORD: "${DB_PASSWORD}"
-      MYSQL_RANDOM_ROOT_PASSWORD: "true"
+      MARIADB_DATABASE: "${DB_DATABASE}"
+      MARIADB_USER: "${DB_USERNAME}"
+      MARIADB_PASSWORD: "${DB_PASSWORD}"
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "true"
     volumes:
       - "./db:/var/lib/mysql"
     healthcheck:

--- a/docker/sail/bin/sail
+++ b/docker/sail/bin/sail
@@ -383,7 +383,7 @@ elif [ "$1" == "mariadb" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(db bash -c)
-        ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mariadb -u \${MYSQL_USER} \${MYSQL_DATABASE}")
+        ARGS+=("MYSQL_PWD=\${MARIADB_PASSWORD:-\${MYSQL_PASSWORD}} mariadb -u \${MARIADB_USER:-\${MYSQL_USER}} \${MARIADB_DATABASE:-\${MYSQL_DATABASE}}")
     else
         sail_is_not_running
     fi


### PR DESCRIPTION
# Fixes \#

## Type (Highlight the corresponding type)

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe)

## Checklist

- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Use MARIADB_ prefixed environment variables for new installations 
- Adjust sail to support MYSQL_ and MARIADB_ prefixed environment variables

## Other information
Does not effect existing installations, as mariadb supports both environment variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configurations to use MariaDB-specific environment variables with backward compatibility support for existing MySQL-style variables in the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->