### PR TITLE
'historical meetings' is confusing

### DIFF
--- a/lang/en/meetings.php
+++ b/lang/en/meetings.php
@@ -20,7 +20,7 @@ return [
     'listener_count' => 'Listener',
     'no_data' => 'There are currently no meetings running!',
     'no_data_filtered' => 'No running meetings were found for the search query!',
-    'no_historical_data' => 'There are no historical meetings available',
+    'no_historical_data' => 'There is no meeting history available',
     'now' => 'now',
     'owner' => 'Owner',
     'participant_count' => 'Participant(s)',


### PR DESCRIPTION
This makes you think more of Meetings in Versaille than your own video conferencing history. I tried to clarify this with a more common expression.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated language translation for meeting history message to improve clarity and grammatical structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->