### PR TITLE
Fix Greenlight v2 migration with 6 digit access codes and leading zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+# Changed
+
+- Improve secure access code generation ([#2433])
+
+# Fixed
+
+- Support for legacy 6-digit access codes imported from Greenlight v2 ([#2433])
+
 ## [v4.7.0] - 2025-07-21
 
 ### Added
@@ -522,6 +530,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2265]: https://github.com/THM-Health/PILOS/issues/2265
 [#2279]: https://github.com/THM-Health/PILOS/pull/2279
 [#2282]: https://github.com/THM-Health/PILOS/pull/2282
+[#2433]: https://github.com/THM-Health/PILOS/pull/2433
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.7.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changed
 
-- Improve secure access code generation ([#2433])
+- Value range and randomness of access code generation ([#2433])
 
 # Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# Changed
+### Changed
 
 - Value range and randomness of access code generation ([#2433])
 
-# Fixed
+### Fixed
 
 - Support for legacy 6-digit access codes imported from Greenlight v2 ([#2433])
 

--- a/app/Http/Requests/UpdateRoomSettings.php
+++ b/app/Http/Requests/UpdateRoomSettings.php
@@ -42,8 +42,10 @@ class UpdateRoomSettings extends FormRequest
      */
     private function getAccessCodeValidationRule(): array
     {
-        // Support legacy 6-digit access codes (Greenlight v2)
-        $digits = strlen($this->room->access_code) == 6 && strlen($this->input('access_code')) == 6 ? 6 : 9;
+        // Support keeping old 6-digit codes (Greenlight v2)
+        $current = $this->room->access_code ?? '';
+        $incoming = $this->str('access_code') ?? '';
+        $digits = ($current == $incoming && strlen($current) == 6) ? 6 : 9;
 
         $rules = ['numeric', 'digits:'.$digits, 'bail'];
 

--- a/app/Http/Requests/UpdateRoomSettings.php
+++ b/app/Http/Requests/UpdateRoomSettings.php
@@ -42,7 +42,10 @@ class UpdateRoomSettings extends FormRequest
      */
     private function getAccessCodeValidationRule(): array
     {
-        $rules = ['numeric', 'digits:9', 'bail'];
+        // Support legacy 6-digit access codes (Greenlight v2)
+        $digits = strlen($this->room->access_code) == 6 && strlen($this->input('access_code')) == 6 ? 6 : 9;
+
+        $rules = ['numeric', 'digits:'.$digits, 'bail'];
 
         // Make sure that the given room type id is a number
         if (is_numeric($this->input('room_type'))) {

--- a/app/Http/Resources/Room.php
+++ b/app/Http/Resources/Room.php
@@ -55,6 +55,7 @@ class Room extends JsonResource
         return [
             'username' => $this->when(! empty($this->token), ! empty($this->token) ? $this->token->fullname : null),
             'authenticated' => $this->authenticated,
+            'legacy_code' => $this->access_code && strlen($this->access_code) == 6,
             'description' => $this->when($this->authenticated, $this->description),
             'allow_membership' => $this->getRoomSetting('allow_membership'),
             'is_member' => $this->resource->isMember(Auth::user()),

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -65,7 +65,6 @@ class Room extends Model
         $casts = [
             'expert_mode' => 'boolean',
             'delete_inactive' => 'datetime',
-            'access_code' => 'integer',
         ];
 
         // Generate casts for settings that are also present in the room type

--- a/database/migrations/2025_09_01_153901_change_access_code_to_string.php
+++ b/database/migrations/2025_09_01_153901_change_access_code_to_string.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Room;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rooms', function (Blueprint $table) {
+            $table->string('access_code')->nullable()->change();
+        });
+
+        Room::whereRaw('LENGTH(access_code) < 6')
+            ->update(['access_code' => \DB::raw("LPAD(access_code, 6, '0')")]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('rooms', function (Blueprint $table) {
+            $table->integer('access_code')->length(11)->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/2025_09_01_153901_change_access_code_to_string.php
+++ b/database/migrations/2025_09_01_153901_change_access_code_to_string.php
@@ -3,6 +3,7 @@
 use App\Models\Room;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -25,8 +26,16 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('rooms', function (Blueprint $table) {
-            $table->integer('access_code')->length(11)->nullable()->change();
-        });
+        $driver = DB::connection($this->getConnection())->getDriverName();
+
+        switch ($driver) {
+            case 'pgsql':
+                DB::statement('ALTER TABLE rooms ALTER COLUMN access_code TYPE integer USING access_code::integer');
+                break;
+            default:
+                Schema::table('rooms', function (Blueprint $table) {
+                    $table->integer('access_code')->length(11)->nullable()->change();
+                });
+        }
     }
 };

--- a/resources/js/components/RoomHeader.vue
+++ b/resources/js/components/RoomHeader.vue
@@ -95,7 +95,7 @@ const props = defineProps({
     default: false,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   disableReload: {

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -203,7 +203,7 @@ const props = defineProps({
     default: null,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
 });

--- a/resources/js/components/RoomMembershipButton.vue
+++ b/resources/js/components/RoomMembershipButton.vue
@@ -69,7 +69,7 @@ const props = defineProps({
     required: true,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   disabled: {

--- a/resources/js/components/RoomShareButton.vue
+++ b/resources/js/components/RoomShareButton.vue
@@ -115,8 +115,6 @@ const roomUrl = computed(() => {
 });
 
 const formattedAccessCode = computed(() => {
-  return String(props.room.access_code)
-    .match(/.{1,3}/g)
-    .join("-");
+  return props.room.access_code.match(/.{1,3}/g).join("-");
 });
 </script>

--- a/resources/js/components/RoomShareButton.vue
+++ b/resources/js/components/RoomShareButton.vue
@@ -115,6 +115,8 @@ const roomUrl = computed(() => {
 });
 
 const formattedAccessCode = computed(() => {
-  return props.room.access_code.match(/.{1,3}/g).join("-");
+  return String(props.room.access_code)
+    .match(/.{1,3}/g)
+    .join("-");
 });
 </script>

--- a/resources/js/components/RoomTabFiles.vue
+++ b/resources/js/components/RoomTabFiles.vue
@@ -314,7 +314,7 @@ const props = defineProps({
     required: true,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   token: {

--- a/resources/js/components/RoomTabFilesViewButton.vue
+++ b/resources/js/components/RoomTabFilesViewButton.vue
@@ -32,7 +32,7 @@ const props = defineProps({
     required: false,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   token: {

--- a/resources/js/components/RoomTabRecordings.vue
+++ b/resources/js/components/RoomTabRecordings.vue
@@ -323,7 +323,7 @@ const props = defineProps({
     required: true,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   token: {

--- a/resources/js/components/RoomTabRecordingsViewButton.vue
+++ b/resources/js/components/RoomTabRecordingsViewButton.vue
@@ -76,7 +76,7 @@ import { EVENT_FORBIDDEN } from "../constants/events.js";
 
 const props = defineProps({
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   token: {

--- a/resources/js/components/RoomTabSection.vue
+++ b/resources/js/components/RoomTabSection.vue
@@ -161,7 +161,7 @@ const props = defineProps({
     required: true,
   },
   accessCode: {
-    type: Number,
+    type: String,
     default: null,
   },
   token: {

--- a/resources/js/components/RoomTabSettingsAccessCodeInput.vue
+++ b/resources/js/components/RoomTabSettingsAccessCodeInput.vue
@@ -108,8 +108,14 @@ const props = defineProps({
  * Create a new access code for the room
  */
 function createAccessCode() {
-  const newCode =
-    Math.floor(Math.random() * (999999999 - 111111112)) + 111111111;
+  // Generate a random value between 0 and 1
+  const array = new Uint32Array(1);
+  window.crypto.getRandomValues(array);
+  const randomValue = array[0] / (0xffffffff + 1);
+
+  const min = 111_111_111;
+  const max = 999_999_999;
+  const newCode = Math.floor(randomValue * (max - min + 1)) + min;
   model.value[props.setting] = newCode.toString();
 }
 </script>

--- a/resources/js/components/RoomTabSettingsAccessCodeInput.vue
+++ b/resources/js/components/RoomTabSettingsAccessCodeInput.vue
@@ -108,14 +108,28 @@ const props = defineProps({
  * Create a new access code for the room
  */
 function createAccessCode() {
-  // Generate a random value between 0 and 1
-  const array = new Uint32Array(1);
-  window.crypto.getRandomValues(array);
-  const randomValue = array[0] / (0xffffffff + 1);
-
-  const min = 111_111_111;
+  // Define the minimum and maximum values for the access code range
+  const min = 0;
   const max = 999_999_999;
-  const newCode = Math.floor(randomValue * (max - min + 1)) + min;
-  model.value[props.setting] = newCode.toString();
+
+  // Calculate the range and the largest multiple of the range that fits in a 32-bit unsigned integer
+  const range = max - min + 1;
+  const limit = Math.floor(0xffffffff / range) * range;
+
+  // Create a array to hold the random uint32 value
+  const array = new Uint32Array(1);
+
+  // Generate a random value within the acceptable range using rejection sampling
+  do {
+    crypto.getRandomValues(array);
+  } while (array[0] > limit);
+
+  // Calculate the random number within the desired range
+  // using modulo to fit it into the range, only possible because of the rejection sampling above
+  // otherwise this would introduce bias
+  const randomNumber = array[0] % range;
+
+  // Convert the random number to a zero-padded 9-digit string
+  model.value[props.setting] = randomNumber.toString().padStart(9, "0");
 }
 </script>

--- a/resources/js/components/RoomTabSettingsAccessCodeInput.vue
+++ b/resources/js/components/RoomTabSettingsAccessCodeInput.vue
@@ -29,7 +29,7 @@
         <!-- Access code -->
         <InputText
           :id="'room-setting-' + setting"
-          v-model.number="model[setting]"
+          v-model="model[setting]"
           :disabled="disabled"
           :invalid="invalid"
           :placeholder="placeholder"
@@ -108,7 +108,8 @@ const props = defineProps({
  * Create a new access code for the room
  */
 function createAccessCode() {
-  model.value[props.setting] =
+  const newCode =
     Math.floor(Math.random() * (999999999 - 111111112)) + 111111111;
+  model.value[props.setting] = newCode.toString();
 }
 </script>

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -119,8 +119,8 @@
                     id="access-code"
                     v-model="accessCodeInput"
                     autofocus
-                    mask="999-999-999"
-                    placeholder="123-456-789"
+                    :mask="room.legacy_code ? '999-999' : '999-999-999'"
+                    :placeholder="room.legacy_code ? '123-456' : '123-456-789'"
                     :invalid="accessCodeInvalid"
                     :disabled="authThrottledFor > 0"
                     class="text-center"
@@ -530,8 +530,8 @@ function setPageTitle(roomName) {
  * Handle login with access code
  */
 function login() {
-  // Parse to int
-  accessCode.value = parseInt(accessCodeInput.value.replace(/[-]/g, ""));
+  // Remove dashes from the access code
+  accessCode.value = accessCodeInput.value.replace(/[-]/g, "");
   // Reload the room with an access code
   reload();
 }

--- a/tests/Backend/Feature/api/v1/RecordingTest.php
+++ b/tests/Backend/Feature/api/v1/RecordingTest.php
@@ -137,7 +137,7 @@ class RecordingTest extends TestCase
             ->assertForbidden();
 
         // Access as guest with wrong access code
-        $this->withHeaders(['Access-Code' => 111])
+        $this->withHeaders(['Access-Code' => '111'])
             ->getJson(route('api.v1.rooms.recordings.index', ['room' => $room->id]))
             ->assertUnauthorized();
 
@@ -155,7 +155,7 @@ class RecordingTest extends TestCase
 
         // Access as authenticated user, with wrong access code
         $this->actingAs($this->user)
-            ->withHeaders(['Access-Code' => 111])
+            ->withHeaders(['Access-Code' => '111'])
             ->getJson(route('api.v1.rooms.recordings.index', ['room' => $room->id]))
             ->assertUnauthorized();
 
@@ -383,7 +383,7 @@ class RecordingTest extends TestCase
             ->assertForbidden();
 
         // Access as guest with wrong access code
-        $this->withHeaders(['Access-Code' => 111])
+        $this->withHeaders(['Access-Code' => '111'])
             ->getJson(route('api.v1.rooms.recordings.formats.show', ['room' => $recording->room->id, 'recording' => $recording->id, 'format' => $format->id]))
             ->assertUnauthorized();
 

--- a/tests/Backend/Feature/api/v1/RecordingTest.php
+++ b/tests/Backend/Feature/api/v1/RecordingTest.php
@@ -119,7 +119,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = true;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -203,7 +203,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -244,7 +244,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -312,7 +312,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -375,7 +375,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = true;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         // Access as guest without access code
@@ -403,7 +403,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = false;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         // Access as guest with correct access code
@@ -422,7 +422,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = false;
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
 
         // Create token

--- a/tests/Backend/Feature/api/v1/RecordingTest.php
+++ b/tests/Backend/Feature/api/v1/RecordingTest.php
@@ -119,7 +119,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = true;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -203,7 +203,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -244,7 +244,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -312,7 +312,7 @@ class RecordingTest extends TestCase
 
         $room = Room::factory()->create();
         $room->allow_guests = false;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         Recording::factory()->count(7)->create(['room_id' => $room->id, 'access' => RecordingAccess::OWNER]);
@@ -375,7 +375,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = true;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         // Access as guest without access code
@@ -403,7 +403,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = false;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         // Access as guest with correct access code
@@ -422,7 +422,7 @@ class RecordingTest extends TestCase
         $recording->save();
 
         $room->allow_guests = false;
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
 
         // Create token

--- a/tests/Backend/Feature/api/v1/Room/FileTest.php
+++ b/tests/Backend/Feature/api/v1/Room/FileTest.php
@@ -160,7 +160,7 @@ class FileTest extends TestCase
             ->assertForbidden();
         \Auth::logout();
 
-        $this->room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $this->room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $this->room->save();
 
         // Testing guests without access code
@@ -333,7 +333,7 @@ class FileTest extends TestCase
     {
         $this->actingAs($this->room->owner)->postJson(route('api.v1.rooms.files.get', ['room' => $this->room]), ['file' => $this->file_valid])
             ->assertSuccessful();
-        $this->room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $this->room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $this->room->save();
         $room_file = $this->room->files()->where('filename', $this->file_valid->name)->first();
         $room_file->download = true;

--- a/tests/Backend/Feature/api/v1/Room/FileTest.php
+++ b/tests/Backend/Feature/api/v1/Room/FileTest.php
@@ -160,7 +160,7 @@ class FileTest extends TestCase
             ->assertForbidden();
         \Auth::logout();
 
-        $this->room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $this->room->access_code = $this->createAccessCode();
         $this->room->save();
 
         // Testing guests without access code
@@ -333,7 +333,7 @@ class FileTest extends TestCase
     {
         $this->actingAs($this->room->owner)->postJson(route('api.v1.rooms.files.get', ['room' => $this->room]), ['file' => $this->file_valid])
             ->assertSuccessful();
-        $this->room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $this->room->access_code = $this->createAccessCode();
         $this->room->save();
         $room_file = $this->room->files()->where('filename', $this->file_valid->name)->first();
         $room_file->download = true;

--- a/tests/Backend/Feature/api/v1/Room/MembershipTest.php
+++ b/tests/Backend/Feature/api/v1/Room/MembershipTest.php
@@ -40,7 +40,7 @@ class MembershipTest extends TestCase
             'allow_guests' => true,
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -50,7 +50,7 @@ class MembershipTest extends TestCase
         $this->withHeaders(['Access-Code' => ''])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         $this->withHeaders(['Access-Code' => $room->access_code])->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -85,80 +85,80 @@ class MembershipTest extends TestCase
         $roomAllowMembershipEnforced1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipEnforced2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipEnforced3 = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipDefault = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomAllowMembershipExpert1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
         $roomAllowMembershipExpert2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomNoMembershipAllowedEnforced1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedEnforced2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedEnforced3 = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedDefault = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
         $roomNoMembershipAllowedExpert1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomNoMembershipAllowedExpert2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
@@ -260,7 +260,7 @@ class MembershipTest extends TestCase
             'allow_guests' => true,
             'allow_membership' => true,
             'expert_mode' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         $room->members()->attach($this->user, ['role' => RoomUserRole::USER]);
@@ -289,7 +289,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         $john = User::factory()->create(['firstname' => 'John', 'lastname' => 'Doe', 'image' => 'test.jpg']);
@@ -431,7 +431,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -520,7 +520,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -600,7 +600,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -668,7 +668,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -823,7 +823,7 @@ class MembershipTest extends TestCase
         // create and save new test-room
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -973,7 +973,7 @@ class MembershipTest extends TestCase
         // create and save new test-room
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         $room->owner()->associate($owner);
         $room->save();

--- a/tests/Backend/Feature/api/v1/Room/MembershipTest.php
+++ b/tests/Backend/Feature/api/v1/Room/MembershipTest.php
@@ -40,7 +40,7 @@ class MembershipTest extends TestCase
             'allow_guests' => true,
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -50,7 +50,7 @@ class MembershipTest extends TestCase
         $this->withHeaders(['Access-Code' => ''])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         $this->withHeaders(['Access-Code' => $room->access_code])->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -85,80 +85,80 @@ class MembershipTest extends TestCase
         $roomAllowMembershipEnforced1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipEnforced2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipEnforced3 = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipEnforced->id,
         ]);
 
         $roomAllowMembershipDefault = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomAllowMembershipExpert1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
         $roomAllowMembershipExpert2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomNoMembershipAllowedEnforced1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedEnforced2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedEnforced3 = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedEnforced->id,
         ]);
 
         $roomNoMembershipAllowedDefault = Room::factory()->create([
             'expert_mode' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
         $roomNoMembershipAllowedExpert1 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeAllowMembershipDefault->id,
         ]);
 
         $roomNoMembershipAllowedExpert2 = Room::factory()->create([
             'expert_mode' => true,
             'allow_membership' => false,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'room_type_id' => $roomTypeNoMembershipAllowedDefault->id,
         ]);
 
@@ -260,7 +260,7 @@ class MembershipTest extends TestCase
             'allow_guests' => true,
             'allow_membership' => true,
             'expert_mode' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         $room->members()->attach($this->user, ['role' => RoomUserRole::USER]);
@@ -289,7 +289,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         $john = User::factory()->create(['firstname' => 'John', 'lastname' => 'Doe', 'image' => 'test.jpg']);
@@ -431,7 +431,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -520,7 +520,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -600,7 +600,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -668,7 +668,7 @@ class MembershipTest extends TestCase
 
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -823,7 +823,7 @@ class MembershipTest extends TestCase
         // create and save new test-room
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();
@@ -973,7 +973,7 @@ class MembershipTest extends TestCase
         // create and save new test-room
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         $room->owner()->associate($owner);
         $room->save();

--- a/tests/Backend/Feature/api/v1/Room/RoomDescriptionTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomDescriptionTest.php
@@ -74,7 +74,7 @@ class RoomDescriptionTest extends TestCase
     {
         $description = $this->faker->text(1000);
 
-        $room = Room::factory()->create(['description' => $description, 'allow_guests' => true, 'access_code' => $this->faker->numberBetween(111111111, 999999999)]);
+        $room = Room::factory()->create(['description' => $description, 'allow_guests' => true, 'access_code' => (string) $this->faker->numberBetween(111111111, 999999999)]);
 
         // Test anoymous user without access code
         $this->getJson(route('api.v1.rooms.show', ['room' => $room]))

--- a/tests/Backend/Feature/api/v1/Room/RoomDescriptionTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomDescriptionTest.php
@@ -74,7 +74,7 @@ class RoomDescriptionTest extends TestCase
     {
         $description = $this->faker->text(1000);
 
-        $room = Room::factory()->create(['description' => $description, 'allow_guests' => true, 'access_code' => (string) $this->faker->numberBetween(111111111, 999999999)]);
+        $room = Room::factory()->create(['description' => $description, 'allow_guests' => true, 'access_code' => $this->createAccessCode()]);
 
         // Test anoymous user without access code
         $this->getJson(route('api.v1.rooms.show', ['room' => $room]))

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -564,19 +564,19 @@ class RoomTest extends TestCase
 
         // Try 6 times with wrong access code
         for ($i = 0; $i < 6; $i++) {
-            $this->withHeaders(['Access-Code' => 999999999])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+            $this->withHeaders(['Access-Code' => '999999999'])->getJson(route('api.v1.rooms.show', ['room' => $room]))
                 ->assertUnauthorized();
         }
 
         // Check if rate limit is reached
-        $this->withHeaders(['Access-Code' => 999999999])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => '999999999'])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertStatus(429);
 
         // Time travel 1 minute to reset rate limit
         $this->travel(1)->minutes();
 
         // Try again
-        $this->withHeaders(['Access-Code' => 999999999])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => '999999999'])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
     }
 

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -529,7 +529,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
         // Try without access code
         $this->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -542,7 +542,7 @@ class RoomTest extends TestCase
             ->assertUnauthorized();
 
         // Try with random access code
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         // Try with correct access code
@@ -550,6 +550,13 @@ class RoomTest extends TestCase
             ->assertStatus(200)
             ->assertJsonFragment(['authenticated' => true])
             ->assertJsonFragment(['current_user' => null]);
+
+        // Try with legacy 6 digit access code
+        $room->access_code = "012345";
+        $room->save();
+        $this->withHeaders(['Access-Code' => '012345'])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+            ->assertStatus(200)
+            ->assertJsonFragment(['authenticated' => true]);
     }
 
     /**
@@ -612,7 +619,7 @@ class RoomTest extends TestCase
             ->assertJsonFragment(['current_user' => null]);
 
         // Test room with access code if the room type has no access code as default
-        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = $this->createAccessCode();
         $room->save();
         $roomType->has_access_code_default = false;
         $roomType->save();
@@ -650,7 +657,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         // Try without access code
@@ -664,7 +671,7 @@ class RoomTest extends TestCase
             ->assertUnauthorized();
 
         // Try with random access code
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         // Try with correct access code
@@ -985,6 +992,24 @@ class RoomTest extends TestCase
 
         $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertJsonPath('data.type.features.streaming.enabled', true);
+
+        // Test with regular access code (9-digit number)
+        $room->access_code = $this->createAccessCode();
+        $room->save();
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
+            ->assertJsonPath('data.legacy_code', false);
+
+        // Test with legacy access code (6-digit number)
+        $room->access_code = $this->createAccessCode(6);
+        $room->save();
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
+            ->assertJsonPath('data.legacy_code', true);
+
+        // Test without access code
+        $room->access_code = null;
+        $room->save();
+        $this->actingAs($this->user)->getJson(route('api.v1.rooms.show', ['room' => $room]))
+            ->assertJsonPath('data.legacy_code', false);
     }
 
     /**
@@ -1626,7 +1651,7 @@ class RoomTest extends TestCase
     public function test_access_code_shown()
     {
         $room = Room::factory()->create([
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         // Testing unauthenticated user
@@ -1753,7 +1778,7 @@ class RoomTest extends TestCase
         ]);
 
         // Test without allow guests enforced in room type
-        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = $this->createAccessCode();
         $settings['room_type'] = $roomType->id;
         $settings['expert_mode'] = false;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -1863,7 +1888,7 @@ class RoomTest extends TestCase
             'auto_start_recording_default' => false,
         ]);
 
-        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = $this->createAccessCode();
         $settings['expert_mode'] = false;
         $settings['room_type'] = $roomType->id;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -2017,7 +2042,7 @@ class RoomTest extends TestCase
             'restrict' => false,
         ]);
 
-        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = $this->createAccessCode();
         $settings['expert_mode'] = true;
         $settings['room_type'] = $roomType->id;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -2154,7 +2179,7 @@ class RoomTest extends TestCase
             'has_access_code_enforced' => true,
         ]);
 
-        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = $this->createAccessCode();
         $settings['room_type'] = $roomType->id;
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertJsonValidationErrors(['access_code']);
@@ -2239,6 +2264,65 @@ class RoomTest extends TestCase
                 'expert_mode',
                 'allow_guests',
             ]);
+    }
+
+    public function test_update_settings_access_code()
+    {
+        config(['bigbluebutton.welcome_message_limit' => 5]);
+        $room = Room::factory()->create([
+            'expert_mode' => true,
+            'access_code' => $this->createAccessCode(),
+        ]);
+        // Get current settings
+        $response = $this->actingAs($room->owner)->getJson(route('api.v1.rooms.settings', ['room' => $room]))
+            ->assertSuccessful();
+
+        $settings = $response->json('data');
+        $settings['room_type'] = $settings['room_type']['id'];
+
+        // Keep access code / do nothing
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertSuccessful();
+
+        // Change access code
+        $settings['access_code'] = $this->createAccessCode();
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertSuccessful();
+        $room->refresh();
+        $this->assertEquals($settings['access_code'], $room->access_code);
+
+        // Remove access code
+        $settings['access_code'] = null;
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertSuccessful();
+        $room->refresh();
+        $this->assertNull($room->access_code);
+
+        // Keep 6-digit access code
+        $room->access_code = "012345";
+        $room->save();
+        $settings['access_code'] = "012345";
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertSuccessful();
+        $room->refresh();
+        $this->assertEquals($settings['access_code'], $room->access_code);
+
+        // Prevent setting a new 6-digit access code
+        $settings['access_code'] = "654321";
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertJsonValidationErrors(['access_code']);
+
+        // Allow setting a new 9-digit access code
+        $settings['access_code'] = "012345678";
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertSuccessful();
+        $room->refresh();
+        $this->assertEquals($settings['access_code'], $room->access_code);
+
+        // Prevent downgrading to a 6-digit access code
+        $settings['access_code'] = "012345";
+        $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
+            ->assertJsonValidationErrors(['access_code']);
     }
 
     /**
@@ -2548,7 +2632,7 @@ class RoomTest extends TestCase
     public function test_start_restricted_no_server()
     {
         $room = Room::factory()->create([
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         // Testing guests
@@ -2611,13 +2695,13 @@ class RoomTest extends TestCase
             'allow_guests' => true,
             'expert_mode' => true,
             'everyone_can_start' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
         ]);
 
         // Testing guests
         $this->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertJsonValidationErrors('name');
@@ -2650,7 +2734,7 @@ class RoomTest extends TestCase
         // Testing authorized users
         $this->actingAs($this->user)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertStatus(CustomStatusCodes::NO_SERVER_AVAILABLE->value);
@@ -3122,7 +3206,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => $this->createAccessCode(),
             'expert_mode' => true,
             'record_attendance' => true,
         ]);
@@ -3293,7 +3377,7 @@ class RoomTest extends TestCase
         // Join as authorized users
         $this->actingAs($this->user)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => $this->createAccessCode()])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertSuccessful();

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -552,7 +552,7 @@ class RoomTest extends TestCase
             ->assertJsonFragment(['current_user' => null]);
 
         // Try with legacy 6 digit access code
-        $room->access_code = "012345";
+        $room->access_code = '012345';
         $room->save();
         $this->withHeaders(['Access-Code' => '012345'])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertStatus(200)
@@ -2299,28 +2299,28 @@ class RoomTest extends TestCase
         $this->assertNull($room->access_code);
 
         // Keep 6-digit access code
-        $room->access_code = "012345";
+        $room->access_code = '012345';
         $room->save();
-        $settings['access_code'] = "012345";
+        $settings['access_code'] = '012345';
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertSuccessful();
         $room->refresh();
         $this->assertEquals($settings['access_code'], $room->access_code);
 
         // Prevent setting a new 6-digit access code
-        $settings['access_code'] = "654321";
+        $settings['access_code'] = '654321';
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertJsonValidationErrors(['access_code']);
 
         // Allow setting a new 9-digit access code
-        $settings['access_code'] = "012345678";
+        $settings['access_code'] = '012345678';
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertSuccessful();
         $room->refresh();
         $this->assertEquals($settings['access_code'], $room->access_code);
 
         // Prevent downgrading to a 6-digit access code
-        $settings['access_code'] = "012345";
+        $settings['access_code'] = '012345';
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertJsonValidationErrors(['access_code']);
     }

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -529,7 +529,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
         // Try without access code
         $this->getJson(route('api.v1.rooms.show', ['room' => $room]))
@@ -542,7 +542,7 @@ class RoomTest extends TestCase
             ->assertUnauthorized();
 
         // Try with random access code
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         // Try with correct access code
@@ -612,7 +612,7 @@ class RoomTest extends TestCase
             ->assertJsonFragment(['current_user' => null]);
 
         // Test room with access code if the room type has no access code as default
-        $room->access_code = $this->faker->numberBetween(111111111, 999999999);
+        $room->access_code = (string) $this->faker->numberBetween(111111111, 999999999);
         $room->save();
         $roomType->has_access_code_default = false;
         $roomType->save();
@@ -650,7 +650,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         // Try without access code
@@ -664,7 +664,7 @@ class RoomTest extends TestCase
             ->assertUnauthorized();
 
         // Try with random access code
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->getJson(route('api.v1.rooms.show', ['room' => $room]))
             ->assertUnauthorized();
 
         // Try with correct access code
@@ -1626,7 +1626,7 @@ class RoomTest extends TestCase
     public function test_access_code_shown()
     {
         $room = Room::factory()->create([
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         // Testing unauthenticated user
@@ -1753,7 +1753,7 @@ class RoomTest extends TestCase
         ]);
 
         // Test without allow guests enforced in room type
-        $settings['access_code'] = $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
         $settings['room_type'] = $roomType->id;
         $settings['expert_mode'] = false;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -1863,7 +1863,7 @@ class RoomTest extends TestCase
             'auto_start_recording_default' => false,
         ]);
 
-        $settings['access_code'] = $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
         $settings['expert_mode'] = false;
         $settings['room_type'] = $roomType->id;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -2017,7 +2017,7 @@ class RoomTest extends TestCase
             'restrict' => false,
         ]);
 
-        $settings['access_code'] = $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
         $settings['expert_mode'] = true;
         $settings['room_type'] = $roomType->id;
         $settings['name'] = RoomFactory::createValidRoomName();
@@ -2154,7 +2154,7 @@ class RoomTest extends TestCase
             'has_access_code_enforced' => true,
         ]);
 
-        $settings['access_code'] = $this->faker->numberBetween(111111111, 999999999);
+        $settings['access_code'] = (string) $this->faker->numberBetween(111111111, 999999999);
         $settings['room_type'] = $roomType->id;
         $this->putJson(route('api.v1.rooms.update', ['room' => $room]), $settings)
             ->assertJsonValidationErrors(['access_code']);
@@ -2548,7 +2548,7 @@ class RoomTest extends TestCase
     public function test_start_restricted_no_server()
     {
         $room = Room::factory()->create([
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         // Testing guests
@@ -2611,13 +2611,13 @@ class RoomTest extends TestCase
             'allow_guests' => true,
             'expert_mode' => true,
             'everyone_can_start' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
         ]);
 
         // Testing guests
         $this->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertJsonValidationErrors('name');
@@ -2650,7 +2650,7 @@ class RoomTest extends TestCase
         // Testing authorized users
         $this->actingAs($this->user)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
             ->assertStatus(CustomStatusCodes::NO_SERVER_AVAILABLE->value);
@@ -3122,7 +3122,7 @@ class RoomTest extends TestCase
     {
         $room = Room::factory()->create([
             'allow_guests' => true,
-            'access_code' => $this->faker->numberBetween(111111111, 999999999),
+            'access_code' => (string) $this->faker->numberBetween(111111111, 999999999),
             'expert_mode' => true,
             'record_attendance' => true,
         ]);
@@ -3293,7 +3293,7 @@ class RoomTest extends TestCase
         // Join as authorized users
         $this->actingAs($this->user)->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertForbidden();
-        $this->withHeaders(['Access-Code' => $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
+        $this->withHeaders(['Access-Code' => (string) $this->faker->numberBetween(111111111, 999999999)])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertUnauthorized();
         $this->withHeaders(['Access-Code' => $room->access_code])->postJson(route('api.v1.rooms.join', ['room' => $room]), ['consent_record_attendance' => true, 'consent_record' => false, 'consent_record_video' => false])
             ->assertSuccessful();

--- a/tests/Backend/TestCase.php
+++ b/tests/Backend/TestCase.php
@@ -90,7 +90,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function createAccessCode(int $digits = 9): string
     {
-       return $this->faker->numerify(Str::repeat('#', $digits));
+        return $this->faker->numerify(Str::repeat('#', $digits));
     }
 
     protected function tearDown(): void

--- a/tests/Backend/TestCase.php
+++ b/tests/Backend/TestCase.php
@@ -12,11 +12,15 @@ use App\Settings\ThemeSettings;
 use App\Settings\UserSettings;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Support\Str;
 use LdapRecord\Laravel\Testing\DirectoryEmulator;
 
 abstract class TestCase extends BaseTestCase
 {
+    use WithFaker;
+
     /**
      * Creates the application.
      *
@@ -82,6 +86,11 @@ abstract class TestCase extends BaseTestCase
         config(['metrics.redis.prefix' => $prefix]);
         $registry = $this->app->make(\App\Prometheus\CollectorRegistry::class);
         $registry->wipeStorage();
+    }
+
+    protected function createAccessCode(int $digits = 9): string
+    {
+       return $this->faker->numerify(Str::repeat('#', $digits));
     }
 
     protected function tearDown(): void

--- a/tests/Backend/Unit/Console/ImportGreenlight2Test.php
+++ b/tests/Backend/Unit/Console/ImportGreenlight2Test.php
@@ -194,9 +194,9 @@ class ImportGreenlight2Test extends TestCase
         $rooms[] = new GreenlightRoom(5, $users[4]->id, 'Test Room 5', 'abc-def-xyz-567');
         $rooms[] = new GreenlightRoom(6, $users[5]->id, 'Test Room 6', 'abc-def-xyz-678');
 
-        $rooms[] = new GreenlightRoom(7, $users[0]->id, 'Test Room 7', 'hij-klm-xyz-123', 123456, ['muteOnStart' => false, 'requireModeratorApproval' => true, 'anyoneCanStart' => false, 'joinModerator' => true]);
+        $rooms[] = new GreenlightRoom(7, $users[0]->id, 'Test Room 7', 'hij-klm-xyz-123', '012345', ['muteOnStart' => false, 'requireModeratorApproval' => true, 'anyoneCanStart' => false, 'joinModerator' => true]);
         $rooms[] = new GreenlightRoom(8, $users[0]->id, 'Test Room 8', 'hij-klm-xyz-234', null, ['muteOnStart' => true, 'requireModeratorApproval' => false, 'anyoneCanStart' => true, 'joinModerator' => false]);
-        $rooms[] = new GreenlightRoom(9, 99, 'Test Room 9', 'hij-klm-xyz-456', 123456);
+        $rooms[] = new GreenlightRoom(9, 99, 'Test Room 9', 'hij-klm-xyz-456', '012345');
         $rooms[] = new GreenlightRoom(10, $users[0]->id, 'Test Room 10', $existingRoom->id);
 
         // Create fake shared accesses
@@ -229,7 +229,7 @@ class ImportGreenlight2Test extends TestCase
             ->expectsOutput('+-------------+-----------------+-------------+')
             ->expectsOutput('| Name        | ID              | Access code |')
             ->expectsOutput('+-------------+-----------------+-------------+')
-            ->expectsOutput('| Test Room 9 | hij-klm-xyz-456 | 123456      |') // user was not found in greenlight DB
+            ->expectsOutput('| Test Room 9 | hij-klm-xyz-456 | 012345      |') // user was not found in greenlight DB
             ->expectsOutput('+-------------+-----------------+-------------+')
             ->expectsOutput('Importing shared room accesses')
             ->expectsOutput('3 created, 3 skipped (user or room not found)')
@@ -260,7 +260,7 @@ class ImportGreenlight2Test extends TestCase
         $this->assertNull(Room::find('abc-def-xyz-456')->access_code);
         $this->assertNull(Room::find('abc-def-xyz-567')->access_code);
         $this->assertNull(Room::find('abc-def-xyz-678')->access_code);
-        $this->assertEquals(123456, Room::find('hij-klm-xyz-123')->access_code);
+        $this->assertEquals('012345', Room::find('hij-klm-xyz-123')->access_code);
         $this->assertNull(Room::find('hij-klm-xyz-234')->access_code);
 
         // check room settings

--- a/tests/Backend/Unit/Console/helper/GreenlightRoom.php
+++ b/tests/Backend/Unit/Console/helper/GreenlightRoom.php
@@ -21,7 +21,7 @@ class GreenlightRoom
     /**
      * GreenlightRoom constructor.
      */
-    public function __construct(string $id, string $user_id, string $name, string $uid, ?int $access_code = null, array $room_settings = [], bool $deleted = false)
+    public function __construct(string $id, string $user_id, string $name, string $uid, ?string $access_code = null, array $room_settings = [], bool $deleted = false)
     {
         $this->id = $id;
         $this->user_id = $user_id;

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -349,6 +349,92 @@ describe("Room View general", function () {
     cy.get('[data-test="room-access-code-overlay"]').should("be.visible");
   });
 
+  it("room view with legacy access code", function () {
+    cy.fixture("room.json").then((room) => {
+      room.data.owner = {
+        id: 2,
+        name: "Max Doe",
+      };
+      room.data.legacy_code = true;
+      room.data.authenticated = false;
+      room.data.description = "<p>Test</p>";
+      room.data.allow_membership = true;
+
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+    });
+
+    cy.visit("/rooms/abc-def-123");
+
+    cy.wait("@roomRequest");
+
+    cy.title().should("eq", "Meeting One - PILOS Test");
+
+    // Check that access code input is shown correctly
+    cy.get('[data-test="room-access-code-overlay"]')
+      .should("be.visible")
+      .within(() => {
+        cy.contains("Meeting One").should("be.visible");
+        cy.contains("Max Doe").should("be.visible");
+        cy.contains("rooms.index.room_component.never_started").should(
+          "be.visible",
+        );
+        cy.contains("rooms.require_access_code").should("be.visible");
+
+        // Submit valid access code
+        cy.get("#access-code").type("012345");
+      });
+
+    cy.fixture("room.json").then((room) => {
+      room.data.owner = {
+        id: 2,
+        name: "Max Doe",
+      };
+      room.data.description = "<p>Test</p>";
+      room.data.allow_membership = true;
+
+      cy.intercept("GET", "api/v1/rooms/abc-def-123", {
+        statusCode: 200,
+        body: room,
+      }).as("roomRequest");
+    });
+
+    cy.get('[data-test="room-login-button"]').click();
+
+    cy.wait("@roomRequest").then((interception) => {
+      expect(interception.request.headers["access-code"]).to.eq("012345");
+    });
+
+    cy.get('[data-test="room-access-code-overlay"]').should("not.exist");
+
+    // Check that room Header is shown correctly
+    cy.contains("Meeting One").should("be.visible");
+    cy.contains("Max Doe").should("be.visible");
+    cy.contains("rooms.index.room_component.never_started").should(
+      "be.visible",
+    );
+
+    // Check that buttons are shown correctly
+    cy.get('[data-test="reload-room-button"]').should("be.visible");
+    cy.get('[data-test="room-join-membership-button"]').should("be.visible");
+    cy.get('[data-test="room-end-membership-button"]').should("not.exist");
+    cy.get('[data-test="room-favorites-button"]').should("be.visible");
+
+    // Check that tabs are shown correctly
+    cy.get("#tab-description").should("be.visible");
+    cy.get("#tab-members").should("not.exist");
+    cy.get("#tab-tokens").should("not.exist");
+    cy.get("#tab-files").should("be.visible");
+    cy.get("#tab-recordings").should("be.visible");
+    cy.get("#tab-history").should("not.exist");
+    cy.get("#tab-settings").should("not.exist");
+
+    // Check that the correct tab is shown
+    cy.contains("rooms.description.title").should("be.visible");
+  });
+
   it("room view as member", function () {
     cy.interceptRoomFilesRequest();
     cy.fixture("room.json").then((room) => {

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -1061,7 +1061,7 @@ describe("Rooms view settings", function () {
               expect(interception.request.body).to.eql({
                 name: "Meeting Two",
                 expert_mode: true,
-                access_code: parseInt(newAccessCodeValue),
+                access_code: newAccessCodeValue,
                 allow_guests: false,
                 short_description: "Short description two",
                 everyone_can_start: true,

--- a/tests/Frontend/fixtures/room.json
+++ b/tests/Frontend/fixtures/room.json
@@ -28,6 +28,7 @@
     "is_co_owner": false,
     "can_start": true,
     "access_code": 508307005,
+    "legacy_code": false,
     "room_type_invalid": false,
     "record_attendance": false,
     "record": false,


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Changed value range and randomness of access code generation
- Fixes support for legacy 6-digit access codes imported from Greenlight v2

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support legacy 6-digit access codes alongside 9-digit codes; added legacy_code in room details.
  - Dynamic access-code mask/placeholder in Rooms view; UI props and inputs now use string access codes.
  - Cryptographically secure access-code generation; input set to read-only.

- **Bug Fixes**
  - Validation updated to allow preserving existing 6-digit codes while enforcing digit rules.

- **Chores**
  - DB migration converting access_code to nullable string and normalizing values.

- **Tests**
  - Updated backend/e2e tests and added helpers to use string/legacy codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->