### PR TITLE
Fix: Room join/start button keeps loading when navigating back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Infinite loading when navigating back to rooms from BBB due to bfcache ([#2313], [#2319])
+
 ## [v4.7.1] - 2025-09-10
 
 ### Changed
@@ -532,6 +536,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2265]: https://github.com/THM-Health/PILOS/issues/2265
 [#2279]: https://github.com/THM-Health/PILOS/pull/2279
 [#2282]: https://github.com/THM-Health/PILOS/pull/2282
+[#2313]: https://github.com/THM-Health/PILOS/issues/2313
+[#2319]: https://github.com/THM-Health/PILOS/pull/2319
 [#2433]: https://github.com/THM-Health/PILOS/pull/2433
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.7.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/resources/js/components/MainNav.vue
+++ b/resources/js/components/MainNav.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, onUnmounted } from "vue";
 import { useSettingsStore } from "../stores/settings.js";
 import { useAuthStore } from "../stores/auth.js";
 import { useUserPermissions } from "../composables/useUserPermission.js";
@@ -341,6 +341,10 @@ async function pageShownAfterLogoutHandler(event) {
     loadingStore.setLoadingFinished();
   }
 }
+
+onUnmounted(() => {
+  window.removeEventListener("pageshow", pageShownAfterLogoutHandler);
+});
 
 async function logout() {
   let response;

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -323,6 +323,22 @@ const autoJoin = computed(() => {
 });
 
 /**
+ * Handle the page is restored from the back/forward cache after redirecting to BBB
+ * The modal is still shown and loaded, close and reload the page
+ */
+async function pageShownAfterBBBHandler(event) {
+  window.removeEventListener("pageshow", pageShownAfterBBBHandler);
+  if (event.persisted) {
+    // Disable loading indicator
+    isLoadingAction.value = false;
+    // Hide modal
+    modalVisible.value = false;
+    // Reload
+    emit("changed");
+  }
+}
+
+/**
  * Join/start
  */
 function getJoinUrl() {
@@ -362,7 +378,9 @@ function getJoinUrl() {
     .then((response) => {
       // Check if response has a join url, if yes redirect
       if (response.data.url !== undefined) {
-        modalVisible.value = false;
+        // Add listener for when user returns to this page
+        // without a full page reload, state is restored from back/forward cache
+        window.addEventListener("pageshow", pageShownAfterBBBHandler);
         window.location = response.data.url;
       }
     })

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -172,7 +172,7 @@
   </Dialog>
 </template>
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onUnmounted } from "vue";
 import { useAuthStore } from "../stores/auth.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { useApi } from "../composables/useApi.js";
@@ -337,6 +337,10 @@ async function pageShownAfterBBBHandler(event) {
     emit("changed");
   }
 }
+
+onUnmounted(() => {
+  window.removeEventListener("pageshow", pageShownAfterBBBHandler);
+});
 
 /**
  * Join/start


### PR DESCRIPTION
# Fixes #2313 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixed infinite loading when navigating back to rooms from BBB meeting user browser controls

## Other information
Equivalent to https://github.com/THM-Health/PILOS/pull/2282, see for more details on the bfcache issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite loading when returning from a BigBlueButton (BBB) meeting by handling browser back/forward cache restoration and resetting UI state.
  * Ensured modals and loading indicators are correctly managed when redirecting to/from BBB.
  * Improved cleanup of pageshow/event listeners (including on component unmount) to avoid leaks on navigation.

* **Documentation**
  * Updated changelog and added related references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->