### PR TITLE
Add virus scan results to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security header X-XSS-Protection ([#2519])
 - Security header Referrer-Policy ([#2519])
 - Docs: HTTP Strict Transport Security (HSTS) recommendations ([#2519])
+- Virus scan results to metrics ([#2304])
 
 ### Changed
 
@@ -558,6 +559,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2265]: https://github.com/THM-Health/PILOS/issues/2265
 [#2279]: https://github.com/THM-Health/PILOS/pull/2279
 [#2282]: https://github.com/THM-Health/PILOS/pull/2282
+[#2304]: https://github.com/THM-Health/PILOS/pull/2304
 [#2313]: https://github.com/THM-Health/PILOS/issues/2313
 [#2319]: https://github.com/THM-Health/PILOS/pull/2319
 [#2383]: https://github.com/THM-Health/PILOS/issues/2383

--- a/app/Prometheus/Collectors/AntiVirusCollector.php
+++ b/app/Prometheus/Collectors/AntiVirusCollector.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Prometheus\Collectors;
+
+use App\Prometheus\CollectorRegistry;
+use App\Prometheus\Counter;
+
+class AntiVirusCollector implements Collector
+{
+    public function register(CollectorRegistry $registry): void
+    {
+        Counter::register($registry, 'virus_scan_total', 'Total number of files scanned for viruses', ['result']);
+    }
+
+    public function collect(): void
+    {
+        Counter::get('virus_scan_total')
+            ->init(['clean', 'virus', 'error']);
+    }
+}

--- a/app/Providers/MetricsServiceProvider.php
+++ b/app/Providers/MetricsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Prometheus\CollectorRegistry;
+use App\Prometheus\Collectors\AntiVirusCollector;
 use App\Prometheus\Collectors\AuthCollector;
 use App\Prometheus\Collectors\FileCollector;
 use App\Prometheus\Collectors\HorizonCollector;
@@ -31,6 +32,7 @@ class MetricsServiceProvider extends ServiceProvider implements DeferrableProvid
         HorizonCollector::class,
         AuthCollector::class,
         RequestCollector::class,
+        AntiVirusCollector::class,
     ];
 
     /**

--- a/app/Rules/Antivirus.php
+++ b/app/Rules/Antivirus.php
@@ -2,6 +2,7 @@
 
 namespace App\Rules;
 
+use App\Prometheus\Counter;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Http\UploadedFile;
@@ -39,12 +40,14 @@ class Antivirus implements ValidationRule
 
             // File is clean
             if ($response->status() === 200) {
+                Counter::get('virus_scan_total')->inc('clean');
+
                 return;
             }
 
             // Infected file
             if ($response->status() === 406) {
-
+                Counter::get('virus_scan_total')->inc('virus');
                 $description = $response->json('0.Description');
 
                 Log::warning('Virus {virus_description} detected', [
@@ -58,6 +61,8 @@ class Antivirus implements ValidationRule
 
                 return;
             }
+
+            Counter::get('virus_scan_total')->inc('error');
 
             // Other clamav errors
             Log::log('error', 'Virus scan failed', ['status' => $response->status()]);

--- a/tests/Backend/Feature/MetricsTest.php
+++ b/tests/Backend/Feature/MetricsTest.php
@@ -11,24 +11,12 @@ use App\Models\Session;
 use App\Models\User;
 use App\Prometheus\Counter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Tests\Backend\TestCase;
+use Tests\Backend\Utils\InteractWithMetrics;
 
 class MetricsTest extends TestCase
 {
-    use RefreshDatabase;
-
-    private function getMetrics(): array
-    {
-        return collect(Str::of($this->get('metrics')->getContent())
-            ->explode("\n")
-            ->filter(fn (string $line) => ! Str::startsWith($line, '#') && $line != '')
-            ->mapWithKeys(function (string $line) {
-                $data = Str::of($line)->explode(' ');
-
-                return [$data[0] => $data[1]];
-            }))->all();
-    }
+    use InteractWithMetrics, RefreshDatabase;
 
     public function test_metrics_disabled()
     {

--- a/tests/Backend/Feature/RouteMetricsTest.php
+++ b/tests/Backend/Feature/RouteMetricsTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Backend\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Tests\Backend\TestCase;
+use Tests\Backend\Utils\InteractWithMetrics;
 
 class RouteMetricsTest extends TestCase
 {
-    use RefreshDatabase;
+    use InteractWithMetrics, RefreshDatabase;
 
     protected function setUp(): void
     {
@@ -28,18 +28,6 @@ class RouteMetricsTest extends TestCase
     {
         putenv('DISABLE_CATCHALL_ROUTES');
         parent::tearDown();
-    }
-
-    private function getMetrics(): array
-    {
-        return collect(Str::of($this->get('metrics')->getContent())
-            ->explode("\n")
-            ->filter(fn (string $line) => ! Str::startsWith($line, '#') && $line != '')
-            ->mapWithKeys(function (string $line) {
-                $data = Str::of($line)->explode(' ');
-
-                return [$data[0] => $data[1]];
-            }))->all();
     }
 
     public function test_route_metrics_request_total()

--- a/tests/Backend/Unit/Rules/AntivirusTest.php
+++ b/tests/Backend/Unit/Rules/AntivirusTest.php
@@ -10,12 +10,13 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Tests\Backend\TestCase;
+use Tests\Backend\Utils\InteractWithMetrics;
 use TiMacDonald\Log\LogEntry;
 use TiMacDonald\Log\LogFake;
 
 class AntivirusTest extends TestCase
 {
-    use RefreshDatabase;
+    use InteractWithMetrics, RefreshDatabase;
 
     protected function setUp(): void
     {
@@ -40,6 +41,12 @@ class AntivirusTest extends TestCase
         $this->assertFalse($failCalled);
 
         Http::assertNothingSent();
+
+        // Check that the metrics are not changed
+        $metrics = $this->getMetrics();
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="clean"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="virus"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="error"}']);
     }
 
     public function test_validation_passes_for_clean_file()
@@ -66,6 +73,12 @@ class AntivirusTest extends TestCase
                 && $data['filename'] === 'clean.txt';
 
         });
+
+        // Check that the metrics are updated
+        $metrics = $this->getMetrics();
+        $this->assertEquals(1, $metrics['pilos_virus_scan_total{result="clean"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="virus"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="error"}']);
     }
 
     public function test_validation_fails_for_infected_file()
@@ -96,6 +109,12 @@ class AntivirusTest extends TestCase
                 && $log->context['file_path'] === $file->path()
                 && $log->context['request_url'] === url()->current()
         );
+
+        // Check that the metrics are updated
+        $metrics = $this->getMetrics();
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="clean"}']);
+        $this->assertEquals(1, $metrics['pilos_virus_scan_total{result="virus"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="error"}']);
     }
 
     public function test_validation_fails_for_clamav_error()
@@ -121,6 +140,12 @@ class AntivirusTest extends TestCase
                 && $log->message == 'Virus scan failed'
                 && $log->context['status'] == '500'
         );
+
+        // Check that the metrics are updated
+        $metrics = $this->getMetrics();
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="clean"}']);
+        $this->assertEquals(0, $metrics['pilos_virus_scan_total{result="virus"}']);
+        $this->assertEquals(1, $metrics['pilos_virus_scan_total{result="error"}']);
     }
 
     public function test_validation_fails_on_exception()

--- a/tests/Backend/Utils/InteractWithMetrics.php
+++ b/tests/Backend/Utils/InteractWithMetrics.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Backend\Utils;
+
+use Illuminate\Support\Str;
+
+trait InteractWithMetrics
+{
+    public function getMetrics(): array
+    {
+        return collect(Str::of($this->get('metrics')->getContent())
+            ->explode("\n")
+            ->filter(fn (string $line) => ! Str::startsWith($line, '#') && $line != '')
+            ->mapWithKeys(function (string $line) {
+                $data = Str::of($line)->explode(' ');
+
+                return [$data[0] => $data[1]];
+            }))->all();
+    }
+}


### PR DESCRIPTION
## Type

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Added virus scan results to metrics

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antivirus scan results are now tracked as Prometheus metrics, reporting counts for clean files, detected viruses, and scan errors.

* **Tests**
  * Added comprehensive test coverage for antivirus metrics collection.

* **Documentation**
  * Updated changelog to document metrics tracking for virus scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->