### PR TITLE
Remove robots.txt, Add robots middleware to api routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable hashing algorithm for BBB API signatures ([#2765], [#2766])
-- `X-Robots-Tag: noindex` header for all web routes, excluding the landing page ([#2770])
-- `X-Robots-Tag: nofollow` header for all web routes ([#2772])
+- `X-Robots-Tag: noindex` header for all routes, excluding the landing page ([#2770], [#2789])
+- `X-Robots-Tag: nofollow` header for all routes ([#2772], [#2789])
 
 ### Changed
 
 - External authentication routes behavior for authenticated users ([#2751], [#2752])
 - Bump redis version in docker compose files to redis 8 ([#2767])
 - Docs: Bumped the recommended PostgreSQL version to v18 ([#2769])
+
+### Removed
+
+- robots.txt file ([#2789])
 
 ### Fixed
 
@@ -658,6 +662,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2769]: https://github.com/THM-Health/PILOS/pull/2769
 [#2770]: https://github.com/THM-Health/PILOS/pull/2770
 [#2772]: https://github.com/THM-Health/PILOS/pull/2772
+[#2789]: https://github.com/THM-Health/PILOS/pull/2789
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.10.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -30,6 +30,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         RequestMetricsMiddleware::class,
+        RobotsHeader::class,
     ];
 
     /**
@@ -50,7 +51,6 @@ class Kernel extends HttpKernel
             'loggedin:ldap,users',
             StoreSessionData::class,
             LogContext::class,
-            RobotsHeader::class,
         ],
 
         'api' => [

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:

--- a/tests/Backend/Feature/RobotsHeaderTest.php
+++ b/tests/Backend/Feature/RobotsHeaderTest.php
@@ -22,14 +22,16 @@ class RobotsHeaderTest extends TestCase
     }
 
     /**
-     * Test that API routes do not have X-Robots-Tag header (middleware not in 'api' group).
+     * Test that API routes have X-Robots-Tag header
+     * with nofollow and noindex directives
      */
-    public function test_api_routes_no_robots_header()
+    public function test_api_routes_robots_header()
     {
         $response = $this->getJson('/api/v1/config');
         $response->assertOk();
 
-        $this->assertFalse($response->headers->has('X-Robots-Tag'));
+        $this->assertTrue($response->headers->has('X-Robots-Tag'));
+        $this->assertEquals('nofollow, noindex', $response->headers->get('X-Robots-Tag'));
     }
 
     /**


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- **Other** (please describe): SEO

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Removed robots.txt
- Added robots middleware to api routes

## Other information

> Important: For the noindex rule to be effective, the page or resource must not be blocked by a robots.txt file, and it has to be otherwise accessible to the crawler. If the page is blocked by a robots.txt file or the crawler can't access the page, the crawler will never see the noindex rule, and the page can still appear in search results, for example if other pages link to it.

Source: https://developers.google.com/search/docs/crawling-indexing/block-indexing?hl=en