### PR TITLE
Add info about room name limit

### DIFF
--- a/docs/docs/administration/03-configuration.md
+++ b/docs/docs/administration/03-configuration.md
@@ -122,7 +122,7 @@ To enable external authentication methods like LDAP, please refer to the [Extern
 | Option                   | Default Value | Description                                                   |
 | ------------------------ | ------------- | ------------------------------------------------------------- |
 | `WELCOME_MESSAGE_LIMIT`  | `500`         | Maximum length of room welcome message. (max. 5000)           |
-| `ROOM_NAME_LIMIT`        | `50`          | Maximum length of room name.                                  |
+| `ROOM_NAME_LIMIT`        | `50`          | Maximum length of room name. (max. 256)                       |
 | `ROOM_REFRESH_RATE`      | `5`           | Base time in seconds to automatically reload room page.       |
 | `USER_SEARCH_LIMIT`      | `10`          | Maximum amount of users to be shown in user search            |
 | `HIDE_DISABLED_FEATURES` | `true`        | Hide all disabled features from the UI (currently: streaming) |


### PR DESCRIPTION
The room name is [limited](https://github.com/THM-Health/PILOS/blob/develop/database/migrations/2022_07_21_000012_create_rooms_table.php#L19) to 256 characters. This MR adds this information to the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation to clarify the maximum room name length constraint (256 characters).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->