### PR TITLE
[5.0] Bump mariadb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - 5432
 
       mariadb:
-        image: mariadb:11
+        image: mariadb:12
         ports:
           - 3306
         env:

--- a/.github/workflows/pull-locales.yml
+++ b/.github/workflows/pull-locales.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:11
+        image: mariadb:12
         ports:
           - 3306
         env:

--- a/.github/workflows/upload-locales.yml
+++ b/.github/workflows/upload-locales.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:11
+        image: mariadb:12
         ports:
           - 3306
         env:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -21,7 +21,7 @@ services:
       redis:
         condition: service_healthy
   db:
-    image: "mariadb:11"
+    image: "mariadb:12"
     environment:
       MARIADB_DATABASE: "app"
       MARIADB_USER: "user"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -67,7 +67,7 @@ services:
       app:
         condition: service_healthy
   db:
-    image: "mariadb:11"
+    image: "mariadb:12"
     environment:
       MARIADB_ROOT_PASSWORD: "${DB_PASSWORD}"
       MARIADB_ROOT_HOST: "%"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       app:
         condition: service_healthy
   db:
-    image: "mariadb:11"
+    image: "mariadb:12"
     restart: unless-stopped
     environment:
       MARIADB_DATABASE: "${DB_DATABASE}"

--- a/docs/docs/administration/05-upgrade.md
+++ b/docs/docs/administration/05-upgrade.md
@@ -203,12 +203,12 @@ All new installations will use this version, existing installations will not be 
 
 To upgrade your MariaDB container, you need to edit your `docker-compose.yml` file:
 
-- Change the MariaDB image tag to `11`.
+- Change the MariaDB image tag to `12`.
 - Add a new environment variable `MARIADB_AUTO_UPGRADE` to trigger the service to upgrade the database:
 
     ```yaml
     db:
-        image: "mariadb:11"
+        image: "mariadb:12"
         environment:
             MARIADB_AUTO_UPGRADE: 1
     ```


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **Bump docker service image version**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Bump mariadb version in docker compose files

## Other information
Bumping database versions in production isn’t recommended.

The most secure process is to export the database, upgrade the container service version and then import it back.
However MariaDB also supports DB upgrades, see: https://thm-health.github.io/PILOS/docs/administration/upgrade#upgrade-mariadb-container-optional

The DB upgrade would not effect production installations as changes to the docker compose file are not applied, but it would for all dev. instances.

As MariaDB 11.8 (LTS) is still supported until 04 Jun 2028 we will wait with the official change for the next major release of PILOS.