### PR TITLE
Fix negative floating point number in room expire email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Negative floating point number in room expire email ([#2476], [#2480])
+
 ## [v4.7.1] - 2025-09-10
 
 ### Changed
@@ -533,6 +537,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2279]: https://github.com/THM-Health/PILOS/pull/2279
 [#2282]: https://github.com/THM-Health/PILOS/pull/2282
 [#2433]: https://github.com/THM-Health/PILOS/pull/2433
+[#2476]: https://github.com/THM-Health/PILOS/issues/2476
+[#2480]: https://github.com/THM-Health/PILOS/pull/2480
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.7.1...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Notifications/RoomExpires.php
+++ b/app/Notifications/RoomExpires.php
@@ -74,7 +74,7 @@ class RoomExpires extends Notification implements ShouldQueue
         }
         // If room has a meeting, that was too long ago
         else {
-            $days = now()->diffInDays($lastMeeting->start);
+            $days = (int) now()->diffInDays($lastMeeting->start, absolute: true);
             $message->line(__('mail.room_expires.inactivity', ['name' => $this->room->name, 'date' => $createdAt, 'days' => $days]));
         }
 


### PR DESCRIPTION
# Fixes #2476

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fix negative floating point number in room expire email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Room expiration emails now display a correct, whole-number count of inactivity days.
  * Ensures consistent, non-negative values regardless of date order.
  * Improves clarity of the inactivity message by normalizing the day difference calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->