### PR TITLE
Fix BBB playback player build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Environment variable `MAIL_VERIFY_PEER` to disable TLS Peer Verification for SMTP(S) ([#2033])
 - Environment variable `MAIL_SCHEME` to set a specific mail protocol `smtp` or `smtps` ([#2033])
 
+### Fixed
+
+- Running BBB playback player build script in BusyBox ([#2053])
+
 ### Removed
 
 - Environment variable `MAIL_ENCRYPTION`, use `MAIL_SCHEME` instead ([#2033])
@@ -449,6 +453,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#1988]: https://github.com/THM-Health/PILOS/pull/1988
 [#2015]: https://github.com/THM-Health/PILOS/pull/2015
 [#2033]: https://github.com/THM-Health/PILOS/pull/2033
+[#2053]: https://github.com/THM-Health/PILOS/pull/2053
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.4.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/docker/app/playback-player/build.sh
+++ b/docker/app/playback-player/build.sh
@@ -22,7 +22,7 @@ folderName="$temporaryDirectory/bbb-playback-$tag"
 wget -O "$downloadFileName" "$downloadBase"
 
 echo "Extracting..."
-unzip "$downloadFileName" -d "$temporaryDirectory" -q
+unzip -q -d "$temporaryDirectory" "$downloadFileName"
 
 if [ $? -eq 0 ]; then
     echo "Extraction complete"

--- a/docker/app/playback-player/build.sh
+++ b/docker/app/playback-player/build.sh
@@ -22,14 +22,15 @@ folderName="$temporaryDirectory/bbb-playback-$tag"
 wget -O "$downloadFileName" "$downloadBase"
 
 echo "Extracting..."
-unzip -q -d "$temporaryDirectory" "$downloadFileName"
-
-if [ $? -eq 0 ]; then
+if unzip -q -d "$temporaryDirectory" "$downloadFileName"; then
     echo "Extraction complete"
 
     # run install script
     echo "Building new player..."
-    cd "$folderName"
+    if ! cd "$folderName"; then
+        echo "Entering directory $folderName failed"
+        exit 2
+    fi
     npm install
     REACT_APP_MEDIA_ROOT_URL=/recording/presentation npm run build
 


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixes order of `unzip` arguments in playback-player build script.

## Other information

BusyBox builtin `unzip` and the one that comes with the `zip` package handle command-line arguments differently.
While `unzip target.zip -q` works with the former, the "proper" unzip searches for a file `-q` within the archive to unpack:
```
Extracting...
Archive:  /tmp/tmp.HcGfBC/player.zip
a8f5a72a7dc55cc8bab6f980035291b6e8fe5de5
caution: filename not matched:  -q
Extraction failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved error handling during the extraction and setup process in the build script to provide clearer feedback if extraction or directory changes fail.
  - Updated the changelog to document a fix for running the playback player build script in BusyBox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->