### PR TITLE
Replace example.org redirect urls

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,6 +10,10 @@ export default defineConfig({
   screenshotsFolder: "tests/Frontend/screenshots",
   videosFolder: "tests/Frontend/videos",
 
+  env: {
+    redirectBaseUrl: "https://thm-health.github.io/PILOS-Redirect_Test_Pages",
+  },
+
   e2e: {
     setupNodeEvents(on, config) {
       configCodeCoverage(on, config);

--- a/tests/Frontend/e2e/Banner.cy.js
+++ b/tests/Frontend/e2e/Banner.cy.js
@@ -9,8 +9,7 @@ describe("Banner", function () {
       config.data.banner.title = "Banner title";
       config.data.banner.icon = "fa-solid fa-door-open";
       config.data.banner.message = "Banner text message";
-      config.data.banner.link =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b";
+      config.data.banner.link = `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`;
       config.data.banner.link_text = "Example link";
       config.data.banner.link_style = "link";
       config.data.banner.link_target = "blank";
@@ -43,7 +42,7 @@ describe("Banner", function () {
         .and(
           "have.attr",
           "href",
-          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
         )
         .and("have.attr", "target", "_blank")
         .and("have.text", "Example link");

--- a/tests/Frontend/e2e/Banner.cy.js
+++ b/tests/Frontend/e2e/Banner.cy.js
@@ -9,7 +9,8 @@ describe("Banner", function () {
       config.data.banner.title = "Banner title";
       config.data.banner.icon = "fa-solid fa-door-open";
       config.data.banner.message = "Banner text message";
-      config.data.banner.link = "https://example.org/?foo=a&bar=b";
+      config.data.banner.link =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b";
       config.data.banner.link_text = "Example link";
       config.data.banner.link_style = "link";
       config.data.banner.link_target = "blank";
@@ -39,7 +40,11 @@ describe("Banner", function () {
         .and("have.text", "Banner text message");
       cy.get('[data-test="banner-link-button"]')
         .should("be.visible")
-        .and("have.attr", "href", "https://example.org/?foo=a&bar=b")
+        .and(
+          "have.attr",
+          "href",
+          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+        )
         .and("have.attr", "target", "_blank")
         .and("have.text", "Example link");
       cy.get('[data-test="banner-link-button"]')

--- a/tests/Frontend/e2e/Footer.cy.js
+++ b/tests/Frontend/e2e/Footer.cy.js
@@ -5,10 +5,8 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, version and no whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal`;
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy`;
       config.data.general.version = "1.0.0";
       config.data.general.whitelabel = false;
 
@@ -26,11 +24,7 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
-          );
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}/legal`);
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
@@ -38,7 +32,7 @@ describe("Footer", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+            `${Cypress.env("redirectBaseUrl")}/privacy`,
           );
 
         cy.get('[data-test="github-button"]')
@@ -53,8 +47,7 @@ describe("Footer", function () {
 
   it("check footer shown correctly with only legal notice link, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal`;
       config.data.general.privacy_policy_url = "";
       config.data.general.version = null;
       config.data.general.whitelabel = true;
@@ -73,11 +66,7 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
-          );
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}/legal`);
 
         cy.get('[data-test="privacy-policy-button"]').should("not.exist");
 
@@ -89,8 +78,7 @@ describe("Footer", function () {
   it("check footer shown correctly with only privacy policy link, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
       config.data.general.legal_notice_url = "";
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy`;
       config.data.general.version = null;
       config.data.general.whitelabel = true;
 
@@ -112,7 +100,7 @@ describe("Footer", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+            `${Cypress.env("redirectBaseUrl")}/privacy`,
           );
 
         cy.get('[data-test="github-button"]').should("not.exist");
@@ -179,10 +167,8 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal`;
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy`;
       config.data.general.version = "1.0.0";
       config.data.general.whitelabel = true;
 
@@ -199,11 +185,7 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
-          );
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}/legal`);
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
@@ -211,7 +193,7 @@ describe("Footer", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+            `${Cypress.env("redirectBaseUrl")}/privacy`,
           );
 
         cy.get('[data-test="github-button"]').should("not.exist");
@@ -223,10 +205,8 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal`;
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy`;
       config.data.general.version = "";
       config.data.general.whitelabel = true;
 
@@ -242,11 +222,7 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
-          );
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}/legal`);
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
@@ -254,7 +230,7 @@ describe("Footer", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+            `${Cypress.env("redirectBaseUrl")}/privacy`,
           );
 
         cy.get('[data-test="github-button"]').should("not.exist");
@@ -281,8 +257,7 @@ describe("Footer", function () {
 
   it("check footer shown correctly with only legal notice link, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal`;
       config.data.general.privacy_policy_url = "";
       config.data.general.version = "1.2.0";
       config.data.general.whitelabel = true;
@@ -301,11 +276,7 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
-          );
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}/legal`);
 
         cy.get('[data-test="privacy-policy-button"]').should("not.exist");
 
@@ -319,8 +290,7 @@ describe("Footer", function () {
   it("check footer shown correctly with only privacy policy link, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
       config.data.general.legal_notice_url = "";
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy`;
       config.data.general.version = "2.1.0";
       config.data.general.whitelabel = true;
 
@@ -342,7 +312,7 @@ describe("Footer", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+            `${Cypress.env("redirectBaseUrl")}/privacy`,
           );
 
         cy.get('[data-test="github-button"]').should("not.exist");
@@ -354,8 +324,7 @@ describe("Footer", function () {
 
   it("open legal notice link", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal?foo=a&bar=b";
+      config.data.general.legal_notice_url = `${Cypress.env("redirectBaseUrl")}/legal?foo=a&bar=b`;
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -365,18 +334,17 @@ describe("Footer", function () {
 
     cy.get('[data-test="legal-notice-button"]').click();
 
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/legal?foo=a&bar=b`,
       );
     });
   });
 
   it("open privacy policy link", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.privacy_policy_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy?foo=a&bar=b";
+      config.data.general.privacy_policy_url = `${Cypress.env("redirectBaseUrl")}/privacy?foo=a&bar=b`;
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -386,10 +354,10 @@ describe("Footer", function () {
 
     cy.get('[data-test="privacy-policy-button"]').click();
 
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/privacy?foo=a&bar=b`,
       );
     });
   });

--- a/tests/Frontend/e2e/Footer.cy.js
+++ b/tests/Frontend/e2e/Footer.cy.js
@@ -5,8 +5,10 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, version and no whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/legal";
-      config.data.general.privacy_policy_url = "https://example.org/privacy";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
+      config.data.general.privacy_policy_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
       config.data.general.version = "1.0.0";
       config.data.general.whitelabel = false;
 
@@ -24,12 +26,20 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and("have.attr", "href", "https://example.org/legal");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
+          );
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.privacy_policy")
-          .and("have.attr", "href", "https://example.org/privacy");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+          );
 
         cy.get('[data-test="github-button"]')
           .should("be.visible")
@@ -43,7 +53,8 @@ describe("Footer", function () {
 
   it("check footer shown correctly with only legal notice link, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/legal";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
       config.data.general.privacy_policy_url = "";
       config.data.general.version = null;
       config.data.general.whitelabel = true;
@@ -62,7 +73,11 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and("have.attr", "href", "https://example.org/legal");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
+          );
 
         cy.get('[data-test="privacy-policy-button"]').should("not.exist");
 
@@ -74,7 +89,8 @@ describe("Footer", function () {
   it("check footer shown correctly with only privacy policy link, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
       config.data.general.legal_notice_url = "";
-      config.data.general.privacy_policy_url = "https://example.org/privacy";
+      config.data.general.privacy_policy_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
       config.data.general.version = null;
       config.data.general.whitelabel = true;
 
@@ -93,7 +109,11 @@ describe("Footer", function () {
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.privacy_policy")
-          .and("have.attr", "href", "https://example.org/privacy");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+          );
 
         cy.get('[data-test="github-button"]').should("not.exist");
         cy.get('[data-test="version"]').should("not.exist");
@@ -159,8 +179,10 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/legal";
-      config.data.general.privacy_policy_url = "https://example.org/privacy";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
+      config.data.general.privacy_policy_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
       config.data.general.version = "1.0.0";
       config.data.general.whitelabel = true;
 
@@ -177,12 +199,20 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and("have.attr", "href", "https://example.org/legal");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
+          );
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.privacy_policy")
-          .and("have.attr", "href", "https://example.org/privacy");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+          );
 
         cy.get('[data-test="github-button"]').should("not.exist");
         cy.get('[data-test="version"]')
@@ -193,8 +223,10 @@ describe("Footer", function () {
 
   it("check footer shown correctly with 2 links, no version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/legal";
-      config.data.general.privacy_policy_url = "https://example.org/privacy";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
+      config.data.general.privacy_policy_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
       config.data.general.version = "";
       config.data.general.whitelabel = true;
 
@@ -210,12 +242,20 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and("have.attr", "href", "https://example.org/legal");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
+          );
 
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.privacy_policy")
-          .and("have.attr", "href", "https://example.org/privacy");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+          );
 
         cy.get('[data-test="github-button"]').should("not.exist");
         cy.get('[data-test="version"]').should("not.exist");
@@ -241,7 +281,8 @@ describe("Footer", function () {
 
   it("check footer shown correctly with only legal notice link, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/legal";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal";
       config.data.general.privacy_policy_url = "";
       config.data.general.version = "1.2.0";
       config.data.general.whitelabel = true;
@@ -260,7 +301,11 @@ describe("Footer", function () {
         cy.get('[data-test="legal-notice-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.legal_notice")
-          .and("have.attr", "href", "https://example.org/legal");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal",
+          );
 
         cy.get('[data-test="privacy-policy-button"]').should("not.exist");
 
@@ -274,7 +319,8 @@ describe("Footer", function () {
   it("check footer shown correctly with only privacy policy link, version and whitelabel", function () {
     cy.fixture("config.json").then((config) => {
       config.data.general.legal_notice_url = "";
-      config.data.general.privacy_policy_url = "https://example.org/privacy";
+      config.data.general.privacy_policy_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy";
       config.data.general.version = "2.1.0";
       config.data.general.whitelabel = true;
 
@@ -293,7 +339,11 @@ describe("Footer", function () {
         cy.get('[data-test="privacy-policy-button"]')
           .should("be.visible")
           .and("have.text", "app.footer.privacy_policy")
-          .and("have.attr", "href", "https://example.org/privacy");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy",
+          );
 
         cy.get('[data-test="github-button"]').should("not.exist");
         cy.get('[data-test="version"]')
@@ -304,7 +354,8 @@ describe("Footer", function () {
 
   it("open legal notice link", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.legal_notice_url = "https://example.org/?foo=a&bar=b";
+      config.data.general.legal_notice_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal?foo=a&bar=b";
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -314,15 +365,18 @@ describe("Footer", function () {
 
     cy.get('[data-test="legal-notice-button"]').click();
 
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/legal?foo=a&bar=b",
+      );
     });
   });
 
   it("open privacy policy link", function () {
     cy.fixture("config.json").then((config) => {
       config.data.general.privacy_policy_url =
-        "https://example.org/?foo=a&bar=b";
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy?foo=a&bar=b";
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -332,8 +386,11 @@ describe("Footer", function () {
 
     cy.get('[data-test="privacy-policy-button"]').click();
 
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/privacy?foo=a&bar=b",
+      );
     });
   });
 });

--- a/tests/Frontend/e2e/GeneralApplication.cy.js
+++ b/tests/Frontend/e2e/GeneralApplication.cy.js
@@ -203,7 +203,8 @@ describe("General", function () {
 
   it("check help button if help url specified", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.help_url = "https://example.org/?foo=a&bar=b";
+      config.data.general.help_url =
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b";
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -211,15 +212,22 @@ describe("General", function () {
 
     cy.get('[data-test="navbar-help"]')
       .should("be.visible")
-      .should("have.attr", "href", "https://example.org/?foo=a&bar=b")
+      .should(
+        "have.attr",
+        "href",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b",
+      )
       .and("have.attr", "target", "_blank")
       .invoke("removeAttr", "target");
 
     cy.get('[data-test="navbar-help"]').click();
 
     // Check that redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b",
+      );
     });
   });
 

--- a/tests/Frontend/e2e/GeneralApplication.cy.js
+++ b/tests/Frontend/e2e/GeneralApplication.cy.js
@@ -203,8 +203,7 @@ describe("General", function () {
 
   it("check help button if help url specified", function () {
     cy.fixture("config.json").then((config) => {
-      config.data.general.help_url =
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b";
+      config.data.general.help_url = `${Cypress.env("redirectBaseUrl")}/help?foo=a&bar=b`;
 
       cy.intercept("GET", "/api/v1/config", config).as("configRequest");
     });
@@ -215,7 +214,7 @@ describe("General", function () {
       .should(
         "have.attr",
         "href",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/help?foo=a&bar=b`,
       )
       .and("have.attr", "target", "_blank")
       .invoke("removeAttr", "target");
@@ -223,10 +222,10 @@ describe("General", function () {
     cy.get('[data-test="navbar-help"]').click();
 
     // Check that redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/help?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/help?foo=a&bar=b`,
       );
     });
   });

--- a/tests/Frontend/e2e/Logout.cy.js
+++ b/tests/Frontend/e2e/Logout.cy.js
@@ -39,7 +39,8 @@ describe("Logout", function () {
     cy.intercept("POST", "api/v1/logout", {
       statusCode: 200,
       body: {
-        redirect: "https://example.org/?foo=a&bar=b",
+        redirect:
+          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/idp?foo=a&bar=b",
       },
     }).as("logoutRequest");
     cy.visit("/rooms");
@@ -55,8 +56,11 @@ describe("Logout", function () {
       });
     cy.wait("@logoutRequest");
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/idp?foo=a&bar=b",
+      );
     });
   });
 

--- a/tests/Frontend/e2e/Logout.cy.js
+++ b/tests/Frontend/e2e/Logout.cy.js
@@ -39,8 +39,7 @@ describe("Logout", function () {
     cy.intercept("POST", "api/v1/logout", {
       statusCode: 200,
       body: {
-        redirect:
-          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/idp?foo=a&bar=b",
+        redirect: `${Cypress.env("redirectBaseUrl")}/idp?foo=a&bar=b`,
       },
     }).as("logoutRequest");
     cy.visit("/rooms");
@@ -56,10 +55,10 @@ describe("Logout", function () {
       });
     cy.wait("@logoutRequest");
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/idp?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/idp?foo=a&bar=b`,
       );
     });
   });

--- a/tests/Frontend/e2e/RoomsViewDescription.cy.js
+++ b/tests/Frontend/e2e/RoomsViewDescription.cy.js
@@ -547,8 +547,7 @@ describe("Rooms view description", function () {
 
   it("open external link", function () {
     cy.fixture("room.json").then((room) => {
-      room.data.description =
-        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
+      room.data.description = `<a href="${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b">Test Link</a>`;
 
       cy.intercept("GET", "api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -574,7 +573,7 @@ describe("Rooms view description", function () {
       .should("include.text", "rooms.description.external_link_warning.title")
       .should(
         "include.text",
-        'rooms.description.external_link_warning.description_{"link":"https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b"}',
+        `rooms.description.external_link_warning.description_{"link":"${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b"}`,
       )
       .within(() => {
         // Cancel opening link
@@ -603,7 +602,7 @@ describe("Rooms view description", function () {
       .should("include.text", "rooms.description.external_link_warning.title")
       .should(
         "include.text",
-        'rooms.description.external_link_warning.description_{"link":"https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b"}',
+        `rooms.description.external_link_warning.description_{"link":"${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b"}`,
       )
       .within(() => {
         cy.get('[data-test="confirm-dialog-accept-button"]')
@@ -615,7 +614,7 @@ describe("Rooms view description", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
         "_blank",
       );
   });
@@ -625,7 +624,7 @@ describe("Rooms view description", function () {
       room.data.description =
         "" +
         '<script>alert("XSS Code")</script>' +
-        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>' +
+        `<a href="${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b">Test Link</a>` +
         '<p style="text-align: center; color: rgb(255, 0, 0); background-color: rgb(0, 255, 0);" >Content with valid style</p>' +
         '<p style="text-align: justify; color: rgba(255, 0, 0, 0); background-color: rgba(0, 255, 0, 0);">Content with invalid style values</p>' +
         '<p style="text-align: center; color: rgb(0, 0, 255); background-color: rgb(255, 255, 0); position: absolute" >Content with invalid style attributes</p>' +
@@ -687,7 +686,7 @@ describe("Rooms view description", function () {
           .should(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+            `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
           );
       });
   });

--- a/tests/Frontend/e2e/RoomsViewDescription.cy.js
+++ b/tests/Frontend/e2e/RoomsViewDescription.cy.js
@@ -548,7 +548,7 @@ describe("Rooms view description", function () {
   it("open external link", function () {
     cy.fixture("room.json").then((room) => {
       room.data.description =
-        '<a href="https://example.org/?foo=a&bar=b">Test Link</a>';
+        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
 
       cy.intercept("GET", "api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -574,7 +574,7 @@ describe("Rooms view description", function () {
       .should("include.text", "rooms.description.external_link_warning.title")
       .should(
         "include.text",
-        'rooms.description.external_link_warning.description_{"link":"https://example.org/?foo=a&bar=b"}',
+        'rooms.description.external_link_warning.description_{"link":"https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b"}',
       )
       .within(() => {
         // Cancel opening link
@@ -603,7 +603,7 @@ describe("Rooms view description", function () {
       .should("include.text", "rooms.description.external_link_warning.title")
       .should(
         "include.text",
-        'rooms.description.external_link_warning.description_{"link":"https://example.org/?foo=a&bar=b"}',
+        'rooms.description.external_link_warning.description_{"link":"https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b"}',
       )
       .within(() => {
         cy.get('[data-test="confirm-dialog-accept-button"]')
@@ -613,7 +613,11 @@ describe("Rooms view description", function () {
 
     cy.get("@openExternalLink")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+        "_blank",
+      );
   });
 
   it("sanitize html", function () {
@@ -621,7 +625,7 @@ describe("Rooms view description", function () {
       room.data.description =
         "" +
         '<script>alert("XSS Code")</script>' +
-        '<a href="https://example.org/?foo=a&bar=b">Test Link</a>' +
+        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>' +
         '<p style="text-align: center; color: rgb(255, 0, 0); background-color: rgb(0, 255, 0);" >Content with valid style</p>' +
         '<p style="text-align: justify; color: rgba(255, 0, 0, 0); background-color: rgba(0, 255, 0, 0);">Content with invalid style values</p>' +
         '<p style="text-align: center; color: rgb(0, 0, 255); background-color: rgb(255, 255, 0); position: absolute" >Content with invalid style attributes</p>' +
@@ -680,7 +684,11 @@ describe("Rooms view description", function () {
         cy.get("a")
           .contains("Test Link")
           .should("be.visible")
-          .should("have.attr", "href", "https://example.org/?foo=a&bar=b");
+          .should(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          );
       });
   });
 });

--- a/tests/Frontend/e2e/RoomsViewDescriptionTipTapEditor.cy.js
+++ b/tests/Frontend/e2e/RoomsViewDescriptionTipTapEditor.cy.js
@@ -312,7 +312,9 @@ describe("Rooms view description TipTap Editor", function () {
 
         // Change url to valid value
         cy.get("#url").clear();
-        cy.get("#url").type("https://example.org/?foo=a&bar=b");
+        cy.get("#url").type(
+          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+        );
 
         // Check that error message is hidden and save button is enabled
         cy.contains("rooms.description.modals.link.invalid_url").should(
@@ -333,7 +335,11 @@ describe("Rooms view description TipTap Editor", function () {
       .within(() => {
         cy.get("a")
           .should("be.visible")
-          .and("have.attr", "href", "https://example.org/?foo=a&bar=b")
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          )
           .and("have.text", "Room description");
       });
 
@@ -347,7 +353,7 @@ describe("Rooms view description TipTap Editor", function () {
   it("edit link", function () {
     cy.fixture("room.json").then((room) => {
       room.data.description =
-        '<a href="https://example.org/?foo=a&bar=b">Test Link</a>';
+        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
 
       cy.intercept("GET", "/api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -369,7 +375,11 @@ describe("Rooms view description TipTap Editor", function () {
       .within(() => {
         cy.get("a")
           .should("be.visible")
-          .and("have.attr", "href", "https://example.org/?foo=a&bar=b")
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          )
           .and("have.text", "Test Link");
       });
 
@@ -392,7 +402,10 @@ describe("Rooms view description TipTap Editor", function () {
       .within(() => {
         // Change to invalid url
         cy.get("#url")
-          .should("have.value", "https://example.org/?foo=a&bar=b")
+          .should(
+            "have.value",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          )
           .clear();
         cy.get("#url").type("invalid");
 
@@ -404,7 +417,9 @@ describe("Rooms view description TipTap Editor", function () {
 
         // Change url back to valid value
         cy.get("#url").clear();
-        cy.get("#url").type("https://example.org/");
+        cy.get("#url").type(
+          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/",
+        );
 
         // Check that error message is hidden and save button is enabled
         cy.contains("rooms.description.modals.link.invalid_url").should(
@@ -431,7 +446,11 @@ describe("Rooms view description TipTap Editor", function () {
       .within(() => {
         cy.get("a")
           .should("be.visible")
-          .and("have.attr", "href", "https://example.org/")
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/",
+          )
           .and("have.text", "Test Link")
           .click();
       });
@@ -440,7 +459,7 @@ describe("Rooms view description TipTap Editor", function () {
   it("delete link", function () {
     cy.fixture("room.json").then((room) => {
       room.data.description =
-        '<a href="https://example.org/?foo=a&bar=b">Test Link</a>';
+        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
 
       cy.intercept("GET", "/api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -463,7 +482,11 @@ describe("Rooms view description TipTap Editor", function () {
         cy.get("a")
           .should("be.visible")
           .and("have.text", "Test Link")
-          .and("have.attr", "href", "https://example.org/?foo=a&bar=b");
+          .and(
+            "have.attr",
+            "href",
+            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+          );
       });
 
     selectTiptapContent();

--- a/tests/Frontend/e2e/RoomsViewDescriptionTipTapEditor.cy.js
+++ b/tests/Frontend/e2e/RoomsViewDescriptionTipTapEditor.cy.js
@@ -312,9 +312,7 @@ describe("Rooms view description TipTap Editor", function () {
 
         // Change url to valid value
         cy.get("#url").clear();
-        cy.get("#url").type(
-          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
-        );
+        cy.get("#url").type(`${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`);
 
         // Check that error message is hidden and save button is enabled
         cy.contains("rooms.description.modals.link.invalid_url").should(
@@ -338,7 +336,7 @@ describe("Rooms view description TipTap Editor", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+            `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
           )
           .and("have.text", "Room description");
       });
@@ -352,8 +350,7 @@ describe("Rooms view description TipTap Editor", function () {
 
   it("edit link", function () {
     cy.fixture("room.json").then((room) => {
-      room.data.description =
-        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
+      room.data.description = `<a href="${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b">Test Link</a>`;
 
       cy.intercept("GET", "/api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -378,7 +375,7 @@ describe("Rooms view description TipTap Editor", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+            `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
           )
           .and("have.text", "Test Link");
       });
@@ -404,7 +401,7 @@ describe("Rooms view description TipTap Editor", function () {
         cy.get("#url")
           .should(
             "have.value",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+            `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
           )
           .clear();
         cy.get("#url").type("invalid");
@@ -417,9 +414,7 @@ describe("Rooms view description TipTap Editor", function () {
 
         // Change url back to valid value
         cy.get("#url").clear();
-        cy.get("#url").type(
-          "https://thm-health.github.io/PILOS-Redirect_Test_Pages/",
-        );
+        cy.get("#url").type(`${Cypress.env("redirectBaseUrl")}`);
 
         // Check that error message is hidden and save button is enabled
         cy.contains("rooms.description.modals.link.invalid_url").should(
@@ -446,11 +441,7 @@ describe("Rooms view description TipTap Editor", function () {
       .within(() => {
         cy.get("a")
           .should("be.visible")
-          .and(
-            "have.attr",
-            "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/",
-          )
+          .and("have.attr", "href", `${Cypress.env("redirectBaseUrl")}`)
           .and("have.text", "Test Link")
           .click();
       });
@@ -458,8 +449,7 @@ describe("Rooms view description TipTap Editor", function () {
 
   it("delete link", function () {
     cy.fixture("room.json").then((room) => {
-      room.data.description =
-        '<a href="https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b">Test Link</a>';
+      room.data.description = `<a href="${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b">Test Link</a>`;
 
       cy.intercept("GET", "/api/v1/rooms/abc-def-123", {
         statusCode: 200,
@@ -485,7 +475,7 @@ describe("Rooms view description TipTap Editor", function () {
           .and(
             "have.attr",
             "href",
-            "https://thm-health.github.io/PILOS-Redirect_Test_Pages/?foo=a&bar=b",
+            `${Cypress.env("redirectBaseUrl")}/?foo=a&bar=b`,
           );
       });
 

--- a/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
@@ -734,7 +734,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
       },
     }).as("downloadFileRequest");
 
@@ -754,7 +754,7 @@ describe("Rooms view files file actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
         "_blank",
       );
 
@@ -812,7 +812,7 @@ describe("Rooms view files file actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
         "_blank",
       );
 
@@ -855,7 +855,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
       },
     }).as("downloadFileRequest");
 
@@ -877,7 +877,7 @@ describe("Rooms view files file actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
         "_blank",
       );
   });
@@ -1032,7 +1032,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
       },
     }).as("downloadFileRequest");
 
@@ -1057,7 +1057,7 @@ describe("Rooms view files file actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
         "_blank",
       );
   });
@@ -1120,7 +1120,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
       },
     }).as("downloadFileRequest");
 
@@ -1140,7 +1140,7 @@ describe("Rooms view files file actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/file?foo=a&bar=b`,
         "_blank",
       );
 

--- a/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
@@ -734,7 +734,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
       },
     }).as("downloadFileRequest");
 
@@ -752,7 +752,11 @@ describe("Rooms view files file actions", function () {
 
     cy.get("@fileDownload")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        "_blank",
+      );
 
     // Reload as guest and with terms of use
     cy.fixture("config.json").then((config) => {
@@ -806,7 +810,11 @@ describe("Rooms view files file actions", function () {
 
     cy.get("@secondFileDownload")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        "_blank",
+      );
 
     cy.get('[data-test="terms-of-use-required-info"]').should("not.exist");
   });
@@ -847,7 +855,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
       },
     }).as("downloadFileRequest");
 
@@ -867,7 +875,11 @@ describe("Rooms view files file actions", function () {
     });
     cy.get("@fileDownload")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        "_blank",
+      );
   });
 
   it("download file with access code errors", function () {
@@ -1020,7 +1032,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
       },
     }).as("downloadFileRequest");
 
@@ -1043,7 +1055,11 @@ describe("Rooms view files file actions", function () {
 
     cy.get("@fileDownload")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        "_blank",
+      );
   });
 
   it("download file with token errors", function () {
@@ -1104,7 +1120,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("GET", "/api/v1/rooms/abc-def-123/files/1", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
       },
     }).as("downloadFileRequest");
 
@@ -1122,7 +1138,11 @@ describe("Rooms view files file actions", function () {
 
     cy.get("@fileDownload")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/file?foo=a&bar=b",
+        "_blank",
+      );
 
     // Check toast message is shown (browser is blocking download)
     cy.checkToastMessage("app.flash.popup_blocked");

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -38,7 +38,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "joinRequest",
@@ -82,10 +82,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -122,7 +122,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "joinRequest",
@@ -170,10 +170,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -210,7 +210,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "joinRequest",
@@ -258,10 +258,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -298,7 +298,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "joinRequest",
@@ -349,10 +349,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -387,7 +387,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("joinRequest");
 
@@ -420,10 +420,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -478,7 +478,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+            url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
           },
         }).as("joinRequest");
 
@@ -498,10 +498,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -686,7 +686,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+            url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
           },
         }).as("joinRequest");
 
@@ -708,10 +708,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -899,7 +899,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("joinRequest");
 
@@ -945,10 +945,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1434,7 +1434,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("joinRequest");
 
@@ -1461,10 +1461,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1476,7 +1476,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "startRequest",
@@ -1531,10 +1531,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1550,7 +1550,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "startRequest",
@@ -1610,10 +1610,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1629,7 +1629,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "startRequest",
@@ -1689,10 +1689,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1708,7 +1708,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
         },
       },
       "startRequest",
@@ -1771,10 +1771,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1800,7 +1800,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("startRequest");
 
@@ -1829,10 +1829,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -1880,7 +1880,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
           statusCode: 200,
           body: {
-            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+            url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
           },
         }).as("startRequest");
 
@@ -1900,10 +1900,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -2069,7 +2069,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
           statusCode: 200,
           body: {
-            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+            url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
           },
         }).as("startRequest");
 
@@ -2091,10 +2091,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -2259,7 +2259,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("startRequest");
 
@@ -2298,10 +2298,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -2703,7 +2703,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+            url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
           },
         }).as("joinRequest");
 
@@ -2712,10 +2712,10 @@ describe("Rooms view meetings", function () {
     cy.wait("@joinRequest");
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });
@@ -2863,7 +2863,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        url: `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       },
     }).as("startRequest");
 
@@ -2901,10 +2901,10 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://thm-health.github.io", () => {
+    cy.origin(Cypress.env("redirectBaseUrl"), () => {
       cy.url().should(
         "eq",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/bigbluebutton?foo=a&bar=b`,
       );
     });
   });

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -38,7 +38,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "joinRequest",
@@ -82,8 +82,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -119,7 +122,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "joinRequest",
@@ -167,8 +170,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -204,7 +210,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "joinRequest",
@@ -252,8 +258,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -289,7 +298,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "joinRequest",
@@ -340,8 +349,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -375,7 +387,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("joinRequest");
 
@@ -408,8 +420,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -463,7 +478,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://example.org/?foo=a&bar=b",
+            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
           },
         }).as("joinRequest");
 
@@ -483,8 +498,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -668,7 +686,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://example.org/?foo=a&bar=b",
+            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
           },
         }).as("joinRequest");
 
@@ -690,8 +708,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -878,7 +899,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("joinRequest");
 
@@ -924,8 +945,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1410,7 +1434,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("joinRequest");
 
@@ -1437,8 +1461,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1449,7 +1476,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "startRequest",
@@ -1504,8 +1531,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1520,7 +1550,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "startRequest",
@@ -1580,8 +1610,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1596,7 +1629,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "startRequest",
@@ -1656,8 +1689,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1672,7 +1708,7 @@ describe("Rooms view meetings", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
         },
       },
       "startRequest",
@@ -1735,8 +1771,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1761,7 +1800,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("startRequest");
 
@@ -1790,8 +1829,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -1838,7 +1880,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
           statusCode: 200,
           body: {
-            url: "https://example.org/?foo=a&bar=b",
+            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
           },
         }).as("startRequest");
 
@@ -1858,8 +1900,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -2024,7 +2069,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
           statusCode: 200,
           body: {
-            url: "https://example.org/?foo=a&bar=b",
+            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
           },
         }).as("startRequest");
 
@@ -2046,8 +2091,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -2211,7 +2259,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("startRequest");
 
@@ -2250,8 +2298,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -2652,7 +2703,7 @@ describe("Rooms view meetings", function () {
         cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
           statusCode: 200,
           body: {
-            url: "https://example.org/?foo=a&bar=b",
+            url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
           },
         }).as("joinRequest");
 
@@ -2661,8 +2712,11 @@ describe("Rooms view meetings", function () {
     cy.wait("@joinRequest");
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 
@@ -2809,7 +2863,7 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 200,
       body: {
-        url: "https://example.org/?foo=a&bar=b",
+        url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
       },
     }).as("startRequest");
 
@@ -2847,8 +2901,11 @@ describe("Rooms view meetings", function () {
     });
 
     // Check if redirect worked
-    cy.origin("https://example.org", () => {
-      cy.url().should("eq", "https://example.org/?foo=a&bar=b");
+    cy.origin("https://thm-health.github.io", () => {
+      cy.url().should(
+        "eq",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/bigbluebutton?foo=a&bar=b",
+      );
     });
   });
 });

--- a/tests/Frontend/e2e/RoomsViewRecordingsRecordingActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewRecordingsRecordingActions.cy.js
@@ -30,7 +30,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         },
       },
       "viewRecordingRequest",
@@ -72,7 +72,7 @@ describe("Rooms view recordings recording actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         "_blank",
       );
 
@@ -140,7 +140,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         },
       },
     ).as("viewRecordingRequest");
@@ -165,7 +165,7 @@ describe("Rooms view recordings recording actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         "_blank",
       );
 
@@ -370,7 +370,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         },
       },
     ).as("viewRecordingRequest");
@@ -397,7 +397,7 @@ describe("Rooms view recordings recording actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         "_blank",
       );
   });
@@ -481,7 +481,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+          url: `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         },
       },
     ).as("viewRecordingRequest");
@@ -503,7 +503,7 @@ describe("Rooms view recordings recording actions", function () {
       .should("be.calledOnce")
       .and(
         "be.calledWith",
-        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        `${Cypress.env("redirectBaseUrl")}/recording?foo=a&bar=b`,
         "_blank",
       );
 

--- a/tests/Frontend/e2e/RoomsViewRecordingsRecordingActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewRecordingsRecordingActions.cy.js
@@ -30,7 +30,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
         },
       },
       "viewRecordingRequest",
@@ -70,7 +70,11 @@ describe("Rooms view recordings recording actions", function () {
 
     cy.get("@recordingView")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        "_blank",
+      );
 
     // Check that dialog stayed open and close it
     cy.get('[data-test="room-recordings-view-dialog"]')
@@ -136,7 +140,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
         },
       },
     ).as("viewRecordingRequest");
@@ -159,7 +163,11 @@ describe("Rooms view recordings recording actions", function () {
 
     cy.get("@recordingView")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        "_blank",
+      );
 
     // Check that dialog stayed open and close it
     cy.get('[data-test="room-recordings-view-dialog"]').should("be.visible");
@@ -362,7 +370,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
         },
       },
     ).as("viewRecordingRequest");
@@ -387,7 +395,11 @@ describe("Rooms view recordings recording actions", function () {
 
     cy.get("@recordingView")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        "_blank",
+      );
   });
 
   it("view recording with token errors", function () {
@@ -469,7 +481,7 @@ describe("Rooms view recordings recording actions", function () {
       {
         statusCode: 200,
         body: {
-          url: "https://example.org/?foo=a&bar=b",
+          url: "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
         },
       },
     ).as("viewRecordingRequest");
@@ -489,7 +501,11 @@ describe("Rooms view recordings recording actions", function () {
 
     cy.get("@recordingView")
       .should("be.calledOnce")
-      .and("be.calledWith", "https://example.org/?foo=a&bar=b", "_blank");
+      .and(
+        "be.calledWith",
+        "https://thm-health.github.io/PILOS-Redirect_Test_Pages/recording?foo=a&bar=b",
+        "_blank",
+      );
 
     // Check toast message is shown (browser is blocking download)
     cy.checkToastMessage("app.flash.popup_blocked");


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, **Test implementation**, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Replace redirect urls in tests from example.org urls to a custom Github Page
- 
## Other information
example.org currently has uptime issues causing tests to fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test data and assertions to use dynamic external URLs based on environment configuration for banners, footers, help buttons, room descriptions, file downloads, meeting redirects, and recording actions.
  * Modified tests to reflect environment-dependent URLs without altering test logic or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->