### PR TITLE
Pass color-scheme preference to BigBlueButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show meeting ended reason ([#2223])
 - Show BBB join errors ([#2223])
+- Pass color-scheme preference to BigBlueButton ([#2153], [#2154])
 
 ## [v4.6.1] - 2025-06-16
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last login datetime to the database ([#2150])
 - Last login datetime to the admin user list ([#2132], [#2150])
 - Custom join parameters in room type settings ([#2099], [#2151])
-- Pass color-scheme preference to BigBlueButton ([#2153], [#2154])
+
 
 ### Fixed
 
@@ -503,6 +504,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2151]: https://github.com/THM-Health/PILOS/pull/2151
 [#2222]: https://github.com/THM-Health/PILOS/pull/2222
 [#2223]: https://github.com/THM-Health/PILOS/pull/2223
+[#2153]: https://github.com/THM-Health/PILOS/pull/2153
+[#2154]: https://github.com/THM-Health/PILOS/pull/2154
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.6.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last login datetime to the database ([#2150])
 - Last login datetime to the admin user list ([#2132], [#2150])
 - Custom join parameters in room type settings ([#2099], [#2151])
+- Pass color-scheme preference to BigBlueButton ([#2153], [#2154])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last login datetime to the admin user list ([#2132], [#2150])
 - Custom join parameters in room type settings ([#2099], [#2151])
 
-
 ### Fixed
 
 - Container restart ([#2134])

--- a/app/Http/Requests/JoinMeeting.php
+++ b/app/Http/Requests/JoinMeeting.php
@@ -20,6 +20,7 @@ class JoinMeeting extends FormRequest
     {
         $rules = [
             'name' => auth()->check() || $this->roomAuthService->getRoomToken($this->room) ? [] : ['required', 'min:2', 'max:50',  new ValidName],
+            'dark_mode' => ['sometimes', 'boolean'],
         ];
 
         $rules += $this->getAttendanceRecordingRules();

--- a/app/Http/Requests/StartMeeting.php
+++ b/app/Http/Requests/StartMeeting.php
@@ -20,6 +20,7 @@ class StartMeeting extends FormRequest
     {
         $rules = [
             'name' => auth()->check() || $this->roomAuthService->getRoomToken($this->room) ? [] : ['required', 'min:2', 'max:50',  new ValidName],
+            'dark_mode' => ['sometimes', 'boolean'],
         ];
 
         $rules += $this->getAttendanceRecordingRules();

--- a/app/Services/MeetingService.php
+++ b/app/Services/MeetingService.php
@@ -668,6 +668,7 @@ class MeetingService
         }
 
         $joinMeetingParams->addUserData('bbb_skip_check_audio', Auth::user() ? Auth::user()->bbb_skip_check_audio : false);
+        $joinMeetingParams->addUserData('bbb_prefer_dark_theme', $request->boolean('dark_mode'));
 
         // If meeting has recording enabled, add parameter to allow recording of own video
         if ($this->meeting->record) {

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -183,6 +183,7 @@ import { useToast } from "../composables/useToast.js";
 import { useI18n } from "vue-i18n";
 import { EVENT_FORBIDDEN } from "../constants/events.js";
 import EventBus from "../services/EventBus.js";
+import { useDark } from "@vueuse/core";
 
 const props = defineProps({
   roomId: {
@@ -217,6 +218,7 @@ const emit = defineEmits([
 ]);
 
 const authStore = useAuthStore();
+const isDark = useDark();
 
 const modalVisible = ref(false);
 const isLoadingAction = ref(false);
@@ -344,6 +346,7 @@ function getJoinUrl() {
       consent_record: recordAgreement.value,
       consent_record_video: recordVideoAgreement.value,
       consent_streaming: streamingAgreement.value,
+      dark_mode: isDark.value,
     },
   };
 

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -3519,6 +3519,117 @@ class RoomTest extends TestCase
     }
 
     /**
+     * Test joining urls contains correct userdata-bbb_prefer_dark_theme parameter
+     * for start and join room depending on the dark_mode api parameter
+     * defaulting to false if no value is passed
+     */
+    public function test_join_url_dark_mode()
+    {
+        $room = Room::factory()->create();
+
+        $server = Server::factory()->create();
+        $room->roomType->serverPool->servers()->attach($server);
+
+        // Create Fake BBB-Server
+        $bbbfaker = new BigBlueButtonServerFaker($server->base_url, $server->secret);
+        // Create meeting 3 times
+        $bbbfaker->addCreateMeetingRequest();
+        $bbbfaker->addCreateMeetingRequest();
+        $bbbfaker->addCreateMeetingRequest();
+        // Get meeting info 3 times
+        $meetingInfoRequest = function (Request $request) {
+            $uri = $request->toPsrRequest()->getUri();
+            parse_str($uri->getQuery(), $params);
+            $xml = '
+                <response>
+                    <returncode>SUCCESS</returncode>
+                    <meetingName>test</meetingName>
+                    <meetingID>'.$params['meetingID'].'</meetingID>
+                    <internalMeetingID>5400b2af9176c1be733b9a4f1adbc7fb41a72123-1624606850899</internalMeetingID>
+                    <createTime>1624606850899</createTime>
+                    <createDate>Fri Jun 25 09:40:50 CEST 2021</createDate>
+                    <voiceBridge>70663</voiceBridge>
+                    <dialNumber>613-555-1234</dialNumber>
+                    <running>true</running>
+                    <duration>0</duration>
+                    <hasUserJoined>true</hasUserJoined>
+                    <recording>false</recording>
+                    <hasBeenForciblyEnded>false</hasBeenForciblyEnded>
+                    <startTime>1624606850956</startTime>
+                    <endTime>0</endTime>
+                    <participantCount>0</participantCount>
+                    <listenerCount>0</listenerCount>
+                    <voiceParticipantCount>0</voiceParticipantCount>
+                    <videoCount>0</videoCount>
+                    <maxUsers>0</maxUsers>
+                    <moderatorCount>0</moderatorCount>
+                    <isBreakout>false</isBreakout>
+                </response>';
+
+            return Http::response($xml);
+        };
+        for ($i = 0; $i < 3; $i++) {
+            $bbbfaker->addRequest($meetingInfoRequest);
+        }
+
+        // Start meeting with passing dark mode parameter invalid
+        $this->actingAs($room->owner)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => 'invalid'])
+            ->assertJsonValidationErrors(['dark_mode']);
+
+        // Start meeting without passing dark mode parameter, should default to false
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('false', $queryParams['userdata-bbb_prefer_dark_theme']);
+        // End meeting to reset state
+        $room->refresh();
+        new MeetingService($room->latestMeeting)->setEnd();
+
+        // Start meeting with passing dark mode parameter false
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => false])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('false', $queryParams['userdata-bbb_prefer_dark_theme']);
+        // End meeting to reset state
+        $room->refresh();
+        new MeetingService($room->latestMeeting)->setEnd();
+
+        // Start meeting with passing dark mode parameter true
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => true])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('true', $queryParams['userdata-bbb_prefer_dark_theme']);
+
+        // Join without passing dark mode parameter, should default to false
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('false', $queryParams['userdata-bbb_prefer_dark_theme']);
+
+        // Join with passing dark mode parameter false
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => false])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('false', $queryParams['userdata-bbb_prefer_dark_theme']);
+
+        // Join with passing dark mode parameter true
+        $response = $this->actingAs($room->owner)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => true])
+            ->assertSuccessful();
+        $queryParams = [];
+        parse_str(parse_url($response->json('url'))['query'], $queryParams);
+        $this->assertEquals('true', $queryParams['userdata-bbb_prefer_dark_theme']);
+
+        // Join with passing dark mode parameter invalid
+        $this->actingAs($room->owner)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false, 'dark_mode' => 'invalid'])
+            ->assertJsonValidationErrors(['dark_mode']);
+    }
+
+    /**
      * Tests if record parameters are validated based on the current running meeting
      */
     public function test_join_record()

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -2804,4 +2804,51 @@ describe("Rooms view meetings", function () {
     // Check dialog is closed
     cy.get('[data-test="room-join-dialog"]').should("not.exist");
   });
+
+  it("start meeting with dark mode", function () {
+    cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
+      statusCode: 200,
+      body: {
+        url: "https://example.org/?foo=a&bar=b",
+      },
+    }).as("startRequest");
+
+    cy.intercept("OPTIONS", "api/v1/rooms/abc-def-123/start", {
+      statusCode: 200,
+      body: {
+        data: {
+          features: {
+            recording: false,
+            attendance_recording: false,
+            streaming: false,
+          },
+        },
+      },
+    }).as("preStartRequest");
+
+    cy.visit("/rooms/abc-def-123");
+
+    cy.get('[data-test="navbar-dark-mode"]').click();
+
+    cy.get('[data-test="room-start-button"]').click();
+
+    cy.wait("@preStartRequest");
+
+    // Check that correct query is sent
+    cy.wait("@startRequest").then((interception) => {
+      expect(interception.request.body).to.eql({
+        name: "",
+        consent_record_attendance: false,
+        consent_record: false,
+        consent_record_video: false,
+        consent_streaming: false,
+        dark_mode: true,
+      });
+    });
+
+    // Check if redirect worked
+    cy.origin("https://example.org", () => {
+      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    });
+  });
 });

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -1381,6 +1381,67 @@ describe("Rooms view meetings", function () {
     cy.get('[data-test="room-join-dialog"]').should("not.exist");
   });
 
+  it("join running meeting with dark mode", function () {
+    cy.fixture("room.json").then((room) => {
+      room.data.last_meeting = {
+        start: "2023-08-21T08:18:28.000000Z",
+        end: null,
+      };
+
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+    });
+
+    cy.intercept("OPTIONS", "api/v1/rooms/abc-def-123/join", {
+      statusCode: 200,
+      body: {
+        data: {
+          features: {
+            recording: false,
+            attendance_recording: false,
+            streaming: false,
+          },
+        },
+      },
+    }).as("preJoinRequest");
+
+    cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
+      statusCode: 200,
+      body: {
+        url: "https://example.org/?foo=a&bar=b",
+      },
+    }).as("joinRequest");
+
+    cy.visit("/rooms/abc-def-123");
+
+    cy.wait("@roomRequest");
+
+    // Toggle dark mode
+    cy.get('[data-test="navbar-dark-mode"]').click();
+
+    cy.get('[data-test="room-join-button"]').click();
+    cy.wait("@preJoinRequest");
+
+    // Check that correct query is sent, dark mode is enabled
+    cy.wait("@joinRequest").then((interception) => {
+      expect(interception.request.body).to.eql({
+        name: "",
+        consent_record_attendance: false,
+        consent_record: false,
+        consent_record_video: false,
+        consent_streaming: false,
+        dark_mode: true,
+      });
+    });
+
+    // Check if redirect worked
+    cy.origin("https://example.org", () => {
+      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    });
+  });
+
   it("start meeting", function () {
     const startRequest = interceptIndefinitely(
       "POST",

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -77,6 +77,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -161,6 +162,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -245,6 +247,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: true,
+        dark_mode: false,
       });
     });
 
@@ -332,6 +335,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -399,6 +403,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -473,6 +478,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -550,6 +556,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -676,6 +683,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
       // Check that header for access code is set
       expect(interception.request.headers["access-code"]).to.eq("123456789");
@@ -907,6 +915,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
       // Check that header for token is set
       expect(interception.request.headers.token).to.eq(
@@ -1429,6 +1438,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1504,6 +1514,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1579,6 +1590,7 @@ describe("Rooms view meetings", function () {
         consent_record: false,
         consent_record_video: false,
         consent_streaming: true,
+        dark_mode: false,
       });
     });
 
@@ -1657,6 +1669,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1711,6 +1724,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: false,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1778,6 +1792,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1848,6 +1863,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
     });
 
@@ -1962,6 +1978,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
       // Check that header for access code is set
       expect(interception.request.headers["access-code"]).to.eq("123456789");
@@ -2163,6 +2180,7 @@ describe("Rooms view meetings", function () {
         consent_record: true,
         consent_record_video: true,
         consent_streaming: false,
+        dark_mode: false,
       });
       // Check that header for token is set
       expect(interception.request.headers.token).to.eq(


### PR DESCRIPTION
# Fixes #2153 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Add: pass color-scheme preference to BigBlueButton

## Other information
Supported in BBB > 3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing your dark mode preference when joining or starting a BigBlueButton meeting. The system will now detect and send your current color scheme preference.
* **Bug Fixes**
  * Improved validation for the dark mode option when joining or starting meetings.
* **Tests**
  * Enhanced backend and end-to-end tests to verify correct handling and transmission of the dark mode setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->