### PR TITLE
Change recording resource path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sun & moon icon in the menu bar ([#2575])
 - Hover style of buttons in room cards ([#2577])
+- URL for loading BBB recording player resources ([#2616])
 
 ### Fixed
 
@@ -603,6 +604,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2575]: https://github.com/THM-Health/PILOS/pull/2575
 [#2577]: https://github.com/THM-Health/PILOS/pull/2577
 [#2604]: https://github.com/THM-Health/PILOS/pull/2604
+[#2616]: https://github.com/THM-Health/PILOS/pull/2616
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.8.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Http/Controllers/RecordingController.php
+++ b/app/Http/Controllers/RecordingController.php
@@ -10,6 +10,11 @@ use ZipStream\ZipStream;
 
 class RecordingController extends Controller
 {
+    public function presentationResource(Recording $recording, string $resource = 'index.html'): \Illuminate\Http\Response
+    {
+        return $this->resource('presentation', $recording, $resource);
+    }
+
     public function resource(string $formatName, Recording $recording, string $resource = 'index.html'): \Illuminate\Http\Response
     {
         // Get format with the given name of the recording

--- a/app/Http/Controllers/RecordingController.php
+++ b/app/Http/Controllers/RecordingController.php
@@ -10,7 +10,7 @@ use ZipStream\ZipStream;
 
 class RecordingController extends Controller
 {
-    public function presentationResource(Recording $recording, string $resource = 'index.html'): \Illuminate\Http\Response
+    public function presentationResource(Recording $recording, string $resource): \Illuminate\Http\Response
     {
         return $this->resource('presentation', $recording, $resource);
     }

--- a/docker/app/playback-player/build.sh
+++ b/docker/app/playback-player/build.sh
@@ -32,7 +32,7 @@ if unzip -q -d "$temporaryDirectory" "$downloadFileName"; then
         exit 2
     fi
     npm install
-    REACT_APP_MEDIA_ROOT_URL=/recording/presentation npm run build
+    npm run build
 
     # clear old public folder
     echo "Clearing old player..."

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::get('download/recording/{recording}', [RecordingController::class, 'downl
 
 // Do not change this url format! Needs to be in this format in order to be compatible with the BBB recording player
 Route::get('recording/{formatName}/{recording}/{resource?}', [RecordingController::class, 'resource'])->where('resource', '.*')->name('recording.resource');
-Route::get('presentation/{recording}/{resource?}', [RecordingController::class, 'presentationResource'])->where('resource', '.*')->name('recording.presentation');
+Route::get('presentation/{recording}/{resource}', [RecordingController::class, 'presentationResource'])->name('recording.presentation');
 
 Route::middleware('enable_if_config:services.shibboleth.enabled')->group(function () {
     Route::get('auth/shibboleth/redirect', [ShibbolethController::class, 'redirect'])->name('auth.shibboleth.redirect');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,8 +22,8 @@ Route::get('download/file/{roomFile}/{filename?}', [FileController::class, 'show
 Route::get('download/attendance/{meeting}', [MeetingController::class, 'attendance'])->name('download.attendance')->middleware('auth:users,ldap');
 Route::get('download/recording/{recording}', [RecordingController::class, 'download'])->middleware('auth:users,ldap')->name('recording.download');
 
-// Do not change this url format! Needs to be in this format in order to be compatible with the BBB recording player
 Route::get('recording/{formatName}/{recording}/{resource?}', [RecordingController::class, 'resource'])->where('resource', '.*')->name('recording.resource');
+// Do not change this url! Needs to be in this format to be compatible with the BBB recording player
 Route::get('presentation/{recording}/{resource}', [RecordingController::class, 'presentationResource'])->name('recording.presentation');
 
 Route::middleware('enable_if_config:services.shibboleth.enabled')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::get('download/recording/{recording}', [RecordingController::class, 'downl
 
 Route::get('recording/{formatName}/{recording}/{resource?}', [RecordingController::class, 'resource'])->where('resource', '.*')->name('recording.resource');
 // Do not change this url! Needs to be in this format to be compatible with the BBB recording player
-Route::get('presentation/{recording}/{resource}', [RecordingController::class, 'presentationResource'])->name('recording.presentation');
+Route::get('presentation/{recording}/{resource}', [RecordingController::class, 'presentationResource'])->where('resource', '.*')->name('recording.presentation');
 
 Route::middleware('enable_if_config:services.shibboleth.enabled')->group(function () {
     Route::get('auth/shibboleth/redirect', [ShibbolethController::class, 'redirect'])->name('auth.shibboleth.redirect');

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ Route::get('download/recording/{recording}', [RecordingController::class, 'downl
 
 // Do not change this url format! Needs to be in this format in order to be compatible with the BBB recording player
 Route::get('recording/{formatName}/{recording}/{resource?}', [RecordingController::class, 'resource'])->where('resource', '.*')->name('recording.resource');
+Route::get('presentation/{recording}/{resource?}', [RecordingController::class, 'presentationResource'])->where('resource', '.*')->name('recording.presentation');
 
 Route::middleware('enable_if_config:services.shibboleth.enabled')->group(function () {
     Route::get('auth/shibboleth/redirect', [ShibbolethController::class, 'redirect'])->name('auth.shibboleth.redirect');

--- a/tests/Backend/Feature/api/v1/RecordingTest.php
+++ b/tests/Backend/Feature/api/v1/RecordingTest.php
@@ -591,6 +591,8 @@ class RecordingTest extends TestCase
 
     public function test_show_url()
     {
+        Storage::fake('recordings');
+
         $format = RecordingFormat::factory()->create(['format' => 'podcast']);
         $recording = $format->recording;
         $room = $recording->room;
@@ -606,12 +608,19 @@ class RecordingTest extends TestCase
         $recording = $format->recording;
         $room = $recording->room;
 
+        UploadedFile::fake()->create('metadata.xml', 100, 'application/xml')->storeAs($recording->id.'/presentation', 'metadata.xml', 'recordings');
+
         config(['recording.player' => 'https://example.com/player']);
 
         $this->actingAs($room->owner)
             ->getJson(route('api.v1.rooms.recordings.formats.show', ['room' => $recording->room->id, 'recording' => $recording->id, 'format' => $format->id]))
             ->assertOk()
             ->assertJson(['url' => 'https://example.com/player/'.$recording->id.'/']);
+
+        // Access presentation files (requested by the player)
+        $this->actingAs($room->owner)
+            ->get(route('recording.presentation', ['recording' => $recording->id, 'resource' => 'metadata.xml']))
+            ->assertHeader('x-accel-redirect', '/private-storage/recordings/'.$recording->id.'/presentation/metadata.xml');
     }
 
     public function test_update()
@@ -886,10 +895,7 @@ class RecordingTest extends TestCase
         // Create format
         $notes = RecordingFormat::factory()->create(['recording_id' => $recording->id, 'format' => 'notes']);
 
-        // Create folder with recording files
-        Storage::disk('recordings')->makeDirectory($recording->id);
-        Storage::disk('recordings')->makeDirectory($recording->id.'/notes');
-        Storage::disk('recordings')->makeDirectory($recording->id.'/podcast');
+        // Create recording files
         UploadedFile::fake()->create('notes.pdf', 100, 'application/pdf')->storeAs($recording->id.'/notes', 'notes.pdf', 'recordings');
         UploadedFile::fake()->create('audio.ogg', 100, 'audio/ogg')->storeAs($recording->id.'/podcast', 'audio.ogg', 'recordings');
 


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Changed internal routing of recording player resource urls to BBB default

## Other information

This change allows the usage of regular bbb-playback players, by overwriting the url on the reverse proxy layer and proxying the traffic to a dedicated host. This change is backward compatible.

```nginx
location /playback/presentation/2.3/ {
    proxy_pass http://playback.example.org;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated presentation route and endpoint to access recording presentation resources directly.

* **Tests**
  * Expanded tests to cover presentation file access and verify correct HTTP header responses.

* **Chores**
  * Simplified the playback player build command by removing an environment variable from the build invocation.

* **Documentation**
  * Updated changelog entry for the changed URL used by the recording player.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->