### PR TITLE
UX: Add tooltip to room details button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -609,6 +609,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2553]: https://github.com/THM-Health/PILOS/pull/2553
 [#2554]: https://github.com/THM-Health/PILOS/issues/2554
 [#2575]: https://github.com/THM-Health/PILOS/pull/2575
+[#2576]: https://github.com/THM-Health/PILOS/pull/2576
 [#2577]: https://github.com/THM-Health/PILOS/pull/2577
 [#2604]: https://github.com/THM-Health/PILOS/pull/2604
 [#2613]: https://github.com/THM-Health/PILOS/pull/2613

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Tooltip for the room info button ([#2576])
+
 ## [v4.9.0] - 2025-12-15
 
 ### Added

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -157,12 +157,12 @@ return [
         'only_favorites' => 'Only show favorites',
         'reset_filter' => 'Reset filter',
         'room_component' => [
-            'show_details' => 'Show room details',
             'details' => 'Details',
             'last_ran_till' => 'Last run until :date',
             'never_started' => 'Never started before',
             'open' => 'Open',
             'running_since' => 'Running since :date',
+            'show_details' => 'Show room details',
         ],
         'show_all' => 'All rooms',
         'show_own' => 'Own rooms',

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -157,6 +157,7 @@ return [
         'only_favorites' => 'Only show favorites',
         'reset_filter' => 'Reset filter',
         'room_component' => [
+            'show_details' =>  'Show room details',
             'details' => 'Details',
             'last_ran_till' => 'Last run until :date',
             'never_started' => 'Never started before',

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -157,7 +157,7 @@ return [
         'only_favorites' => 'Only show favorites',
         'reset_filter' => 'Reset filter',
         'room_component' => [
-            'show_details' =>  'Show room details',
+            'show_details' => 'Show room details',
             'details' => 'Details',
             'last_ran_till' => 'Last run until :date',
             'never_started' => 'Never started before',

--- a/resources/js/components/RoomCard.vue
+++ b/resources/js/components/RoomCard.vue
@@ -29,6 +29,8 @@
                   icon="fa-solid fa-info"
                   data-test="room-info-button"
                   @click.stop="modalVisible = true"
+                  v-tooltip="$t('rooms.index.room_component.show_details')"
+                  :aria-label="$t('rooms.index.room_component.show_details')"
                 />
                 <RoomFavoriteButton
                   :room="props.room"

--- a/resources/js/components/RoomCard.vue
+++ b/resources/js/components/RoomCard.vue
@@ -24,13 +24,13 @@
               <div class="relative z-10 flex shrink-0 gap-2">
                 <Button
                   v-if="props.room.short_description != null"
+                  v-tooltip="$t('rooms.index.room_component.show_details')"
                   severity="secondary"
                   class="room-card-button h-8 w-8 p-0 text-sm"
                   icon="fa-solid fa-info"
                   data-test="room-info-button"
-                  @click.stop="modalVisible = true"
-                  v-tooltip="$t('rooms.index.room_component.show_details')"
                   :aria-label="$t('rooms.index.room_component.show_details')"
+                  @click.stop="modalVisible = true"
                 />
                 <RoomFavoriteButton
                   :room="props.room"


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.): **UX**
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Added tooltip to room details button
- Added aria-label to room details button

## Other information

Motivation: To improve learnability, all icon-only buttons should have a tooltip explaining the button's action.

Before
<img width="537" height="177" alt="image" src="https://github.com/user-attachments/assets/6fe91094-979e-4dbc-aa1b-25d024eb71ae" />

After
<img width="537" height="177" alt="image" src="https://github.com/user-attachments/assets/02985608-5407-4d91-9cbd-cb95c3b53e4a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip on the room info button that displays "Show room details" to provide contextual help.
  * Improved accessibility: added semantic labels for assistive technologies and screen readers to make room details easier to discover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->