### PR TITLE
Refactor: Rename search query api parameter

### DIFF
--- a/app/Http/Controllers/api/v1/MeetingController.php
+++ b/app/Http/Controllers/api/v1/MeetingController.php
@@ -47,8 +47,8 @@ class MeetingController extends Controller
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
         // And-search, sub queries split by space
-        if ($request->has('search') && trim($request->search) != '') {
-            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->search));
+        if ($request->has('query')) {
+            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->query('query')));
             foreach ($searchQueries as $searchQuery) {
                 $resource = $resource->where(function ($query) use ($searchQuery) {
                     $query->whereHas('room', function ($subQuery) use ($searchQuery) {

--- a/app/Http/Controllers/api/v1/RecordingController.php
+++ b/app/Http/Controllers/api/v1/RecordingController.php
@@ -63,8 +63,8 @@ class RecordingController extends Controller
         $additional['meta']['total_no_filter'] = $resource->count();
 
         // Apply search filter
-        if ($request->has('search')) {
-            $resource = $resource->whereLike('description', '%'.$request->query('search').'%');
+        if ($request->has('query')) {
+            $resource = $resource->whereLike('description', '%'.$request->query('query').'%');
         }
 
         // Apply filter if set, first element is the column, second the value to query

--- a/app/Http/Controllers/api/v1/RoleController.php
+++ b/app/Http/Controllers/api/v1/RoleController.php
@@ -55,8 +55,8 @@ class RoleController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('search')) {
-            $resource = $resource->withName($request->query('search'));
+        if ($request->has('query')) {
+            $resource = $resource->withName($request->query('query'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/RoleController.php
+++ b/app/Http/Controllers/api/v1/RoleController.php
@@ -55,8 +55,8 @@ class RoleController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('name')) {
-            $resource = $resource->withName($request->query('name'));
+        if ($request->has('search')) {
+            $resource = $resource->withName($request->query('search'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/RoomController.php
+++ b/app/Http/Controllers/api/v1/RoomController.php
@@ -120,8 +120,8 @@ class RoomController extends Controller
         }
 
         // rooms that can be found with the search
-        if ($request->has('search') && trim($request->search) != '') {
-            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->search));
+        if ($request->has('query')) {
+            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->query('query')));
             foreach ($searchQueries as $searchQuery) {
                 $collection = $collection->where(function ($query) use ($searchQuery) {
                     $query->whereLike('rooms.name', '%'.$searchQuery.'%')

--- a/app/Http/Controllers/api/v1/RoomFileController.php
+++ b/app/Http/Controllers/api/v1/RoomFileController.php
@@ -55,8 +55,8 @@ class RoomFileController extends Controller
         $additional['meta']['total_no_filter'] = $resource->count();
 
         // Apply search filter
-        if ($request->has('search')) {
-            $resource = $resource->where('filename', 'like', '%'.$request->query('search').'%');
+        if ($request->has('query')) {
+            $resource = $resource->where('filename', 'like', '%'.$request->query('query').'%');
         }
 
         // Apply filter if set, first element is the column, second the value to query

--- a/app/Http/Controllers/api/v1/RoomMemberController.php
+++ b/app/Http/Controllers/api/v1/RoomMemberController.php
@@ -60,9 +60,9 @@ class RoomMemberController extends Controller
         $additional['meta']['total_no_filter'] = $resource->count();
 
         // Apply search query if set
-        if ($request->has('search')) {
+        if ($request->has('query')) {
             // Split search query into single words and search for them in firstname and lastname
-            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->search));
+            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->query('query')));
             foreach ($searchQueries as $searchQuery) {
                 $resource = $resource->where(function ($query) use ($searchQuery) {
                     $query->whereLike('firstname', '%'.$searchQuery.'%')

--- a/app/Http/Controllers/api/v1/RoomTokenController.php
+++ b/app/Http/Controllers/api/v1/RoomTokenController.php
@@ -59,9 +59,9 @@ class RoomTokenController extends Controller
         $additional['meta']['total_no_filter'] = $resource->count();
 
         // Apply search query if set
-        if ($request->has('search')) {
+        if ($request->has('query')) {
             // Split search query into single words and search for them in firstname and lastname
-            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->search));
+            $searchQueries = explode(' ', preg_replace('/\s\s+/', ' ', $request->query('query')));
             foreach ($searchQueries as $searchQuery) {
                 $resource = $resource->where(function ($query) use ($searchQuery) {
                     $query->whereLike('firstname', '%'.$searchQuery.'%')

--- a/app/Http/Controllers/api/v1/ServerController.php
+++ b/app/Http/Controllers/api/v1/ServerController.php
@@ -70,8 +70,8 @@ class ServerController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('name')) {
-            $resource = $resource->withName($request->query('name'));
+        if ($request->has('search')) {
+            $resource = $resource->withName($request->query('search'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/ServerController.php
+++ b/app/Http/Controllers/api/v1/ServerController.php
@@ -70,8 +70,8 @@ class ServerController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('search')) {
-            $resource = $resource->withName($request->query('search'));
+        if ($request->has('query')) {
+            $resource = $resource->withName($request->query('query'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/ServerPoolController.php
+++ b/app/Http/Controllers/api/v1/ServerPoolController.php
@@ -52,8 +52,8 @@ class ServerPoolController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('name')) {
-            $resource = $resource->withName($request->query('name'));
+        if ($request->has('search')) {
+            $resource = $resource->withName($request->query('search'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/ServerPoolController.php
+++ b/app/Http/Controllers/api/v1/ServerPoolController.php
@@ -52,8 +52,8 @@ class ServerPoolController extends Controller
         // count all before search
         $additionalMeta['meta']['total_no_filter'] = $resource->count();
 
-        if ($request->has('search')) {
-            $resource = $resource->withName($request->query('search'));
+        if ($request->has('query')) {
+            $resource = $resource->withName($request->query('query'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/UserController.php
+++ b/app/Http/Controllers/api/v1/UserController.php
@@ -46,7 +46,7 @@ class UserController extends Controller
      */
     public function search(Request $request)
     {
-        $query = User::withNameOrEmail($request->query('search'));
+        $query = User::withNameOrEmail($request->query('query'));
 
         if ($query->count() > config('bigbluebutton.user_search_limit')) {
             abort(204, 'Too many results');
@@ -98,8 +98,8 @@ class UserController extends Controller
             $resource = $resource->withRole($request->query('role'));
         }
 
-        if ($request->has('search')) {
-            $resource = $resource->withNameOrEmail($request->query('search'));
+        if ($request->has('query')) {
+            $resource = $resource->withNameOrEmail($request->query('query'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/UserController.php
+++ b/app/Http/Controllers/api/v1/UserController.php
@@ -98,8 +98,8 @@ class UserController extends Controller
             $resource = $resource->withRole($request->query('role'));
         }
 
-        if ($request->has('name')) {
-            $resource = $resource->withName($request->query('name'));
+        if ($request->has('search')) {
+            $resource = $resource->withNameOrEmail($request->query('search'));
         }
 
         $resource = $resource->paginate(app(GeneralSettings::class)->pagination_page_size);

--- a/app/Http/Controllers/api/v1/UserController.php
+++ b/app/Http/Controllers/api/v1/UserController.php
@@ -46,7 +46,7 @@ class UserController extends Controller
      */
     public function search(Request $request)
     {
-        $query = User::withName($request->query('query'));
+        $query = User::withNameOrEmail($request->query('query'));
 
         if ($query->count() > config('bigbluebutton.user_search_limit')) {
             abort(204, 'Too many results');

--- a/app/Http/Controllers/api/v1/UserController.php
+++ b/app/Http/Controllers/api/v1/UserController.php
@@ -46,7 +46,7 @@ class UserController extends Controller
      */
     public function search(Request $request)
     {
-        $query = User::withNameOrEmail($request->query('query'));
+        $query = User::withNameOrEmail($request->query('search'));
 
         if ($query->count() > config('bigbluebutton.user_search_limit')) {
             abort(204, 'Too many results');

--- a/app/Http/Requests/ShowRoomsRequest.php
+++ b/app/Http/Requests/ShowRoomsRequest.php
@@ -18,7 +18,7 @@ class ShowRoomsRequest extends FormRequest
             'only_favorites' => ['required', 'boolean'],
             'room_type' => ['nullable', 'integer', 'exists:App\Models\RoomType,id'],
             'sort_by' => ['required', Rule::enum(RoomSortingType::class)],
-            'search' => ['string'],
+            'query' => ['string'],
             'page' => ['required', 'integer'],
             'per_page' => ['required', 'integer', 'max:20'],
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -227,7 +227,7 @@ class User extends Authenticatable implements HasLocalePreference
      * @param  string  $name  Name to search for
      * @return Builder The scoped query
      */
-    public function scopeWithName(Builder $query, $name)
+    public function scopewithNameOrEmail(Builder $query, $name)
     {
         $name = preg_replace('/\s\s+/', ' ', $name);
         $splittedName = explode(' ', $name);

--- a/resources/js/components/RoomTabFiles.vue
+++ b/resources/js/components/RoomTabFiles.vue
@@ -381,7 +381,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: search.value === "" ? null : search.value,
+      query: search.value === "" ? null : search.value,
       filter: filter.value === "all" ? null : filter.value,
     },
   };

--- a/resources/js/components/RoomTabMembers.vue
+++ b/resources/js/components/RoomTabMembers.vue
@@ -359,7 +359,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: search.value === "" ? null : search.value,
+      query: search.value === "" ? null : search.value,
       filter: filter.value === "all" ? null : filter.value,
     },
   };

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -168,14 +168,14 @@ defineExpose({
 
 /**
  * Search for users in database
- * @param search
+ * @param query
  */
-function asyncFind(search) {
+function asyncFind(query) {
   isLoadingSearch.value = true;
 
   const config = {
     params: {
-      search,
+      query,
     },
   };
 

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -168,14 +168,14 @@ defineExpose({
 
 /**
  * Search for users in database
- * @param query
+ * @param search
  */
-function asyncFind(query) {
+function asyncFind(search) {
   isLoadingSearch.value = true;
 
   const config = {
     params: {
-      query,
+      search,
     },
   };
 

--- a/resources/js/components/RoomTabPersonalizedLinks.vue
+++ b/resources/js/components/RoomTabPersonalizedLinks.vue
@@ -297,7 +297,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: search.value === "" ? null : search.value,
+      query: search.value === "" ? null : search.value,
       filter: filter.value === "all" ? null : filter.value,
     },
   };

--- a/resources/js/components/RoomTabRecordings.vue
+++ b/resources/js/components/RoomTabRecordings.vue
@@ -392,7 +392,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: search.value === "" ? null : search.value,
+      query: search.value === "" ? null : search.value,
       filter: filter.value === "all" ? null : filter.value,
     },
   };

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -256,14 +256,14 @@ function showModal() {
 
 /**
  * Search for users in database
- * @param search
+ * @param query
  */
-function asyncFind(search) {
+function asyncFind(query) {
   isLoadingSearch.value = true;
 
   const config = {
     params: {
-      search,
+      query,
     },
   };
 

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -256,14 +256,14 @@ function showModal() {
 
 /**
  * Search for users in database
- * @param query
+ * @param search
  */
-function asyncFind(query) {
+function asyncFind(search) {
   isLoadingSearch.value = true;
 
   const config = {
     params: {
-      query,
+      search,
     },
   };
 

--- a/resources/js/views/AdminRolesIndex.vue
+++ b/resources/js/views/AdminRolesIndex.vue
@@ -196,7 +196,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: filter.value,
+      query: filter.value,
     },
   };
 

--- a/resources/js/views/AdminRolesIndex.vue
+++ b/resources/js/views/AdminRolesIndex.vue
@@ -196,7 +196,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      name: filter.value,
+      search: filter.value,
     },
   };
 

--- a/resources/js/views/AdminServerPoolsIndex.vue
+++ b/resources/js/views/AdminServerPoolsIndex.vue
@@ -193,7 +193,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      name: filter.value,
+      search: filter.value,
     },
   };
 

--- a/resources/js/views/AdminServerPoolsIndex.vue
+++ b/resources/js/views/AdminServerPoolsIndex.vue
@@ -193,7 +193,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: filter.value,
+      query: filter.value,
     },
   };
 

--- a/resources/js/views/AdminServersIndex.vue
+++ b/resources/js/views/AdminServersIndex.vue
@@ -326,7 +326,7 @@ function loadData(page = null, updateUsage = false) {
       update_usage: updateUsage,
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      name: filter.value,
+      search: filter.value,
     },
   };
 

--- a/resources/js/views/AdminServersIndex.vue
+++ b/resources/js/views/AdminServersIndex.vue
@@ -326,7 +326,7 @@ function loadData(page = null, updateUsage = false) {
       update_usage: updateUsage,
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: filter.value,
+      query: filter.value,
     },
   };
 

--- a/resources/js/views/AdminUsersIndex.vue
+++ b/resources/js/views/AdminUsersIndex.vue
@@ -4,7 +4,7 @@
       <div>
         <InputGroup data-test="user-search">
           <InputText
-            v-model="filter.name"
+            v-model="filter.search"
             :disabled="isBusy"
             :placeholder="$t('app.search')"
             @keyup.enter="loadData(1)"
@@ -344,7 +344,7 @@ const sortField = ref("id");
 const sortOrder = ref(1);
 
 const filter = ref({
-  name: undefined,
+  search: undefined,
   role: undefined,
 });
 
@@ -410,7 +410,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      name: filter.value.name,
+      search: filter.value.search,
       role: filter.value.role?.id,
     },
   };

--- a/resources/js/views/AdminUsersIndex.vue
+++ b/resources/js/views/AdminUsersIndex.vue
@@ -410,7 +410,7 @@ function loadData(page = null) {
       page: page || paginator.getCurrentPage(),
       sort_by: sortField.value,
       sort_direction: sortOrder.value === 1 ? "asc" : "desc",
-      search: filter.value.search,
+      query: filter.value.search,
       role: filter.value.role?.id,
     },
   };

--- a/resources/js/views/MeetingsIndex.vue
+++ b/resources/js/views/MeetingsIndex.vue
@@ -289,7 +289,7 @@ function loadData(page = null) {
   };
 
   if (search.value) {
-    config.params.search = search.value;
+    config.params.query = search.value;
   }
 
   api

--- a/resources/js/views/RoomsIndex.vue
+++ b/resources/js/views/RoomsIndex.vue
@@ -488,7 +488,7 @@ function loadRooms(page = null) {
         only_favorites: onlyShowFavorites.value ? 1 : 0,
         room_type: selectedRoomType.value == 0 ? null : selectedRoomType.value,
         sort_by: selectedSortingType.value,
-        search:
+        query:
           rawSearchQuery.value.trim() !== ""
             ? rawSearchQuery.value.trim()
             : null,

--- a/tests/Backend/Feature/api/v1/MeetingTest.php
+++ b/tests/Backend/Feature/api/v1/MeetingTest.php
@@ -112,7 +112,7 @@ class MeetingTest extends TestCase
         Meeting::destroy($runningMeetings->pluck('id'));
 
         // Filtering by room name
-        $this->getJson(route('api.v1.meetings.index').'?search=Test+room')
+        $this->getJson(route('api.v1.meetings.index').'?query=Test+room')
             ->assertSuccessful()
             ->assertJsonCount(3, 'data')
             ->assertJsonFragment(['id' => $meeting1->id])
@@ -120,14 +120,14 @@ class MeetingTest extends TestCase
             ->assertJsonFragment(['id' => $meeting3->id]);
 
         // Filtering by owner
-        $this->getJson(route('api.v1.meetings.index').'?search=John+Doe')
+        $this->getJson(route('api.v1.meetings.index').'?query=John+Doe')
             ->assertSuccessful()
             ->assertJsonCount(2, 'data')
             ->assertJsonFragment(['id' => $meeting1->id])
             ->assertJsonFragment(['id' => $meeting2->id]);
 
         // Filtering by server
-        $this->getJson(route('api.v1.meetings.index').'?search=Testserver')
+        $this->getJson(route('api.v1.meetings.index').'?query=Testserver')
             ->assertSuccessful()
             ->assertJsonCount(3, 'data')
             ->assertJsonFragment(['id' => $meeting1->id])
@@ -135,7 +135,7 @@ class MeetingTest extends TestCase
             ->assertJsonFragment(['id' => $meeting3->id]);
 
         // Filtering by combination
-        $this->getJson(route('api.v1.meetings.index').'?search=Testserver+Doe+room+2')
+        $this->getJson(route('api.v1.meetings.index').'?query=Testserver+Doe+room+2')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $meeting2->id]);

--- a/tests/Backend/Feature/api/v1/RoleTest.php
+++ b/tests/Backend/Feature/api/v1/RoleTest.php
@@ -66,7 +66,7 @@ class RoleTest extends TestCase
         // Test search
         $this->generalSettings->pagination_page_size = 10;
         $this->generalSettings->save();
-        $this->getJson(route('api.v1.roles.index').'?name=Admin')
+        $this->getJson(route('api.v1.roles.index').'?search=Admin')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['name' => $roleA->name])

--- a/tests/Backend/Feature/api/v1/RoleTest.php
+++ b/tests/Backend/Feature/api/v1/RoleTest.php
@@ -66,7 +66,7 @@ class RoleTest extends TestCase
         // Test search
         $this->generalSettings->pagination_page_size = 10;
         $this->generalSettings->save();
-        $this->getJson(route('api.v1.roles.index').'?search=Admin')
+        $this->getJson(route('api.v1.roles.index').'?query=Admin')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['name' => $roleA->name])

--- a/tests/Backend/Feature/api/v1/Room/FileTest.php
+++ b/tests/Backend/Feature/api/v1/Room/FileTest.php
@@ -240,7 +240,7 @@ class FileTest extends TestCase
 
         // Test search
         $this->actingAs($this->room->owner)
-            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'search' => '.pdf']))
+            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'query' => '.pdf']))
             ->assertSuccessful()
             ->assertJsonCount(2, 'data')
             ->assertJsonPath('data.0.filename', 'document.pdf')
@@ -264,7 +264,7 @@ class FileTest extends TestCase
 
         // Test filter and search
         $this->actingAs($this->room->owner)
-            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'filter' => 'use_in_meeting', 'search' => '.pdf']))
+            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'filter' => 'use_in_meeting', 'query' => '.pdf']))
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.filename', 'document.pdf')
@@ -272,7 +272,7 @@ class FileTest extends TestCase
 
         // Test search with no results
         $this->actingAs($this->room->owner)
-            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'search' => 'test']))
+            ->getJson(route('api.v1.rooms.files.get', ['room' => $this->room, 'query' => 'test']))
             ->assertSuccessful()
             ->assertJsonCount(0, 'data')
             ->assertJsonPath('meta.total', 0)

--- a/tests/Backend/Feature/api/v1/Room/MembershipTest.php
+++ b/tests/Backend/Feature/api/v1/Room/MembershipTest.php
@@ -380,7 +380,7 @@ class MembershipTest extends TestCase
             ->assertJsonPath('data.4.lastname', 'Osorio');
 
         // Check search
-        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.member.get', ['room' => $room, 'search' => 'Jo']))
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.member.get', ['room' => $room, 'query' => 'Jo']))
             ->assertJsonCount(2, 'data')
             ->assertJsonPath('data.0.firstname', 'Angela')
             ->assertJsonPath('data.1.firstname', 'John')
@@ -388,7 +388,7 @@ class MembershipTest extends TestCase
             ->assertJsonPath('meta.total_no_filter', 6);
 
         // Check search with whitespaces (all should match in first or last name)
-        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.member.get', ['room' => $room, 'search' => 'John Doe']))
+        $this->actingAs($room->owner)->getJson(route('api.v1.rooms.member.get', ['room' => $room, 'query' => 'John Doe']))
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.firstname', 'John')
             ->assertJsonPath('meta.total', 1)

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -1490,47 +1490,47 @@ class RoomTest extends TestCase
             ->assertJsonPath('meta.total_no_filter', 2);
 
         // Testing with empty query
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=')
-            ->assertJsonValidationErrors('search');
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=')
+            ->assertJsonValidationErrors('query');
 
         // Find by room name
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=Test')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=Test')
             ->assertOk()
             ->assertJsonFragment(['id' => $room1->id])
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('meta.total_no_filter', 2);
 
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=Test+a')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=Test+a')
             ->assertOk()
             ->assertJsonFragment(['id' => $room1->id])
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('meta.total_no_filter', 2);
 
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=Test+a+xyz')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=Test+a+xyz')
             ->assertOk()
             ->assertJsonCount(0, 'data');
 
         // Find by owner name
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=john')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=john')
             ->assertOk()
             ->assertJsonCount(2, 'data');
 
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=john+d')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=john+d')
             ->assertOk()
             ->assertJsonCount(2, 'data');
 
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=john+d+xyz')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=john+d+xyz')
             ->assertOk()
             ->assertJsonCount(0, 'data');
 
         // Find by owner name and room name
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=test+john')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=test+john')
             ->assertOk()
             ->assertJsonFragment(['id' => $room1->id])
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('meta.total_no_filter', 2);
 
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&search=test+john+xyz')
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.index').'?filter_own=1&filter_shared=1&filter_public=1&filter_all=1&only_favorites=0&sort_by=last_started&page=1&per_page=12&query=test+john+xyz')
             ->assertOk()
             ->assertJsonCount(0, 'data');
     }

--- a/tests/Backend/Feature/api/v1/Room/RoomTokenTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTokenTest.php
@@ -155,7 +155,7 @@ class RoomTokenTest extends TestCase
             ->assertJsonPath('data.3.firstname', 'John');
 
         // Check search
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.tokens.get', ['room' => $this->room, 'search' => 'Jo']))
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.tokens.get', ['room' => $this->room, 'query' => 'Jo']))
             ->assertJsonCount(2, 'data')
             ->assertJsonPath('data.0.firstname', 'Angela')
             ->assertJsonPath('data.1.firstname', 'John')
@@ -163,7 +163,7 @@ class RoomTokenTest extends TestCase
             ->assertJsonPath('meta.total_no_filter', 6);
 
         // Check search with whitespaces (all should match in first or last name)
-        $this->actingAs($this->user)->getJson(route('api.v1.rooms.tokens.get', ['room' => $this->room, 'search' => 'John Doe']))
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.tokens.get', ['room' => $this->room, 'query' => 'John Doe']))
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.firstname', 'John')
             ->assertJsonPath('meta.total', 1)

--- a/tests/Backend/Feature/api/v1/ServerPoolTest.php
+++ b/tests/Backend/Feature/api/v1/ServerPoolTest.php
@@ -89,7 +89,7 @@ class ServerPoolTest extends TestCase
             ->assertJsonFragment(['id' => $serverPools[5]->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.serverPools.index').'?search=testPool')
+        $this->getJson(route('api.v1.serverPools.index').'?query=testPool')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $serverPool1->id]);

--- a/tests/Backend/Feature/api/v1/ServerPoolTest.php
+++ b/tests/Backend/Feature/api/v1/ServerPoolTest.php
@@ -89,7 +89,7 @@ class ServerPoolTest extends TestCase
             ->assertJsonFragment(['id' => $serverPools[5]->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.serverPools.index').'?name=testPool')
+        $this->getJson(route('api.v1.serverPools.index').'?search=testPool')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $serverPool1->id]);

--- a/tests/Backend/Feature/api/v1/ServerTest.php
+++ b/tests/Backend/Feature/api/v1/ServerTest.php
@@ -116,13 +116,13 @@ class ServerTest extends TestCase
             ->assertJsonFragment(['id' => $servers[5]->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.servers.index').'?search=serverDisabled')
+        $this->getJson(route('api.v1.servers.index').'?query=serverDisabled')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $serverDisabled->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.servers.index').'?search=server')
+        $this->getJson(route('api.v1.servers.index').'?query=server')
             ->assertSuccessful()
             ->assertJsonCount(5, 'data')
             ->assertJsonFragment(['id' => $serverOnline->id])
@@ -160,7 +160,7 @@ class ServerTest extends TestCase
             ->assertJsonMissing(['id' => Server::orderBy('name')->first()->id]);
 
         // Check server health
-        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&search=server')
+        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&query=server')
             ->assertSuccessful()
             ->assertJsonCount(5, 'data');
 
@@ -176,7 +176,7 @@ class ServerTest extends TestCase
         $this->assertEquals(ServerHealth::UNHEALTHY->value, $response->json('data.4.health'));
 
         // Request with forced usage update, should see that the online servers are now unhealthy (because it's fake data)
-        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&search=server&update_usage=true')
+        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&query=server&update_usage=true')
             ->assertSuccessful()
             ->assertJsonCount($page_size, 'data');
 

--- a/tests/Backend/Feature/api/v1/ServerTest.php
+++ b/tests/Backend/Feature/api/v1/ServerTest.php
@@ -116,13 +116,13 @@ class ServerTest extends TestCase
             ->assertJsonFragment(['id' => $servers[5]->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.servers.index').'?name=serverDisabled')
+        $this->getJson(route('api.v1.servers.index').'?search=serverDisabled')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $serverDisabled->id]);
 
         // Filtering by name
-        $this->getJson(route('api.v1.servers.index').'?name=server')
+        $this->getJson(route('api.v1.servers.index').'?search=server')
             ->assertSuccessful()
             ->assertJsonCount(5, 'data')
             ->assertJsonFragment(['id' => $serverOnline->id])
@@ -160,7 +160,7 @@ class ServerTest extends TestCase
             ->assertJsonMissing(['id' => Server::orderBy('name')->first()->id]);
 
         // Check server health
-        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&name=server')
+        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&search=server')
             ->assertSuccessful()
             ->assertJsonCount(5, 'data');
 
@@ -176,7 +176,7 @@ class ServerTest extends TestCase
         $this->assertEquals(ServerHealth::UNHEALTHY->value, $response->json('data.4.health'));
 
         // Request with forced usage update, should see that the online servers are now unhealthy (because it's fake data)
-        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&name=server&update_usage=true')
+        $response = $this->getJson(route('api.v1.servers.index').'?sort_by=name&sort_direction=asc&search=server&update_usage=true')
             ->assertSuccessful()
             ->assertJsonCount($page_size, 'data');
 

--- a/tests/Backend/Feature/api/v1/UserTest.php
+++ b/tests/Backend/Feature/api/v1/UserTest.php
@@ -186,14 +186,14 @@ class UserTest extends TestCase
             ->assertJsonValidationErrors(['role']);
 
         // Filtering by name / email
-        $this->getJson(route('api.v1.users.index').'?search=J%20Doe')
+        $this->getJson(route('api.v1.users.index').'?query=J%20Doe')
             ->assertSuccessful()
             ->assertJsonCount(2, 'data')
             ->assertJsonFragment(['firstname' => $user->firstname])
             ->assertJsonFragment(['firstname' => $externalUser->firstname]);
 
         // Filtering by role and name
-        $this->getJson(route('api.v1.users.index').'?search=John&role='.$role2->id)
+        $this->getJson(route('api.v1.users.index').'?query=John&role='.$role2->id)
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $user->id]);
@@ -220,11 +220,11 @@ class UserTest extends TestCase
             ->assertNoContent();
 
         // Test with query and order, too many results
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=a')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=a')
             ->assertNoContent();
 
         // Check with lastname query
-        $result = $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Braun')
+        $result = $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Braun')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[4]->firstname)
             ->assertJsonPath('data.1.firstname', $users[5]->firstname)
@@ -236,13 +236,13 @@ class UserTest extends TestCase
         }
 
         // check with multiple words
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Braun+Connie')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Braun+Connie')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[4]->firstname)
             ->assertJsonCount(1, 'data');
 
         // check with fragment
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Ma')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Ma')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[0]->firstname)
             ->assertJsonPath('data.1.firstname', $users[1]->firstname)
@@ -250,7 +250,7 @@ class UserTest extends TestCase
             ->assertJsonCount(3, 'data');
 
         // check with email fragment
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=deborah.brown')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=deborah.brown')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[5]->firstname)
             ->assertJsonCount(1, 'data');

--- a/tests/Backend/Feature/api/v1/UserTest.php
+++ b/tests/Backend/Feature/api/v1/UserTest.php
@@ -186,14 +186,14 @@ class UserTest extends TestCase
             ->assertJsonValidationErrors(['role']);
 
         // Filtering by name / email
-        $this->getJson(route('api.v1.users.index').'?name=J%20Doe')
+        $this->getJson(route('api.v1.users.index').'?search=J%20Doe')
             ->assertSuccessful()
             ->assertJsonCount(2, 'data')
             ->assertJsonFragment(['firstname' => $user->firstname])
             ->assertJsonFragment(['firstname' => $externalUser->firstname]);
 
         // Filtering by role and name
-        $this->getJson(route('api.v1.users.index').'?name=John&role='.$role2->id)
+        $this->getJson(route('api.v1.users.index').'?search=John&role='.$role2->id)
             ->assertSuccessful()
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment(['id' => $user->id]);

--- a/tests/Backend/Feature/api/v1/UserTest.php
+++ b/tests/Backend/Feature/api/v1/UserTest.php
@@ -220,11 +220,11 @@ class UserTest extends TestCase
             ->assertNoContent();
 
         // Test with query and order, too many results
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=a')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=a')
             ->assertNoContent();
 
         // Check with lastname query
-        $result = $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Braun')
+        $result = $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Braun')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[4]->firstname)
             ->assertJsonPath('data.1.firstname', $users[5]->firstname)
@@ -236,13 +236,13 @@ class UserTest extends TestCase
         }
 
         // check with multiple words
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Braun+Connie')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Braun+Connie')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[4]->firstname)
             ->assertJsonCount(1, 'data');
 
         // check with fragment
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=Ma')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=Ma')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[0]->firstname)
             ->assertJsonPath('data.1.firstname', $users[1]->firstname)
@@ -250,7 +250,7 @@ class UserTest extends TestCase
             ->assertJsonCount(3, 'data');
 
         // check with email fragment
-        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?query=deborah.brown')
+        $this->actingAs($users[0])->getJson(route('api.v1.users.search').'?search=deborah.brown')
             ->assertSuccessful()
             ->assertJsonPath('data.0.firstname', $users[5]->firstname)
             ->assertJsonCount(1, 'data');

--- a/tests/Backend/Unit/UserTest.php
+++ b/tests/Backend/Unit/UserTest.php
@@ -64,26 +64,26 @@ class UserTest extends TestCase
 
     public function test_returns_user_with_given_name_part()
     {
-        $result = User::withName('ust ax')->get();
+        $result = User::withNameOrEmail('ust ax')->get();
         $this->assertCount(1, $result);
         $this->assertEquals($this->users[0]->firstname, $result[0]->firstname);
         $this->assertEquals($this->users[0]->lastname, $result[0]->lastname);
 
-        $result = User::withName('ax    ust')->get();
+        $result = User::withNameOrEmail('ax    ust')->get();
         $this->assertCount(1, $result);
         $this->assertEquals($this->users[0]->firstname, $result[0]->firstname);
         $this->assertEquals($this->users[0]->lastname, $result[0]->lastname);
 
-        $result = User::withName('ax    ust')->where('id', $this->users[1]->id)->get();
+        $result = User::withNameOrEmail('ax    ust')->where('id', $this->users[1]->id)->get();
         $this->assertCount(0, $result);
 
-        $result = User::withName('Max Doe')->where('id', $this->users[1]->id)->get();
+        $result = User::withNameOrEmail('Max Doe')->where('id', $this->users[1]->id)->get();
         $this->assertCount(0, $result);
     }
 
     public function test_returns_empty_array_for_not_existing_name()
     {
-        $result = User::withName('Darth Vader')->get();
+        $result = User::withNameOrEmail('Darth Vader')->get();
         $this->assertCount(0, $result);
     }
 

--- a/tests/Frontend/e2e/AdminRolesIndex.cy.js
+++ b/tests/Frontend/e2e/AdminRolesIndex.cy.js
@@ -352,7 +352,7 @@ describe("Admin roles index", function () {
     cy.visit("/admin/roles");
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -377,7 +377,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > button').click();
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("Test");
+      expect(interception.request.query.query).to.equal("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -407,7 +407,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > input').type("{enter}");
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("Test2");
+      expect(interception.request.query.query).to.equal("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -436,7 +436,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > button').click();
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("e");
+      expect(interception.request.query.query).to.equal("e");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -479,7 +479,7 @@ describe("Admin roles index", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@rolesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "e",
+        query: "e",
         page: "2",
       });
     });
@@ -516,7 +516,7 @@ describe("Admin roles index", function () {
     // Check that roles are loaded with the page reset to the first page
     cy.wait("@rolesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "o",
+        query: "o",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/AdminRolesIndex.cy.js
+++ b/tests/Frontend/e2e/AdminRolesIndex.cy.js
@@ -352,7 +352,7 @@ describe("Admin roles index", function () {
     cy.visit("/admin/roles");
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.name).to.be.undefined;
+      expect(interception.request.query.search).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -377,7 +377,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > button').click();
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("Test");
+      expect(interception.request.query.search).to.equal("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -407,7 +407,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > input').type("{enter}");
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("Test2");
+      expect(interception.request.query.search).to.equal("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -436,7 +436,7 @@ describe("Admin roles index", function () {
     cy.get('[data-test="role-search"] > button').click();
 
     cy.wait("@rolesRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("e");
+      expect(interception.request.query.search).to.equal("e");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -479,7 +479,7 @@ describe("Admin roles index", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@rolesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        name: "e",
+        search: "e",
         page: "2",
       });
     });
@@ -516,7 +516,7 @@ describe("Admin roles index", function () {
     // Check that roles are loaded with the page reset to the first page
     cy.wait("@rolesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        name: "o",
+        search: "o",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
@@ -336,7 +336,7 @@ describe("Admin server pools index", function () {
   it("server pools search", function () {
     cy.visit("/admin/server_pools");
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -361,7 +361,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > button').click();
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test");
+      expect(interception.request.query.query).to.eql("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -391,7 +391,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > input').type("{enter}");
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test2");
+      expect(interception.request.query.query).to.eql("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -419,7 +419,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > button').click();
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("T");
+      expect(interception.request.query.query).to.eql("T");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -459,7 +459,7 @@ describe("Admin server pools index", function () {
 
     // Check if search query stays the same after changing the page
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("T");
+      expect(interception.request.query.query).to.eql("T");
       expect(interception.request.query).to.contain({
         page: "2",
       });
@@ -496,7 +496,7 @@ describe("Admin server pools index", function () {
 
     // Check that server pools are loaded with the page reset to the first page
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Te");
+      expect(interception.request.query.query).to.eql("Te");
       expect(interception.request.query).to.contain({
         page: "1",
       });

--- a/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
@@ -336,7 +336,7 @@ describe("Admin server pools index", function () {
   it("server pools search", function () {
     cy.visit("/admin/server_pools");
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.be.undefined;
+      expect(interception.request.query.search).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -361,7 +361,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > button').click();
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Test");
+      expect(interception.request.query.search).to.eql("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -391,7 +391,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > input').type("{enter}");
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Test2");
+      expect(interception.request.query.search).to.eql("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -419,7 +419,7 @@ describe("Admin server pools index", function () {
     cy.get('[data-test="server-pool-search"] > button').click();
 
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("T");
+      expect(interception.request.query.search).to.eql("T");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -459,7 +459,7 @@ describe("Admin server pools index", function () {
 
     // Check if search query stays the same after changing the page
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("T");
+      expect(interception.request.query.search).to.eql("T");
       expect(interception.request.query).to.contain({
         page: "2",
       });
@@ -496,7 +496,7 @@ describe("Admin server pools index", function () {
 
     // Check that server pools are loaded with the page reset to the first page
     cy.wait("@serverPoolsRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Te");
+      expect(interception.request.query.search).to.eql("Te");
       expect(interception.request.query).to.contain({
         page: "1",
       });

--- a/tests/Frontend/e2e/AdminServersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServersIndex.cy.js
@@ -527,7 +527,7 @@ describe("Admin servers index", function () {
   it("server search", function () {
     cy.visit("/admin/servers");
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -553,7 +553,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > button').click();
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test");
+      expect(interception.request.query.query).to.eql("Test");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -584,7 +584,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > input').type("{enter}");
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test2");
+      expect(interception.request.query.query).to.eql("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -614,7 +614,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > button').click();
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Server");
+      expect(interception.request.query.query).to.eql("Server");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -656,7 +656,7 @@ describe("Admin servers index", function () {
 
     // Check if the search query stays the same after changing the page
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Server");
+      expect(interception.request.query.query).to.eql("Server");
       expect(interception.request.query).to.contain({
         page: "2",
         update_usage: "false",
@@ -699,7 +699,7 @@ describe("Admin servers index", function () {
 
     // Check that servers are loaded with the page reset to the first page
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Se");
+      expect(interception.request.query.query).to.eql("Se");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",

--- a/tests/Frontend/e2e/AdminServersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServersIndex.cy.js
@@ -527,7 +527,7 @@ describe("Admin servers index", function () {
   it("server search", function () {
     cy.visit("/admin/servers");
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.be.undefined;
+      expect(interception.request.query.search).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -553,7 +553,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > button').click();
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Test");
+      expect(interception.request.query.search).to.eql("Test");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -584,7 +584,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > input').type("{enter}");
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Test2");
+      expect(interception.request.query.search).to.eql("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -614,7 +614,7 @@ describe("Admin servers index", function () {
     cy.get('[data-test="server-search"] > button').click();
 
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Server");
+      expect(interception.request.query.search).to.eql("Server");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",
@@ -656,7 +656,7 @@ describe("Admin servers index", function () {
 
     // Check if the search query stays the same after changing the page
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Server");
+      expect(interception.request.query.search).to.eql("Server");
       expect(interception.request.query).to.contain({
         page: "2",
         update_usage: "false",
@@ -699,7 +699,7 @@ describe("Admin servers index", function () {
 
     // Check that servers are loaded with the page reset to the first page
     cy.wait("@serversRequest").then((interception) => {
-      expect(interception.request.query.name).to.eql("Se");
+      expect(interception.request.query.search).to.eql("Se");
       expect(interception.request.query).to.contain({
         page: "1",
         update_usage: "false",

--- a/tests/Frontend/e2e/AdminUsersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminUsersIndex.cy.js
@@ -731,7 +731,7 @@ describe("Admin users index", function () {
     cy.visit("/admin/users");
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -756,7 +756,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > button').click();
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("Test");
+      expect(interception.request.query.query).to.equal("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -786,7 +786,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > input').type("{enter}");
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("Test2");
+      expect(interception.request.query.query).to.equal("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -815,7 +815,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > button').click();
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.search).to.equal("e");
+      expect(interception.request.query.query).to.equal("e");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -855,7 +855,7 @@ describe("Admin users index", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@usersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "e",
+        query: "e",
         page: "2",
       });
     });
@@ -892,7 +892,7 @@ describe("Admin users index", function () {
     // Check that users are loaded with the page reset to the first page
     cy.wait("@usersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "o",
+        query: "o",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/AdminUsersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminUsersIndex.cy.js
@@ -731,7 +731,7 @@ describe("Admin users index", function () {
     cy.visit("/admin/users");
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.name).to.be.undefined;
+      expect(interception.request.query.search).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -756,7 +756,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > button').click();
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("Test");
+      expect(interception.request.query.search).to.equal("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -786,7 +786,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > input').type("{enter}");
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("Test2");
+      expect(interception.request.query.search).to.equal("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -815,7 +815,7 @@ describe("Admin users index", function () {
     cy.get('[data-test="user-search"] > button').click();
 
     cy.wait("@usersRequest").then((interception) => {
-      expect(interception.request.query.name).to.equal("e");
+      expect(interception.request.query.search).to.equal("e");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -855,7 +855,7 @@ describe("Admin users index", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@usersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        name: "e",
+        search: "e",
         page: "2",
       });
     });
@@ -892,7 +892,7 @@ describe("Admin users index", function () {
     // Check that users are loaded with the page reset to the first page
     cy.wait("@usersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        name: "o",
+        search: "o",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/MeetingsIndex.cy.js
+++ b/tests/Frontend/e2e/MeetingsIndex.cy.js
@@ -500,7 +500,7 @@ describe("Meetings index", function () {
   it("meeting search", function () {
     cy.visit("/meetings");
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -525,7 +525,7 @@ describe("Meetings index", function () {
     cy.get('[data-test="meeting-search"] > button').click();
 
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test");
+      expect(interception.request.query.query).to.eql("Test");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -555,7 +555,7 @@ describe("Meetings index", function () {
     cy.get('[data-test="meeting-search"] > input').type("{enter}");
 
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Test2");
+      expect(interception.request.query.query).to.eql("Test2");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -584,7 +584,7 @@ describe("Meetings index", function () {
     cy.get('[data-test="meeting-search"] > button').click();
 
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Meeting");
+      expect(interception.request.query.query).to.eql("Meeting");
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -626,7 +626,7 @@ describe("Meetings index", function () {
 
     // Check if search query stays the same after changing the page
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Meeting");
+      expect(interception.request.query.query).to.eql("Meeting");
       expect(interception.request.query).to.contain({
         page: "2",
       });
@@ -669,7 +669,7 @@ describe("Meetings index", function () {
 
     // Check that meetings are loaded with the page reset to the first page
     cy.wait("@meetingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.eql("Meet");
+      expect(interception.request.query.query).to.eql("Meet");
       expect(interception.request.query).to.contain({
         page: "1",
       });

--- a/tests/Frontend/e2e/RoomsIndex.cy.js
+++ b/tests/Frontend/e2e/RoomsIndex.cy.js
@@ -453,7 +453,7 @@ describe("Room Index", function () {
     cy.visit("/rooms");
 
     cy.wait("@roomRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -478,7 +478,7 @@ describe("Room Index", function () {
 
     cy.wait("@roomRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test",
+        query: "Test",
         page: "1",
       });
     });
@@ -508,7 +508,7 @@ describe("Room Index", function () {
 
     cy.wait("@roomRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test2",
+        query: "Test2",
         page: "1",
       });
     });
@@ -537,7 +537,7 @@ describe("Room Index", function () {
 
     cy.wait("@roomRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Meeting",
+        query: "Meeting",
         page: "1",
       });
     });
@@ -577,7 +577,7 @@ describe("Room Index", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@roomRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Meeting",
+        query: "Meeting",
         page: "2",
       });
     });
@@ -615,7 +615,7 @@ describe("Room Index", function () {
     // Check that rooms are loaded with the page reset to the first page
     cy.wait("@roomRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Meet",
+        query: "Meet",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/RoomsViewFiles.cy.js
+++ b/tests/Frontend/e2e/RoomsViewFiles.cy.js
@@ -1265,7 +1265,7 @@ describe("Rooms View Files", function () {
     cy.visit("/rooms/abc-def-123#tab=files");
 
     cy.wait("@roomFilesRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -1289,7 +1289,7 @@ describe("Rooms View Files", function () {
 
     cy.wait("@roomFilesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test",
+        query: "Test",
         page: "1",
       });
     });
@@ -1318,7 +1318,7 @@ describe("Rooms View Files", function () {
 
     cy.wait("@roomFilesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test2",
+        query: "Test2",
         page: "1",
       });
     });
@@ -1347,7 +1347,7 @@ describe("Rooms View Files", function () {
 
     cy.wait("@roomFilesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "File",
+        query: "File",
         page: "1",
       });
     });
@@ -1389,7 +1389,7 @@ describe("Rooms View Files", function () {
     // Check if search query stays the same after changing the page
     cy.wait("@roomFilesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "File",
+        query: "File",
         page: "2",
       });
     });
@@ -1430,7 +1430,7 @@ describe("Rooms View Files", function () {
 
     cy.wait("@roomFilesRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Fil",
+        query: "Fil",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/RoomsViewMembers.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembers.cy.js
@@ -564,7 +564,7 @@ describe("Rooms view members", function () {
     cy.visit("/rooms/abc-def-123#tab=members");
 
     cy.wait("@roomMembersRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -588,7 +588,7 @@ describe("Rooms view members", function () {
 
     cy.wait("@roomMembersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test",
+        query: "Test",
         page: "1",
       });
     });
@@ -617,7 +617,7 @@ describe("Rooms view members", function () {
 
     cy.wait("@roomMembersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test2",
+        query: "Test2",
         page: "1",
       });
     });
@@ -646,7 +646,7 @@ describe("Rooms view members", function () {
 
     cy.wait("@roomMembersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Laura",
+        query: "Laura",
         page: "1",
       });
     });
@@ -697,7 +697,7 @@ describe("Rooms view members", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@roomMembersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Laura",
+        query: "Laura",
         page: "2",
       });
     });
@@ -739,7 +739,7 @@ describe("Rooms view members", function () {
     // Check that members are loaded with the page reset to the first page
     cy.wait("@roomMembersRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Laur",
+        query: "Laur",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
@@ -28,7 +28,7 @@ describe("Rooms view members member actions", function () {
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
     // Start typing and respond with too many results
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 204,
     }).as("userSearchRequest");
 
@@ -70,7 +70,7 @@ describe("Rooms view members member actions", function () {
       .and("not.be.visible");
 
     // Continue typing and respond with results
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 200,
       body: {
         data: [
@@ -256,7 +256,7 @@ describe("Rooms view members member actions", function () {
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
     // Test 500 error on user search
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 500,
       body: {
         message: "Test",
@@ -292,7 +292,7 @@ describe("Rooms view members member actions", function () {
         cy.get('[data-test="select-user-dropdown"]').find("input").type("a");
       },
       "GET",
-      "/api/v1/users/search?search=*",
+      "/api/v1/users/search?query=*",
       "members",
     );
 
@@ -314,7 +314,7 @@ describe("Rooms view members member actions", function () {
 
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 200,
       body: {
         data: [

--- a/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
@@ -28,7 +28,7 @@ describe("Rooms view members member actions", function () {
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
     // Start typing and respond with too many results
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 204,
     }).as("userSearchRequest");
 
@@ -70,7 +70,7 @@ describe("Rooms view members member actions", function () {
       .and("not.be.visible");
 
     // Continue typing and respond with results
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 200,
       body: {
         data: [
@@ -256,7 +256,7 @@ describe("Rooms view members member actions", function () {
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
     // Test 500 error on user search
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 500,
       body: {
         message: "Test",
@@ -292,7 +292,7 @@ describe("Rooms view members member actions", function () {
         cy.get('[data-test="select-user-dropdown"]').find("input").type("a");
       },
       "GET",
-      "/api/v1/users/search?query=*",
+      "/api/v1/users/search?search=*",
       "members",
     );
 
@@ -314,7 +314,7 @@ describe("Rooms view members member actions", function () {
 
     cy.get('[data-test="room-members-add-single-dialog"]').should("be.visible");
 
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 200,
       body: {
         data: [

--- a/tests/Frontend/e2e/RoomsViewPersonalizedLinks.cy.js
+++ b/tests/Frontend/e2e/RoomsViewPersonalizedLinks.cy.js
@@ -800,7 +800,7 @@ describe("Rooms view personalized links", function () {
     cy.visit("/rooms/abc-def-123#tab=tokens");
 
     cy.wait("@roomTokensRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -824,7 +824,7 @@ describe("Rooms view personalized links", function () {
 
     cy.wait("@roomTokensRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test",
+        query: "Test",
         page: "1",
       });
     });
@@ -858,7 +858,7 @@ describe("Rooms view personalized links", function () {
 
     cy.wait("@roomTokensRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test2",
+        query: "Test2",
         page: "1",
       });
     });
@@ -890,7 +890,7 @@ describe("Rooms view personalized links", function () {
 
     cy.wait("@roomTokensRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Doe",
+        query: "Doe",
         page: "1",
       });
     });
@@ -935,7 +935,7 @@ describe("Rooms view personalized links", function () {
     // Check if the search query stays the same after changing the page
     cy.wait("@roomTokensRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Doe",
+        query: "Doe",
         page: "2",
       });
     });
@@ -980,7 +980,7 @@ describe("Rooms view personalized links", function () {
     // Check that personalized-links are loaded with the page reset to the first page
     cy.wait("@roomTokensRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Do",
+        query: "Do",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/RoomsViewRecordings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewRecordings.cy.js
@@ -1241,7 +1241,7 @@ describe("Rooms view recordings", function () {
     cy.visit("/rooms/abc-def-123#tab=recordings");
 
     cy.wait("@roomRecordingsRequest").then((interception) => {
-      expect(interception.request.query.search).to.be.undefined;
+      expect(interception.request.query.query).to.be.undefined;
       expect(interception.request.query).to.contain({
         page: "1",
       });
@@ -1265,7 +1265,7 @@ describe("Rooms view recordings", function () {
 
     cy.wait("@roomRecordingsRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test",
+        query: "Test",
         page: "1",
       });
     });
@@ -1294,7 +1294,7 @@ describe("Rooms view recordings", function () {
 
     cy.wait("@roomRecordingsRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Test2",
+        query: "Test2",
         page: "1",
       });
     });
@@ -1323,7 +1323,7 @@ describe("Rooms view recordings", function () {
 
     cy.wait("@roomRecordingsRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Recording",
+        query: "Recording",
         page: "1",
       });
     });
@@ -1365,7 +1365,7 @@ describe("Rooms view recordings", function () {
     // Check if search query stays the same after changing the page
     cy.wait("@roomRecordingsRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Recording",
+        query: "Recording",
         page: "2",
       });
     });
@@ -1406,7 +1406,7 @@ describe("Rooms view recordings", function () {
 
     cy.wait("@roomRecordingsRequest").then((interception) => {
       expect(interception.request.query).to.contain({
-        search: "Record",
+        query: "Record",
         page: "1",
       });
     });

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -1732,7 +1732,7 @@ describe("Rooms view settings", function () {
         cy.get(".multiselect__content").should("be.visible");
 
         // Start typing and respond with too many results
-        cy.intercept("GET", "/api/v1/users/search?query=*", {
+        cy.intercept("GET", "/api/v1/users/search?search=*", {
           statusCode: 204,
         }).as("userSearchRequest");
 
@@ -1768,7 +1768,7 @@ describe("Rooms view settings", function () {
           .should("include.text", "rooms.members.modals.add.no_options")
           .and("not.be.visible");
 
-        cy.intercept("GET", "/api/v1/users/search?query=*", {
+        cy.intercept("GET", "/api/v1/users/search?search=*", {
           statusCode: 200,
           body: {
             data: [
@@ -2028,7 +2028,7 @@ describe("Rooms view settings", function () {
     cy.get("[data-test=room-transfer-ownership-dialog]").should("be.visible");
 
     // Test 500 error on user search
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 500,
       body: {
         message: "Test",
@@ -2061,7 +2061,7 @@ describe("Rooms view settings", function () {
         cy.get('[data-test="new-owner-dropdown"]').find("input").type("L");
       },
       "GET",
-      "/api/v1/users/search?query=*",
+      "/api/v1/users/search?search=*",
       "settings",
     );
 
@@ -2078,7 +2078,7 @@ describe("Rooms view settings", function () {
 
     cy.get("[data-test=room-transfer-ownership-dialog]").should("be.visible");
 
-    cy.intercept("GET", "/api/v1/users/search?query=*", {
+    cy.intercept("GET", "/api/v1/users/search?search=*", {
       statusCode: 200,
       body: {
         data: [

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -1732,7 +1732,7 @@ describe("Rooms view settings", function () {
         cy.get(".multiselect__content").should("be.visible");
 
         // Start typing and respond with too many results
-        cy.intercept("GET", "/api/v1/users/search?search=*", {
+        cy.intercept("GET", "/api/v1/users/search?query=*", {
           statusCode: 204,
         }).as("userSearchRequest");
 
@@ -1768,7 +1768,7 @@ describe("Rooms view settings", function () {
           .should("include.text", "rooms.members.modals.add.no_options")
           .and("not.be.visible");
 
-        cy.intercept("GET", "/api/v1/users/search?search=*", {
+        cy.intercept("GET", "/api/v1/users/search?query=*", {
           statusCode: 200,
           body: {
             data: [
@@ -2028,7 +2028,7 @@ describe("Rooms view settings", function () {
     cy.get("[data-test=room-transfer-ownership-dialog]").should("be.visible");
 
     // Test 500 error on user search
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 500,
       body: {
         message: "Test",
@@ -2061,7 +2061,7 @@ describe("Rooms view settings", function () {
         cy.get('[data-test="new-owner-dropdown"]').find("input").type("L");
       },
       "GET",
-      "/api/v1/users/search?search=*",
+      "/api/v1/users/search?query=*",
       "settings",
     );
 
@@ -2078,7 +2078,7 @@ describe("Rooms view settings", function () {
 
     cy.get("[data-test=room-transfer-ownership-dialog]").should("be.visible");
 
-    cy.intercept("GET", "/api/v1/users/search?search=*", {
+    cy.intercept("GET", "/api/v1/users/search?query=*", {
       statusCode: 200,
       body: {
         data: [


### PR DESCRIPTION
# Fixes #1602

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Unified the search query parameter on all api requests to `query` for consistency.

## Other information

Long term alternatives:
- Remove own logic for filtering and sorting and switch to https://spatie.be/docs/laravel-query-builder/v6/introduction
- Rewrite the whole API with https://api-platform.com/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
- **Bug Fixes**
	- Standardized the search query parameter across the application from various keys (such as `name` and `search`) to a single key: `query`.

- **Style**
	- Updated user interface components to reflect the new search parameter naming for consistency.

- **Tests**
	- Adjusted backend and frontend tests to use the unified `query` parameter for search-related assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->