### PR TITLE
Fix: Allow global streaming join parameters to be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow global streaming join parameters to be empty ([#2222])
+
 ## [v4.6.0] - 2025-06-12
 
 ### Added
@@ -489,6 +493,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2134]: https://github.com/THM-Health/PILOS/pull/2134
 [#2150]: https://github.com/THM-Health/PILOS/pull/2150
 [#2151]: https://github.com/THM-Health/PILOS/pull/2151
+[#2222]: https://github.com/THM-Health/PILOS/pull/2222
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.6.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -197,7 +197,7 @@ function updateSettings() {
     formData.append("css_file", "");
   }
 
-  formData.append("join_parameters", settings.value.join_parameters);
+  formData.append("join_parameters", settings.value.join_parameters || "");
 
   formData.append("_method", "PUT");
 


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixes allow global streaming join parameters to be empty


## Additional information
This view uses a multi-part form. Unlike JSON form requests used in other views/components, it cannot contain null, true or false values, only strings. The current implementation results in the value 'null' being sent as a string. However, by sending an empty string, Laravel will convert this to null internally - solving the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where global streaming join parameters could not be left empty in the admin settings. Now, empty values are handled correctly.

- **Documentation**
  - Updated the changelog to document the fix for empty global streaming join parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->