### PR TITLE
Show messages created by BBB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Show meeting ended reason ([#2223])
+- Show BBB join errors ([#2223])
+
 ## [v4.6.1] - 2025-06-16
 
 ### Fixed
@@ -496,6 +501,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2150]: https://github.com/THM-Health/PILOS/pull/2150
 [#2151]: https://github.com/THM-Health/PILOS/pull/2151
 [#2222]: https://github.com/THM-Health/PILOS/pull/2222
+[#2223]: https://github.com/THM-Health/PILOS/pull/2223
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.6.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -5,7 +5,7 @@ return [
     'auth_throttled' => 'Too many attempts. Please try again in :try_again seconds.',
     'bbb_error_message' => [
         'maxParticipantsReached' => 'Failed to join meeting: The number of participants allowed for this meeting has been reached.',
-        'guestDeniedAccess' => 'Failed to join meeting: You have been denied access to this meeting based on the meeting\'s guest policy',
+        'guestDeniedAccess' => 'Failed to join meeting: You have been denied access to this meeting based on the meeting\'s guest policy.',
         'meetingForciblyEnded' => 'Failed to join meeting: The meeting is no longer running.',
     ],
     'become_member' => 'Become member',

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -3,6 +3,11 @@
 return [
     'access_code' => 'Access code',
     'auth_throttled' => 'Too many attempts. Please try again in :try_again seconds.',
+    'bbb_error_message' => [
+        'maxParticipantsReached' => 'Failed to join meeting: The number of participants allowed for this meeting has been reached.',
+        'guestDeniedAccess' => 'Failed to join meeting: You have been denied access to this meeting based on the meeting\'s guest policy',
+        'meetingForciblyEnded' => 'Failed to join meeting: The meeting is no longer running.',
+    ],
     'become_member' => 'Become member',
     'change_type' => [
         'changing_settings' => 'The following changes will be made to the room settings',

--- a/resources/js/components/RoomBBBMessage.vue
+++ b/resources/js/components/RoomBBBMessage.vue
@@ -14,10 +14,15 @@ const closeReasonMessage = () => {
 // Parse the errors from the URL query parameter
 const errorMessages = ref(null);
 try {
-  // Remove all errors that are unknown to the localization system
-  errorMessages.value = JSON.parse(urlSearchParams.errors).filter((error) => {
-    return te("rooms.bbb_error_message." + error.key);
-  });
+  if (urlSearchParams.errors) {
+    const parsed = JSON.parse(urlSearchParams.errors);
+    if (Array.isArray(parsed)) {
+      // Remove all errors that are unknown to the localization system
+      errorMessages.value = parsed
+        .filter((e) => typeof e === "object" && e && "key" in e)
+        .filter((e) => te("rooms.bbb_error_message." + e.key));
+    }
+  }
 } catch (e) {
   console.error(e);
 }
@@ -45,6 +50,7 @@ watch(errorMessages, (errors) => {
   <!-- Show reason meeting was ended -->
   <Message
     v-if="urlSearchParams.reason"
+    data-test="room-meeting-ended-reason"
     class="mb-3"
     closable
     @close="closeReasonMessage"
@@ -56,6 +62,7 @@ watch(errorMessages, (errors) => {
     <Message
       v-for="error in errorMessages"
       :key="error.key"
+      data-test="room-meeting-bbb-error"
       closable
       severity="error"
       @close="() => closeErrorMessage(error)"

--- a/resources/js/components/RoomBBBMessage.vue
+++ b/resources/js/components/RoomBBBMessage.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { useUrlSearchParams } from "@vueuse/core";
+import { ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+const { te } = useI18n();
+
+const urlSearchParams = useUrlSearchParams("history");
+
+// Handle closing the reason message
+const closeReasonMessage = () => {
+  urlSearchParams.reason = null;
+};
+
+// Parse the errors from the URL query parameter
+const errorMessages = ref(null);
+try {
+  // Remove all errors that are unknown to the localization system
+  errorMessages.value = JSON.parse(urlSearchParams.errors).filter((error) => {
+    return te("rooms.bbb_error_message." + error.key);
+  });
+} catch (e) {
+  console.error(e);
+}
+
+// Handle closing of an error message
+const closeErrorMessage = (errorToRemove) => {
+  // Remove the error from the list of error messages
+  errorMessages.value = errorMessages.value.filter(
+    (error) => error.key !== errorToRemove.key,
+  );
+
+  if (errorMessages.value.length === 0) {
+    errorMessages.value = null;
+  }
+};
+
+// Update the URL search parameters when the error messages change
+// to prevent the error messages from being lost on page reload
+watch(errorMessages, (errors) => {
+  urlSearchParams.errors = errors ? JSON.stringify(errors) : null;
+});
+</script>
+
+<template>
+  <!-- Show reason meeting was ended -->
+  <Message
+    v-if="urlSearchParams.reason"
+    class="mb-3"
+    closable
+    @close="closeReasonMessage"
+    >{{ urlSearchParams.reason }}</Message
+  >
+
+  <!-- Show error messages -->
+  <div v-if="errorMessages" class="mb-3 flex flex-col gap-3">
+    <Message
+      v-for="error in errorMessages"
+      :key="error.key"
+      closable
+      severity="error"
+      @close="() => closeErrorMessage(error)"
+    >
+      {{ $t("rooms.bbb_error_message." + error.key) }}
+    </Message>
+  </div>
+</template>

--- a/resources/js/components/RoomBBBMessage.vue
+++ b/resources/js/components/RoomBBBMessage.vue
@@ -1,21 +1,35 @@
 <script setup>
-import { useUrlSearchParams } from "@vueuse/core";
 import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
 const { te } = useI18n();
+const router = useRouter();
+const route = useRoute();
 
-const urlSearchParams = useUrlSearchParams("history");
+const props = defineProps({
+  reason: {
+    type: String,
+    default: null,
+  },
+  errors: {
+    type: String,
+    default: null,
+  },
+});
 
 // Handle closing the reason message
 const closeReasonMessage = () => {
-  urlSearchParams.reason = null;
+  // Remove the reason in the URL query parameter
+  router.replace({
+    query: { ...route.query, reason: undefined },
+  });
 };
 
 // Parse the errors from the URL query parameter
 const errorMessages = ref(null);
 try {
-  if (urlSearchParams.errors) {
-    const parsed = JSON.parse(urlSearchParams.errors);
+  if (props.errors) {
+    const parsed = JSON.parse(props.errors);
     if (Array.isArray(parsed)) {
       // Remove all errors that are unknown to the localization system
       errorMessages.value = parsed
@@ -23,8 +37,8 @@ try {
         .filter((e) => te("rooms.bbb_error_message." + e.key));
     }
   }
-} catch (e) {
-  console.error(e);
+} catch {
+  // Ignore parsing errors
 }
 
 // Handle closing of an error message
@@ -39,22 +53,27 @@ const closeErrorMessage = (errorToRemove) => {
   }
 };
 
-// Update the URL search parameters when the error messages change
+// Update the query parameters when the error messages change
 // to prevent the error messages from being lost on page reload
 watch(errorMessages, (errors) => {
-  urlSearchParams.errors = errors ? JSON.stringify(errors) : null;
+  router.replace({
+    query: {
+      ...route.query,
+      errors: errors ? JSON.stringify(errors) : undefined,
+    },
+  });
 });
 </script>
 
 <template>
   <!-- Show reason meeting was ended -->
   <Message
-    v-if="urlSearchParams.reason"
+    v-if="reason"
     data-test="room-meeting-ended-reason"
     class="mb-3"
     closable
     @close="closeReasonMessage"
-    >{{ urlSearchParams.reason }}</Message
+    >{{ reason }}</Message
   >
 
   <!-- Show error messages -->

--- a/resources/js/components/RoomHeader.vue
+++ b/resources/js/components/RoomHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col gap-6">
-    <RoomBBBMessage />
+    <RoomBBBMessage :reason="bbbReason" :errors="bbbErrors" />
 
     <div class="flex flex-col-reverse gap-2 md:flex-row">
       <div class="grow">
@@ -100,6 +100,14 @@ const props = defineProps({
   disableReload: {
     type: Boolean,
     default: false,
+  },
+  bbbReason: {
+    type: String,
+    default: null,
+  },
+  bbbErrors: {
+    type: String,
+    default: null,
   },
 });
 

--- a/resources/js/components/RoomHeader.vue
+++ b/resources/js/components/RoomHeader.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="flex flex-col gap-6">
+    <RoomBBBMessage />
+
     <div class="flex flex-col-reverse gap-2 md:flex-row">
       <div class="grow">
         <!-- Display room type, name and owner  -->

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -143,6 +143,8 @@ export const routes = [
       return {
         id: route.params.id,
         token: route.params.token,
+        bbbReason: route.query.reason,
+        bbbErrors: route.query.errors,
       };
     },
   },

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -38,6 +38,8 @@
           </Badge>
         </template>
         <template #content>
+          <RoomBBBMessage />
+
           <span class="font-bold">
             {{ $t("rooms.only_used_by_authenticated_users") }}
           </span>

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -38,7 +38,7 @@
           </Badge>
         </template>
         <template #content>
-          <RoomBBBMessage />
+          <RoomBBBMessage :reason="bbbReason" :errors="bbbErrors" />
 
           <span class="font-bold">
             {{ $t("rooms.only_used_by_authenticated_users") }}
@@ -100,6 +100,8 @@
                 :hide-favorites="true"
                 :hide-membership="true"
                 :disable-reload="authThrottledFor > 0"
+                :bbb-errors="bbbErrors"
+                :bbb-reason="bbbReason"
                 @reload="reload"
               />
               <Divider />
@@ -164,6 +166,8 @@
                 :loading="loading"
                 :access-code="accessCode"
                 :details-inline="true"
+                :bbb-errors="bbbErrors"
+                :bbb-reason="bbbReason"
                 @reload="reload"
                 @invalid-code="handleInvalidCode"
                 @joined-membership="
@@ -249,6 +253,14 @@ const props = defineProps({
     required: true,
   },
   token: {
+    type: String,
+    default: null,
+  },
+  bbbReason: {
+    type: String,
+    default: null,
+  },
+  bbbErrors: {
     type: String,
     default: null,
   },

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -1932,10 +1932,7 @@ describe("Room View general", function () {
       .should("contain.text", "Maximum participants reached");
 
     // Check url is updated (closed and invalid error removed)
-    errors = encodeURIComponent(
-      JSON.stringify([{ key: "maxParticipantsReached" }]),
-    );
-    cy.url().should("include", `errors=${errors}`);
+    cy.url().should("include", "[{%22key%22:%22maxParticipantsReached%22}]");
 
     // Close last error message
     cy.get('[data-test="room-meeting-bbb-error"]').eq(0).find("button").click();

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -1847,4 +1847,103 @@ describe("Room View general", function () {
     cy.get("#tab-history").should("be.visible");
     cy.get("#tab-settings").should("be.visible");
   });
+
+  it("displays meeting ended reason", function () {
+    cy.fixture("room.json").then((room) => {
+      room.data.allow_membership = true;
+      room.data.current_user = null;
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+    });
+
+    cy.visit("/rooms/abc-def-123?reason=Meeting+ended+by+John+Doe");
+    cy.wait("@roomRequest");
+
+    // Reason message should be shown
+    cy.get('[data-test="room-meeting-ended-reason"]')
+      .should("be.visible")
+      .should("have.text", "Meeting ended by John Doe");
+
+    // Close reason message
+    cy.get('[data-test="room-meeting-ended-reason"] button').click();
+
+    // Check that reason message is removed
+    cy.get('[data-test="room-meeting-ended-reason"]').should("not.exist");
+
+    // Check reason message is removed from URL
+    cy.url().should("not.include", "reason");
+  });
+
+  it("displays bbb error messages", function () {
+    cy.fixture("room.json").then((room) => {
+      room.data.allow_membership = true;
+      room.data.current_user = null;
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+    });
+
+    cy.fixture("en.json").then((locale) => {
+      locale.data = {
+        rooms: {
+          bbb_error_message: {
+            guestDeniedAccess: "Guest access denied",
+            maxParticipantsReached: "Maximum participants reached",
+          },
+        },
+      };
+      cy.intercept("GET", "api/v1/locale/en", {
+        statusCode: 200,
+        body: locale,
+      });
+    });
+
+    // Simulate BBB errors
+    let errors = encodeURIComponent(
+      JSON.stringify([
+        { key: "guestDeniedAccess" },
+        { key: "maxParticipantsReached" },
+        { key: "unknown_error" },
+      ]),
+    );
+    cy.visit(`/rooms/abc-def-123?errors=${errors}`);
+    cy.wait("@roomRequest");
+
+    // Check only two error messages are shown
+    cy.get('[data-test="room-meeting-bbb-error"]').should("have.length", 2);
+
+    cy.get('[data-test="room-meeting-bbb-error"]')
+      .eq(0)
+      .should("contain.text", "Guest access denied");
+    cy.get('[data-test="room-meeting-bbb-error"]')
+      .eq(1)
+      .should("contain.text", "Maximum participants reached");
+
+    // Close first error message
+    cy.get('[data-test="room-meeting-bbb-error"]').eq(0).find("button").click();
+
+    // Check only one error message is shown
+    cy.get('[data-test="room-meeting-bbb-error"]').should("have.length", 1);
+    cy.get('[data-test="room-meeting-bbb-error"]')
+      .eq(0)
+      .should("contain.text", "Maximum participants reached");
+
+    // Check url is updated (closed and invalid error removed)
+    errors = encodeURIComponent(
+      JSON.stringify([{ key: "maxParticipantsReached" }]),
+    );
+    cy.url().should("include", `errors=${errors}`);
+
+    // Close last error message
+    cy.get('[data-test="room-meeting-bbb-error"]').eq(0).find("button").click();
+
+    // Check no error messages are shown
+    cy.get('[data-test="room-meeting-bbb-error"]').should("not.exist");
+
+    // Check url is updated (no errors)
+    cy.url().should("not.include", "errors");
+  });
 });


### PR DESCRIPTION
## Type

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Added showing BBB error messages
- Added showing BBB meeting ended messages

## Other information
- BBB 3.0 appends the meeting ended reason to the logout url (PILOS room page)
- If joining a room fails, the user is also redirected to the PILOS rooms page, with an error message in the url

<img width="1559" alt="image" src="https://github.com/user-attachments/assets/cb26b516-95c8-4cfe-afe4-9b7d301a9c07" />

<img width="1546" alt="image" src="https://github.com/user-attachments/assets/89b35098-a60b-460e-806e-f7b9cca9f3ab" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added user-facing messages displaying the reason for meeting endings and specific BigBlueButton (BBB) join errors.
  - Error and end reason messages can be closed by users, with state synchronized in the URL.

- **Documentation**
  - Updated changelog to reflect new features and relevant pull request references.

- **Tests**
  - Added end-to-end tests verifying display and dismissal of meeting end reasons and BBB error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->