### PR TITLE
Improve docker caching by moving bbb recording player build step

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -62,6 +62,11 @@ COPY ./docker/app/playback-player /usr/local/etc/playback-player
 RUN chmod +x /usr/local/etc/playback-player/build.sh
 RUN chown www-data:www-data /usr/local/etc/playback-player/
 
+# Install BBB Recording Player
+RUN mkdir -p /var/www/html/public/playback-player
+RUN chown -R www-data:www-data /var/www/html
+RUN pilos-cli playback-player:build $PLAYBACK_PLAYER_VERSION
+
 # Copy supervisor config
 RUN mkdir -p /var/log/supervisor
 COPY ./docker/app/supervisord/ /etc/supervisor/conf.d
@@ -98,9 +103,6 @@ RUN if [ "$VITE_COVERAGE" != "true" ] ; then \
 # Run and optimize composer for production
 RUN su-exec www-data composer install --no-dev
 RUN su-exec www-data composer dump-autoload -o
-
-# Install BBB Recording Player
-RUN pilos-cli playback-player:build $PLAYBACK_PLAYER_VERSION
 
 EXPOSE 80
 EXPOSE 443

--- a/docker/app/playback-player/build.sh
+++ b/docker/app/playback-player/build.sh
@@ -22,7 +22,7 @@ folderName="$temporaryDirectory/bbb-playback-$tag"
 wget -O "$downloadFileName" "$downloadBase"
 
 echo "Extracting..."
-unzip "$downloadFileName" -d "$temporaryDirectory"
+unzip "$downloadFileName" -d "$temporaryDirectory" -q
 
 if [ $? -eq 0 ]; then
     echo "Extraction complete"


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.) **DX**
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

## Changes

- Improve Docker build performance by caching the BBB recording player build step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced BBB Recording Player configuration and installation process
	- Improved playback player setup with version-specific build

- **Chores**
	- Updated Dockerfile to optimize playback player deployment
	- Modified build script to reduce extraction output verbosity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->