### PR TITLE
Add 'nofollow' directive to X-Robots-Tag header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable hashing algorithm for BBB API signatures ([#2765], [#2766])
-- `X-Robots-Tag: noindex` for all routes, excluding the landing page ([#2770])
+- `X-Robots-Tag: noindex` header for all routes, excluding the landing page ([#2770])
+- `X-Robots-Tag: nofollow` header for all routes ([#2772])
 
 ### Changed
 
@@ -656,6 +657,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2767]: https://github.com/THM-Health/PILOS/pull/2767
 [#2769]: https://github.com/THM-Health/PILOS/pull/2769
 [#2770]: https://github.com/THM-Health/PILOS/pull/2770
+[#2772]: https://github.com/THM-Health/PILOS/pull/2772
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.10.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable hashing algorithm for BBB API signatures ([#2765], [#2766])
-- `X-Robots-Tag: noindex` header for all routes, excluding the landing page ([#2770])
-- `X-Robots-Tag: nofollow` header for all routes ([#2772])
+- `X-Robots-Tag: noindex` header for all web routes, excluding the landing page ([#2770])
+- `X-Robots-Tag: nofollow` header for all web routes ([#2772])
 
 ### Changed
 

--- a/app/Http/Middleware/RobotsHeader.php
+++ b/app/Http/Middleware/RobotsHeader.php
@@ -15,7 +15,9 @@ class RobotsHeader
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $directives = [];
+        // Do not follow any links on the page
+        // e.g. links in the footer, menu, etc.
+        $directives = ['nofollow'];
 
         // Add noindex to all requests except for the landing page "/"
         if ($request->path() !== '/') {
@@ -26,7 +28,7 @@ class RobotsHeader
 
         // If any directives were added, set the X-Robots-Tag header
         if ($directives) {
-            $response->headers->set('X-Robots-Tag', implode(',', $directives));
+            $response->headers->set('X-Robots-Tag', implode(', ', $directives));
         }
 
         return $response;

--- a/tests/Backend/Feature/RobotsHeaderTest.php
+++ b/tests/Backend/Feature/RobotsHeaderTest.php
@@ -10,7 +10,7 @@ class RobotsHeaderTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * Test that the landing page does not have X-Robots-Tag header.
+     * Test that the landing page only has the nofollow X-Robots-Tag.
      */
     public function test_landing_page_robots_header()
     {
@@ -33,7 +33,8 @@ class RobotsHeaderTest extends TestCase
     }
 
     /**
-     * Test that frontend routes (except the landing page) have X-Robots-Tag header.
+     * Test that frontend routes (except the landing page) have X-Robots-Tag header
+     * with nofollow and noindex directives.
      */
     public function test_frontend_routes_robots_header()
     {

--- a/tests/Backend/Feature/RobotsHeaderTest.php
+++ b/tests/Backend/Feature/RobotsHeaderTest.php
@@ -12,12 +12,13 @@ class RobotsHeaderTest extends TestCase
     /**
      * Test that the landing page does not have X-Robots-Tag header.
      */
-    public function test_landing_page_no_robots_header()
+    public function test_landing_page_robots_header()
     {
         $response = $this->get('/');
         $response->assertOk();
 
-        $this->assertFalse($response->headers->has('X-Robots-Tag'));
+        $this->assertTrue($response->headers->has('X-Robots-Tag'));
+        $this->assertEquals('nofollow', $response->headers->get('X-Robots-Tag'));
     }
 
     /**
@@ -40,6 +41,6 @@ class RobotsHeaderTest extends TestCase
         $response->assertOk();
 
         $this->assertTrue($response->headers->has('X-Robots-Tag'));
-        $this->assertEquals('noindex', $response->headers->get('X-Robots-Tag'));
+        $this->assertEquals('nofollow, noindex', $response->headers->get('X-Robots-Tag'));
     }
 }


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.): SEO
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- `X-Robots-Tag: nofollow` for all routes

## Other information
Add 'nofollow' to X-Robots-Tag header in RobotsHeader middleware to prevent search engines from following links on pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * X-Robots-Tag headers refined: landing page now sends "nofollow"; all other web pages send "nofollow, noindex" to control indexing and link-following.
* **Tests**
  * Backend tests updated to reflect the new header presence and values for landing and frontend routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->