### PR TITLE
Fix: Allow global streaming join parameters to be empty

### DIFF
--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -197,7 +197,7 @@ function updateSettings() {
     formData.append("css_file", "");
   }
 
-  formData.append("join_parameters", settings.value.join_parameters);
+  formData.append("join_parameters", settings.value.join_parameters || "");
 
   formData.append("_method", "PUT");
 


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixes allow global streaming join parameters to be empty


## Additional information
This view uses a multi-part form. Unlike JSON form requests used in other views/components, it cannot contain null, true or false values, only strings. The current implementation results in the value 'null' being sent as a string. However, by sending an empty string, Laravel will convert this to null internally - solving the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of updating streaming settings by ensuring the "join_parameters" field is always included, preventing issues with missing or undefined values during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->