### PR TITLE
Do not send ContentType with empty GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Icon alignment inside room files tab ([#2660], [#2728])
 - Race condition during room start ([#2742])
+- Remove unnecessary `Content-Type` header from GET requests to the BigBlueButton API ([#2774], [#2775])
 
 ## [v4.10.0] - 2026-01-12
 
@@ -662,6 +663,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2769]: https://github.com/THM-Health/PILOS/pull/2769
 [#2770]: https://github.com/THM-Health/PILOS/pull/2770
 [#2772]: https://github.com/THM-Health/PILOS/pull/2772
+[#2774]: https://github.com/THM-Health/PILOS/issues/2774
+[#2775]: https://github.com/THM-Health/PILOS/pull/2775
 [#2789]: https://github.com/THM-Health/PILOS/pull/2789
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.10.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/app/Services/BigBlueButton/LaravelHTTPClient.php
+++ b/app/Services/BigBlueButton/LaravelHTTPClient.php
@@ -42,7 +42,6 @@ final class LaravelHTTPClient implements TransportInterface
                     ->post($request->getUrl());
             } else {
                 $httpResponse = $this->httpClient
-                    ->contentType($request->getContentType())
                     ->get($request->getUrl());
             }
         } catch (ConnectionException $e) {

--- a/tests/Backend/Unit/MeetingTest.php
+++ b/tests/Backend/Unit/MeetingTest.php
@@ -197,9 +197,6 @@ class MeetingTest extends TestCase
         $request = Http::recorded()[0][0];
         $data = $request->data();
 
-        // Check content type of body
-        $this->assertEquals('application/xml', $request->header('Content-Type')[0]);
-
         $this->assertEquals(url('logo.png'), $data['logo']);
 
         // Check dark logo missing

--- a/tests/Backend/Unit/MeetingTest.php
+++ b/tests/Backend/Unit/MeetingTest.php
@@ -63,6 +63,11 @@ class MeetingTest extends TestCase
         $request = Http::recorded()[0][0];
         $data = $request->data();
 
+        // Check request is GET and has no content type and body
+        $this->assertEquals('GET', $request->method());
+        $this->assertFalse($request->hasHeader('Content-Type'));
+        $this->assertEmpty($request->body());
+
         $this->assertEquals($meeting->id, $data['meetingID']);
         $this->assertEquals($meeting->room->name, $data['name']);
         $this->assertEquals(url('rooms/'.$meeting->room->id), $data['logoutURL']);
@@ -273,7 +278,8 @@ class MeetingTest extends TestCase
 
         $this->assertCount(3, $docs);
 
-        // Check content type of body
+        // Check request is POST and has content type and body
+        $this->assertEquals('POST', $request->method());
         $this->assertEquals('application/xml', $request->header('Content-Type')[0]);
 
         // check order based on default and missing file 4 because use_in_meeting disabled


### PR DESCRIPTION
GET requests usually cannot have a body, and thus also should not have a Content-Type header.

# Fixes #2774

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary Content-Type header on requests without a payload, improving interoperability with services that expect no Content-Type for GET/no-body calls.
* **Tests**
  * Updated unit test expectations to reflect the absence of a Content-Type header for no-payload requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->