### PR TITLE
Fix icon alignment in room tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tooltip for the room info button ([#2576])
 
+### Fixed
+
+- Icon alignment inside room tabs ([#2660], [#2686])
+
 ## [v4.9.0] - 2025-12-15
 
 ### Added
@@ -614,6 +618,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2604]: https://github.com/THM-Health/PILOS/pull/2604
 [#2613]: https://github.com/THM-Health/PILOS/pull/2613
 [#2616]: https://github.com/THM-Health/PILOS/pull/2616
+[#2660]: https://github.com/THM-Health/PILOS/issues/2660
+[#2686]: https://github.com/THM-Health/PILOS/pull/2686
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.9.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/components/RoomTabFiles.vue
+++ b/resources/js/components/RoomTabFiles.vue
@@ -200,7 +200,7 @@
                     {{ item.filename }}
                   </p>
                   <div class="flex flex-col items-start gap-2">
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-clock" />
                       <p class="m-0 text-sm">
                         {{ $d(new Date(item.uploaded), "datetimeLong") }}
@@ -211,7 +211,7 @@
                     v-if="userPermissions.can('manageSettings', props.room)"
                     class="flex flex-col items-start gap-2"
                   >
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-download" />
                       <p class="m-0 text-sm">
                         <Tag v-if="item.download" severity="success">{{
@@ -227,7 +227,7 @@
                     v-if="userPermissions.can('manageSettings', props.room)"
                     class="flex flex-col items-start gap-2"
                   >
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i
                         v-if="item.use_in_meeting"
                         class="fa-solid fa-circle-check"

--- a/resources/js/components/RoomTabHistory.vue
+++ b/resources/js/components/RoomTabHistory.vue
@@ -112,7 +112,7 @@
                     {{ $d(new Date(item.start), "datetimeShort") }}
                   </p>
                   <div class="flex flex-col items-start gap-2">
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-hourglass" />
                       <p
                         v-tooltip.bottom="

--- a/resources/js/components/RoomTabMembers.vue
+++ b/resources/js/components/RoomTabMembers.vue
@@ -217,13 +217,13 @@
                       {{ item.firstname }} {{ item.lastname }}
                     </p>
                     <div class="flex flex-col items-start gap-2">
-                      <div class="flex flex-row gap-2">
+                      <div class="flex flex-row items-center gap-2">
                         <i class="fa-solid fa-envelope" />
                         <p class="text-word-break m-0 text-sm">
                           {{ item.email }}
                         </p>
                       </div>
-                      <div class="flex flex-row gap-2">
+                      <div class="flex flex-row items-center gap-2">
                         <i class="fa-solid fa-user-tag"></i>
                         <RoomRoleBadge :role="item.role" />
                       </div>

--- a/resources/js/components/RoomTabPersonalizedLinks.vue
+++ b/resources/js/components/RoomTabPersonalizedLinks.vue
@@ -158,7 +158,7 @@
                     {{ item.firstname }} {{ item.lastname }}
                   </p>
                   <div class="flex flex-col items-start gap-2">
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-clock" />
                       <p class="m-0 text-sm">
                         <span v-if="item.last_usage == null">{{
@@ -176,7 +176,7 @@
                     </div>
                     <div
                       v-if="item.expires !== null"
-                      class="flex flex-row gap-2"
+                      class="flex flex-row items-center gap-2"
                     >
                       <i class="fa-regular fa-calendar-xmark"></i>
                       <p class="m-0 text-sm">
@@ -187,7 +187,7 @@
                         }}
                       </p>
                     </div>
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-user-tag"></i>
                       <RoomRoleBadge :role="item.role" />
                     </div>

--- a/resources/js/components/RoomTabRecordings.vue
+++ b/resources/js/components/RoomTabRecordings.vue
@@ -152,13 +152,13 @@
                     {{ item.description }}
                   </p>
                   <div class="flex flex-col items-start gap-2">
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-clock" />
                       <p class="m-0 text-sm">
                         {{ $d(new Date(item.start), "datetimeShort") }}
                       </p>
                     </div>
-                    <div class="flex flex-row gap-2">
+                    <div class="flex flex-row items-center gap-2">
                       <i class="fa-solid fa-hourglass" />
                       <p
                         v-tooltip.bottom="
@@ -180,7 +180,7 @@
                     </div>
                     <div
                       v-if="userPermissions.can('manageSettings', props.room)"
-                      class="flex flex-row gap-2"
+                      class="flex flex-row items-center gap-2"
                     >
                       <i class="fa-solid fa-lock"></i>
                       <RoomRecordingAccessBadge :access="item.access" />


### PR DESCRIPTION
# Fixes #2660

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixes icon alignment inside room tabs

## Other information

**Before**
<img width="283" height="142" alt="image" src="https://github.com/user-attachments/assets/5be43d3c-efea-4d62-a768-8a9632516a34" />

**After**
<img width="283" height="142" alt="image" src="https://github.com/user-attachments/assets/7feac9ba-3a3e-400c-96b0-f7864d9ac5de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment of icons and text across room tabs (files, history, members, personalized links, recordings) for a cleaner, more consistent UI.

* **Documentation**
  * Updated changelog to note icon alignment fixes in room tabs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->