### PR TITLE
UX: Show login button when guests are not allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BBB API URL is now automatically normalized to include a trailing `/` when adding BBB servers using the provision command ([#3011], [#3014])
 - Provision command data format to support partial provision using optional sections and fields ([#3014])
-- Show login button instead of reload button in room can only be used by authenticated users view ([#2321])
+- Show a login button instead of a reload button for guests without access to a room ([#2321])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BBB API URL is now automatically normalized to include a trailing `/` when adding BBB servers using the provision command ([#3011], [#3014])
 - Provision command data format to support partial provision using optional sections and fields ([#3014])
+- Show login button instead of reload button in room can only be used by authenticated users view ([#2321])
 
 ### Fixed
 
@@ -687,6 +688,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2304]: https://github.com/THM-Health/PILOS/pull/2304
 [#2313]: https://github.com/THM-Health/PILOS/issues/2313
 [#2319]: https://github.com/THM-Health/PILOS/pull/2319
+[#2321]: https://github.com/THM-Health/PILOS/pull/2321
 [#2325]: https://github.com/THM-Health/PILOS/pull/2325
 [#2345]: https://github.com/THM-Health/PILOS/issues/2345
 [#2383]: https://github.com/THM-Health/PILOS/issues/2383

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -45,14 +45,13 @@
           </span>
         </template>
         <template #footer>
-          <div class="flex w-full justify-start">
-            <!-- Reload page, in case the room settings changed -->
+          <div class="mt-4 flex w-full justify-start">
             <Button
-              data-test="reload-room-button"
-              :loading="loading"
-              icon="fa-solid fa-sync"
-              :label="$t('rooms.try_again')"
-              @click="reload"
+              data-test="login-room-button"
+              icon="fa-solid fa-lock"
+              :label="$t('auth.login')"
+              as="router-link"
+              :to="{ name: 'login', query: { redirect: $route.fullPath } }"
             />
           </div>
         </template>

--- a/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
@@ -1119,9 +1119,6 @@ describe("Rooms view files file actions", function () {
     // Check that the error message is shown
     cy.contains("rooms.only_used_by_authenticated_users").should("be.visible");
 
-    // Check that reload button is shown
-    cy.get('[data-test="reload-room-button"]').should("be.visible");
-
     cy.interceptRoomViewRequests();
     cy.interceptRoomFilesRequest(true);
 

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -691,9 +691,6 @@ describe("Room View general", function () {
     // Check that the error message is shown
     cy.contains("rooms.only_used_by_authenticated_users").should("be.visible");
 
-    // Check that reload button is shown
-    cy.get('[data-test="reload-room-button"]').should("be.visible");
-
     // Check that access code overlay is hidden
     cy.get('[data-test="room-access-code-overlay"]').should("not.exist");
   });
@@ -2715,22 +2712,12 @@ describe("Room View general", function () {
     // Check that the error message is shown
     cy.contains("rooms.only_used_by_authenticated_users").should("be.visible");
 
-    // Get reload button and reload without error
-    const reloadRequest = interceptIndefinitely(
-      "GET",
-      "api/v1/rooms/abc-def-123",
-      { fixture: "room.json" },
-      "roomRequest",
+    // Get login button and check if redirect is correctly set
+    cy.get('a[data-test="login-room-button"]').should(
+      "have.attr",
+      "href",
+      "/login?redirect=/rooms/abc-def-123",
     );
-    cy.get('[data-test="reload-room-button"]').click();
-    cy.get('[data-test="reload-room-button"]')
-      .should("be.disabled")
-      .then(() => {
-        reloadRequest.sendResponse();
-      });
-
-    cy.wait("@roomRequest");
-    cy.contains("Meeting One").should("be.visible");
   });
 
   it("visit with personalized link as authenticated user", function () {
@@ -2884,20 +2871,6 @@ describe("Room View general", function () {
     cy.wait("@roomRequest");
     cy.contains("Meeting One").should("be.visible");
 
-    // Test reload with guests forbidden
-    cy.intercept("GET", "api/v1/rooms/abc-def-123", {
-      statusCode: 403,
-      body: {
-        message: "guests_not_allowed",
-      },
-    }).as("roomRequest");
-
-    cy.get('[data-test="reload-room-button"]').click();
-
-    cy.wait("@roomRequest");
-    // Check that the error message is shown
-    cy.contains("rooms.only_used_by_authenticated_users").should("be.visible");
-
     // Test reload with general error
     cy.intercept("GET", "api/v1/rooms/abc-def-123", {
       statusCode: 500,
@@ -2913,6 +2886,35 @@ describe("Room View general", function () {
       'app.flash.server_error.message_{"message":"Test"}',
       'app.flash.server_error.error_code_{"statusCode":500}',
     ]);
+
+    // Test reload with guests forbidden
+    cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+      statusCode: 403,
+      body: {
+        message: "guests_not_allowed",
+      },
+    }).as("roomRequest");
+
+    cy.get('[data-test="reload-room-button"]').click();
+
+    cy.wait("@roomRequest");
+    // Check that the error message is shown
+    cy.contains("rooms.only_used_by_authenticated_users").should("be.visible");
+
+    // Reload page successfully
+    cy.fixture("room.json").then((room) => {
+      room.data.allow_membership = true;
+      room.data.current_user = null;
+
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+
+      cy.reload();
+    });
+
+    cy.wait("@roomRequest");
 
     // Test reload with room not found
     cy.intercept("GET", "api/v1/rooms/abc-def-123", {

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -1125,7 +1125,7 @@ describe("Rooms view meetings", function () {
     });
 
     // Reload room
-    cy.get('[data-test="reload-room-button"]').click();
+    cy.reload();
 
     cy.wait("@roomRequest");
 
@@ -2545,7 +2545,7 @@ describe("Rooms view meetings", function () {
     }).as("roomRequest");
 
     // Reload room
-    cy.get('[data-test="reload-room-button"]').click();
+    cy.reload();
 
     cy.wait("@roomRequest");
 


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **UX**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Instead of showing a reload button (user can always reload via the browser) a login button is shown

## Other information
Before
<img width="564" height="221" alt="image" src="https://github.com/user-attachments/assets/8169d0ef-ade8-4db2-8be8-e281adce1f2c" />

After
<img width="557" height="235" alt="image" src="https://github.com/user-attachments/assets/801f21e0-64a4-4d92-b288-a69291541e04" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Restricted-room error screen now shows a login button (which returns users to the room after signing in) instead of a reload button; footer spacing adjusted for clarity.
* **Tests**
  * Automated frontend tests updated to reflect the new login link and the revised reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->