### PR TITLE
Fix: Infinite loading when navigating back after logout redirect due to bfcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logout session_expired warning message style ([68abce8](https://github.com/THM-Health/PILOS/commit/68abce87bcd241db3261a448cf53e430bd639e28))
 - Show unavailable room types in create room dialog ([#2265], [#2279])
 - Show unavailable room types in change room type dialog ([#2265], [#2279])
+- Infinite loading when navigating back after logout redirect due to bfcache ([#2282])
 
 ## [v4.6.1] - 2025-06-16
 
@@ -514,6 +515,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2223]: https://github.com/THM-Health/PILOS/pull/2223
 [#2265]: https://github.com/THM-Health/PILOS/issues/2265
 [#2279]: https://github.com/THM-Health/PILOS/pull/2279
+[#2282]: https://github.com/THM-Health/PILOS/pull/2282
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.6.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/components/MainNav.vue
+++ b/resources/js/components/MainNav.vue
@@ -329,6 +329,19 @@ const loginRoute = computed(() => {
   return loginRoute;
 });
 
+/**
+ * Handle the page is restored from the back/forward cache after logout.
+ * The loading spinner is still visible, so we need to remove it
+ * and redirect the user to the logout page.
+ */
+async function pageShownAfterLogoutHandler(event) {
+  window.removeEventListener("pageshow", pageShownAfterLogoutHandler);
+  if (event.persisted) {
+    await router.push({ name: "logout" });
+    loadingStore.setLoadingFinished();
+  }
+}
+
 async function logout() {
   let response;
   try {
@@ -342,6 +355,9 @@ async function logout() {
   }
 
   if (response.data.redirect) {
+    // Add listener for when user returns to this page
+    // without a full page reload, state is restored from back/forward cache
+    window.addEventListener("pageshow", pageShownAfterLogoutHandler);
     window.location = response.data.redirect;
     return;
   }


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixed infinite loading when navigating back after logout redirect due to bfcache

## Other information
Safari and Chrome are creating a bfcache , ignoring the no-cache header.
Firefox currently respects the no-cache header and does not create a bfcache.

Without this PR the JS and DOM state is restored after navigating back from a logout redirect. During logout the page is covered with a loading spinner. If the user returns to this state, the loading never finishes. This PR adds a new listener to handle the restoration from the bfcache, redirects the user to the logout page and closes the loading spinner overlay.

I'm unable to write a cypress test that triggers the bfcache, therefore this code cannot be tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where navigating back after logout could result in an infinite loading state due to browser cache restoration. Users are now properly redirected and the loading spinner is cleared in this scenario.

* **Documentation**
  * Updated the changelog to reflect the fix for the infinite loading issue after logout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->