### PR TITLE
UX: Change style of cards on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Sun & moon icon in the menu bar ([#2575])
+- Hover style of buttons in room cards ([#2577])
 
 ### Fixed
 
@@ -600,6 +601,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2553]: https://github.com/THM-Health/PILOS/pull/2553
 [#2554]: https://github.com/THM-Health/PILOS/issues/2554
 [#2575]: https://github.com/THM-Health/PILOS/pull/2575
+[#2577]: https://github.com/THM-Health/PILOS/pull/2577
 [#2604]: https://github.com/THM-Health/PILOS/pull/2604
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.8.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/resources/css/app/_room.css
+++ b/resources/css/app/_room.css
@@ -1,3 +1,17 @@
+.room-card {
+    @apply transition-colors duration-200;
+
+    &:hover {
+        .room-card-button.p-button-secondary {
+            @apply border-surface-200 bg-surface-200 text-surface-700 transition-colors duration-200 dark:border-surface-700 dark:bg-surface-700 dark:text-surface-200;
+
+            &:hover {
+                @apply border-surface-300 bg-surface-300 text-surface-800 dark:border-surface-600 dark:bg-surface-600 dark:text-surface-100;
+            }
+        }
+    }
+}
+
 .room-details__icon {
     width: 1.5rem;
     margin-right: 0.5rem;

--- a/resources/js/components/RoomCard.vue
+++ b/resources/js/components/RoomCard.vue
@@ -4,7 +4,7 @@
     <div
       tabindex="0"
       data-test="room-card"
-      class="relative h-full rounded-border border border-surface shadow-none hover:bg-emphasis"
+      class="room-card relative h-full rounded-border border border-surface shadow-none hover:bg-emphasis"
       @click="open"
       @keyup.enter="open"
     >
@@ -25,14 +25,14 @@
                 <Button
                   v-if="props.room.short_description != null"
                   severity="secondary"
-                  class="h-8 w-8 p-0 text-sm"
+                  class="room-card-button h-8 w-8 p-0 text-sm"
                   icon="fa-solid fa-info"
                   data-test="room-info-button"
                   @click.stop="modalVisible = true"
                 />
                 <RoomFavoriteButton
                   :room="props.room"
-                  class="h-8 w-8 p-0 text-sm"
+                  class="room-card-button h-8 w-8 p-0 text-sm"
                   @favorites-changed="$emit('favoritesChanged')"
                 />
               </div>


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. **Style updates**, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Changes hover style of button in room cards

## Other information

Motivation: Improved visibility of buttons when hovering over the card. Previously, the background and button were the same when hovering, so users might not have recognized that this was a clickable element.

Before
<img width="376" height="172" alt="image" src="https://github.com/user-attachments/assets/7371bd6f-17a9-4988-955e-324899656995" />

After
<img width="376" height="172" alt="image" src="https://github.com/user-attachments/assets/635bbbf7-d34e-4ca2-8f84-5d05a9edbeda" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated hover styling for buttons in room cards to provide clearer visual feedback, consistent transitions, and adjusted colors for both light and dark modes.
* **Documentation**
  * Added an entry to the unreleased changelog documenting the room card button hover style update and referenced the related pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->