### PR TITLE
Fix race condition on room start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Icon alignment inside room files tab ([#2660], [#2728])
+- Race condition during room start ([#2742])
 
 ## [v4.10.0] - 2026-01-12
 
@@ -636,6 +637,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2660]: https://github.com/THM-Health/PILOS/issues/2660
 [#2686]: https://github.com/THM-Health/PILOS/pull/2686
 [#2728]: https://github.com/THM-Health/PILOS/pull/2728
+[#2742]: https://github.com/THM-Health/PILOS/pull/2742
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.10.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Services/RoomService.php
+++ b/app/Services/RoomService.php
@@ -37,7 +37,8 @@ class RoomService
             // Block the lock for a max. of 45sec
             $lock->block($timeout);
 
-            // Get latest of the room
+            // Get latest meeting of the room
+            $this->room->refresh();
             $meeting = $this->room->latestMeeting;
 
             // Do not create a new meeting, if there is already a running meeting and it is not detached

--- a/tests/Backend/Feature/api/v1/Room/RoomTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomTest.php
@@ -22,6 +22,7 @@ use App\Services\ServerService;
 use Database\Factories\RoomFactory;
 use Database\Seeders\RolesAndPermissionsSeeder;
 use Http;
+use Illuminate\Cache\Lock;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -3126,8 +3127,9 @@ class RoomTest extends TestCase
 
     /**
      * Tests parallel starting of the same room
+     * The lock if not released within the timeout
      */
-    public function test_start_while_starting()
+    public function test_start_while_starting_lock_not_released()
     {
         config(['bigbluebutton.server_timeout' => 2]);
         config(['bigbluebutton.server_connect_timeout' => 2]);
@@ -3147,6 +3149,59 @@ class RoomTest extends TestCase
         } catch (LockTimeoutException $e) {
             $this->fail('lock did not work');
         }
+    }
+
+    /**
+     * Tests parallel starting of the same room
+     * The lock is released within the timeout because another request started the meeting
+     * and released the lock before the timeout is reached
+     */
+    public function test_start_while_starting_lock_released()
+    {
+        config(['bigbluebutton.server_timeout' => 2]);
+        config(['bigbluebutton.server_connect_timeout' => 2]);
+        $room = Room::factory()->create();
+        $timeout = config('bigbluebutton.server_timeout') + config('bigbluebutton.server_connect_timeout');
+
+        $server = Server::factory()->create();
+        $room->roomType->serverPool->servers()->attach($server);
+
+        $lock = \Mockery::mock(Lock::class);
+
+        Cache::shouldReceive('lock')
+            ->once()
+            ->with('startroom-'.$room->id, $timeout)
+            ->andReturn($lock);
+
+        // Simulate another request starts the room and releases the lock
+        $lock->shouldReceive('block')
+            ->once()
+            ->with($timeout)
+            ->andReturnUsing(function () use ($server, $room) {
+                $meeting = new Meeting;
+                $meeting->record_attendance = false;
+                $meeting->record = false;
+                $meeting->server()->associate($server);
+                $meeting->room()->associate($room);
+                $meeting->start = date('Y-m-d H:i:s');
+                $meeting->save();
+                $room->latestMeeting()->associate($meeting);
+                $room->save();
+
+                return true;
+            });
+
+        $lock->shouldReceive('release')
+            ->once()
+            ->andReturnTrue();
+
+        // Try to start the room
+        // At the beginning of the request no meeting is running
+        // the request waits for the lock to be released
+        // when the lock is released a meeting is now running
+        // so the request should fail with the proper status code
+        $this->actingAs($room->owner)->postJson(route('api.v1.rooms.start', ['room' => $room]), ['consent_record_attendance' => false, 'consent_record' => false, 'consent_record_video' => false])
+            ->assertStatus(474);
     }
 
     /**


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixes race condition on room start

## Other information
Without refreshing the room model, the second request will have an outdated state of the model once the lock has been released, as the data was fetched from the database before the first request started the room. By reloading the room model from the db, we now have the latest state of the model and decide how to handle another start request - in most cases we will reject, as the room is already running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure room state is refreshed before checking for an active meeting to prevent showing outdated meeting info.

* **Tests**
  * Added and refined tests covering parallel start/lock scenarios to validate correct behavior when concurrent starts occur.

* **Chore**
  * Updated changelog with an entry noting the race condition fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->