### PR TITLE
Close join/start modal before redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logo url in emails for logos with absolute path ([#1900])
 - Logo height and width in emails ([#1900])
 - Download files with special characters in the filename ([#1960])
+- Close join/start dialog before joining the BBB meeting ([#1940])
 
 ## [v4.3.1] - 2025-02-17
 
@@ -422,6 +423,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1855]: https://github.com/THM-Health/PILOS/pull/1855
 [#1900]: https://github.com/THM-Health/PILOS/pull/1900
 [#1937]: https://github.com/THM-Health/PILOS/pull/1937
+[#1940]: https://github.com/THM-Health/PILOS/pull/1940
 [#1960]: https://github.com/THM-Health/PILOS/pull/1960
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.3.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -279,6 +279,7 @@ function getJoinUrl() {
     .then((response) => {
       // Check if response has a join url, if yes redirect
       if (response.data.url !== undefined) {
+        modalVisible.value = false;
         window.location = response.data.url;
       }
     })


### PR DESCRIPTION
# Fixes \#

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Close join/start modal before redirecting

## Other information
If the user goes back to the previous page in a BBB meeting he returns to PILOS and the state is kept.
Once a valid join url is generated by PILOS the modal was kept in a busy state, giving the user no option to continue, as closing the modal was blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the meeting initiation process by ensuring the join/start dialog automatically closes when a valid meeting URL is returned, eliminating unnecessary lingering on the screen.
- **Documentation**
	- Updated release notes to reflect the new behavior change for meeting join actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->