### PR TITLE
docker compose version attribute is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # For more information: https://laravel.com/docs/sail
-version: "3"
 
 x-docker-pilos-common: &pilos-common
   image: "${CONTAINER_IMAGE:-pilos/pilos:latest}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker Compose configuration to remove the version declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->