### PR TITLE
Revert "Run cypress tests with chrome browser", limit usage of cypress cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,14 +261,9 @@ jobs:
 
       - name: Start app
         run: docker compose -f compose.test.yml -f compose.test.ci.yml up -d
-      - name: Install chrome for testing
-        run: |
-          npx @puppeteer/browsers install chrome@stable --path /opt
-          sudo find /opt/chrome/ -type f -name "chrome" -exec ln -s {} /usr/local/bin/chrome ';'
       - name: Cypress run frontend tests
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome-for-testing
           wait-on: "http://localhost:9080" # Waits for above
           group: "Frontend tests"
           parallel: true
@@ -328,14 +323,10 @@ jobs:
 
       - name: Start app
         run: docker compose -f compose.test.yml -f compose.test.ci.yml up -d
-      - name: Install chrome for testing
-        run: |
-          npx @puppeteer/browsers install chrome@stable --path /opt
-          sudo find /opt/chrome/ -type f -name "chrome" -exec ln -s {} /usr/local/bin/chrome ';'
+
       - name: Run cypress
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome-for-testing
           command-prefix: happo-e2e -- npx
           group: "Visual tests"
           record: true
@@ -392,14 +383,10 @@ jobs:
 
       - name: Start app
         run: docker compose -f compose.test.yml -f compose.test.ci.yml up -d
-      - name: Install chrome for testing
-        run: |
-          npx @puppeteer/browsers install chrome@stable --path /opt
-          sudo find /opt/chrome/ -type f -name "chrome" -exec ln -s {} /usr/local/bin/chrome ';'
+
       - name: Cypress run system tests
         uses: cypress-io/github-action@v6
         with:
-          browser: chrome-for-testing
           wait-on: "http://localhost:9080" # Waits for above
           group: "System tests"
           record: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,38 +196,35 @@ jobs:
           name: pilos-image
           path: /tmp/pilos-image.tar
 
+  generate-frontend-matrix:
+    name: Generate Frontend Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+      record: ${{ steps.generate-matrix.outputs.record }}
+    steps:
+      - name: Generate matrix
+        id: generate-matrix
+        run: |
+          if [ ${{ (github.actor == 'dependabot[bot]' || github.event_name == 'push') && runner.debug != '1' }} = true ]; then
+              record=false
+              matrix='{ "containers": [1] }'
+          else
+              record=true
+              matrix='{ "containers": [1,2,3,4,5] }'
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "record=$record" >> "$GITHUB_OUTPUT"
   frontend-tests:
     name: Frontend Tests
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs:
+      - docker-build
+      - generate-frontend-matrix
     strategy:
       # don't fail the entire matrix on failure
       fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-          ]
+      matrix: ${{ fromJson(needs.generate-frontend-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout
@@ -266,8 +263,8 @@ jobs:
         with:
           wait-on: "http://localhost:9080" # Waits for above
           group: "Frontend tests"
-          parallel: true
-          record: true
+          parallel: ${{ needs.generate-frontend-matrix.outputs.record }}
+          record: ${{ needs.generate-frontend-matrix.outputs.record }}
           tag: ${{ github.event_name }}
         env:
           CYPRESS_PROJECT_ID: ${{ env.CYPRESS_PROJECT_ID }}
@@ -292,7 +289,9 @@ jobs:
   visual-tests:
     name: Visual Tests
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs:
+      - docker-build
+      - generate-frontend-matrix
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -329,7 +328,7 @@ jobs:
         with:
           command-prefix: happo-e2e -- npx
           group: "Visual tests"
-          record: true
+          record: ${{ needs.generate-frontend-matrix.outputs.record }}
           tag: ${{ github.event_name }}
           project: ./tests/Visual
         env:
@@ -347,7 +346,9 @@ jobs:
   system-tests:
     name: System Tests
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs:
+      - docker-build
+      - generate-frontend-matrix
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
     steps:
@@ -389,7 +390,7 @@ jobs:
         with:
           wait-on: "http://localhost:9080" # Waits for above
           group: "System tests"
-          record: true
+          record: ${{ needs.generate-frontend-matrix.outputs.record }}
           tag: ${{ github.event_name }}
           project: ./tests/System
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "@eslint/json": "^0.11.0",
         "@intlify/eslint-plugin-vue-i18n": "^4.0.1",
         "cypress": "^14.3.0",
-        "cypress-real-events": "^1.14.0",
         "eslint": "^9.24.0",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-cypress": "^4.2.0",
@@ -6526,16 +6525,6 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      }
-    },
-    "node_modules/cypress-real-events": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
-      "integrity": "sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x"
       }
     },
     "node_modules/cypress/node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "prettier:fix": "prettier . --write",
     "docs:install": "cd docs && npm install",
     "docs:dev": "cd docs && npm run start -- --host 0.0.0.0",
-    "cypress:open": "TZ=America/New_York ELECTRON_EXTRA_LAUNCH_ARGS=--lang=en cypress open --browser chrome",
-    "cypress:run": "TZ=America/New_York ELECTRON_EXTRA_LAUNCH_ARGS=--lang=en cypress run --browser chrome",
+    "cypress:open": "TZ=America/New_York ELECTRON_EXTRA_LAUNCH_ARGS=--lang=en cypress open",
+    "cypress:run": "TZ=America/New_York ELECTRON_EXTRA_LAUNCH_ARGS=--lang=en cypress run",
     "create-coverage-report": "nyc report --reporter html -t coverage",
     "happo": "happo",
     "happo-ci-github-actions": "happo-ci-github-actions"
@@ -23,7 +23,6 @@
     "@eslint/json": "^0.11.0",
     "@intlify/eslint-plugin-vue-i18n": "^4.0.1",
     "cypress": "^14.3.0",
-    "cypress-real-events": "^1.14.0",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-cypress": "^4.2.0",

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -457,7 +457,7 @@ describe("Room View general", function () {
     );
     cy.get("#invitationCode").should("have.value", "508-307-005");
 
-    cy.get('[data-test="room-copy-invitation-button"]').realClick();
+    cy.get('[data-test="room-copy-invitation-button"]').click();
 
     cy.checkToastMessage("rooms.invitation.copied");
 

--- a/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
@@ -1085,7 +1085,14 @@ describe("Rooms view members bulk actions", function () {
             "have.text",
             "rooms.members.modals.bulk_import.copy_and_close",
           )
-          .realClick();
+          .click();
+
+        // Check clipboard
+        cy.window().then((win) => {
+          win.navigator.clipboard.readText().then((text) => {
+            expect(text).to.eq("notanemail\ninvalidemail@domain.tld");
+          });
+        });
       });
 
     cy.get('[data-test="room-members-bulk-import-dialog"]').should("not.exist");
@@ -1093,13 +1100,6 @@ describe("Rooms view members bulk actions", function () {
     cy.checkToastMessage(
       "rooms.members.modals.bulk_import.copied_invalid_users",
     );
-
-    // Check clipboard
-    cy.window().then((win) => {
-      win.navigator.clipboard.readText().then((text) => {
-        expect(text).to.eq("notanemail\ninvalidemail@domain.tld");
-      });
-    });
 
     // Check that members are shown correctly
     cy.get('[data-test="room-member-item"]').should("have.length", 4);

--- a/tests/Frontend/e2e/RoomsViewPersonalizedLinksTokenActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewPersonalizedLinksTokenActions.cy.js
@@ -740,7 +740,7 @@ describe("Rooms view personalized links token actions", function () {
     cy.get('[data-test="room-personalized-link-item"]')
       .eq(0)
       .find('[data-test="room-personalized-links-copy-button"]')
-      .realClick();
+      .click();
 
     // Check clipboard content
     cy.window().then((win) => {

--- a/tests/Frontend/support/e2e.js
+++ b/tests/Frontend/support/e2e.js
@@ -20,7 +20,6 @@ import "./commands/adminRoomTypesCommands.js";
 import "./commands/adminSettingsCommands.js";
 import "./commands/adminRolesCommands.js";
 import "@cypress/code-coverage/support";
-import "cypress-real-events";
 
 Cypress.on("uncaught:exception", (err) => {
   // Check if error should be ignored


### PR DESCRIPTION
Reverts THM-Health/PILOS#2004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test matrix and recording behavior in CI to dynamically adjust based on event context.
  - Removed explicit Chrome installation and browser specification from test workflows.
  - Removed the `cypress-real-events` package and related imports.

- **Tests**
  - Replaced `.realClick()` with standard `.click()` in several end-to-end tests.
  - Improved clipboard content validation timing in bulk import members test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->