### PR TITLE
Fix room limit radio on edit roles page not reset on stale error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Input fields not disabled correctly on login page ([#1791], [#1794])
 - Style of 'clear' button of the room replacement selector in the 'Delete room type' dialog ([#1784], [#1787])
 - Missing form validation feedback on forgot password page ([#1802])
+- Room limit radio on edit roles page not reset on stale error ([#1824], [#1825])
 
 ## [v4.2.0] - 2025-01-06
 
@@ -353,6 +354,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1791]: https://github.com/THM-Health/PILOS/issues/1791
 [#1794]: https://github.com/THM-Health/PILOS/pull/1794
 [#1802]: https://github.com/THM-Health/PILOS/pull/1802
+[#1824]: https://github.com/THM-Health/PILOS/issues/1824
+[#1825]: https://github.com/THM-Health/PILOS/pull/1825
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.2.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -619,6 +619,12 @@ function handleStaleError(staleError) {
         (permission) => permission.id,
       );
       name.value = staleError.new_model.name;
+      roomLimitMode.value =
+        model.value.room_limit === null
+          ? "default"
+          : model.value.room_limit === -1
+            ? "unlimited"
+            : "custom";
     },
   });
 }


### PR DESCRIPTION
# Fixes #1824 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fix room limit radio on edit roles page not reset on stale error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with room limit radio button not resetting correctly on the edit roles page when encountering a stale error
  - Improved handling of stale model errors to ensure correct UI state for room limit settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->