### PR TITLE
Fix missing aria labels for PrimeVue UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File downloads blocked in some browsers due to restrictions on opening new windows without user interaction ([#1409], [#2726])
 - Room start failed with a 404 error when an uploaded file was missing from storage ([#2726])
 - Low color contrast in room utilization statistic chart ([#2854], [#2855])
+- Missing localized aria-labels for some UI components ([#2856], [#2857])
 
 ## [v4.12.0] - 2026-02-09
 
@@ -694,6 +695,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2809]: https://github.com/THM-Health/PILOS/pull/2809
 [#2854]: https://github.com/THM-Health/PILOS/issues/2854
 [#2855]: https://github.com/THM-Health/PILOS/pull/2855
+[#2856]: https://github.com/THM-Health/PILOS/issues/2856
+[#2857]: https://github.com/THM-Health/PILOS/pull/2857
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.12.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "mitt": "^3.0.1",
         "pinia": "^3.0.4",
         "primeicons": "^7.0.0",
+        "primelocale": "^2.3.0",
         "primevue": "^4.5.4",
         "tailwindcss": "^4.1.14",
         "tailwindcss-primeui": "^0.6.1",
@@ -10692,6 +10693,16 @@
       "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
       "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
       "license": "MIT"
+    },
+    "node_modules/primelocale": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/primelocale/-/primelocale-2.3.0.tgz",
+      "integrity": "sha512-xo9QRzXcXlORu+T3InrdBYs3XcEDidUqKawjE/sQL1Cze+3zLv7HkK4LF7q+FcHi+W/STQ4qcDSII13n3oG6fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
     },
     "node_modules/primevue": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mitt": "^3.0.1",
     "pinia": "^3.0.4",
     "primeicons": "^7.0.0",
+    "primelocale": "^2.3.0",
     "primevue": "^4.5.4",
     "tailwindcss": "^4.1.14",
     "tailwindcss-primeui": "^0.6.1",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,4 @@
-import { createApp, h, Fragment } from "vue";
+import { createApp, h, Fragment, markRaw } from "vue";
 import { createPinia } from "pinia";
 import App from "./components/App.vue";
 import createRouter from "./router";
@@ -51,6 +51,10 @@ const setupApp = (app) => {
 
   app.provide("$router", app.config.globalProperties.$router);
   app.provide("$route", app.config.globalProperties.$route);
+
+  pinia.use(({ store }) => {
+    store.primevue = markRaw(app.config.globalProperties.$primevue);
+  });
 
   app.mount("#app");
 };

--- a/resources/js/stores/locale.js
+++ b/resources/js/stores/locale.js
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import i18n, { setTimeZone, setLocale } from "../i18n";
 import { useApi } from "../composables/useApi.js";
 import { useTextDirection } from "@vueuse/core";
+import { all as primeVueLocales } from "primelocale";
 
 export const useLocaleStore = defineStore("locale", {
   state: () => {
@@ -48,6 +49,13 @@ export const useLocaleStore = defineStore("locale", {
       setTimeZone(this.i18n, this.timezone);
       const dir = useTextDirection();
       dir.value = this.locales[currentLocale].textDirection;
+
+      // Set PrimeVue locale
+      // Try exact match first, then match language only (e.g. "en" for "en-US"), then fallback to English
+      this.primevue.config.locale =
+        primeVueLocales[currentLocale] ||
+        primeVueLocales[currentLocale.split("-")[0]] ||
+        primeVueLocales["en"];
     },
 
     async setTimezone(timezone) {

--- a/tests/Frontend/e2e/GeneralApplication.cy.js
+++ b/tests/Frontend/e2e/GeneralApplication.cy.js
@@ -52,9 +52,9 @@ describe("General", function () {
       "localeRequest",
     );
 
-    cy.intercept("GET", "/api/v1/locale/de", {
-      statusCode: 200,
-    }).as("deRequest");
+    cy.intercept("GET", "/api/v1/locale/de", { fixture: "en.json" }).as(
+      "deRequest",
+    );
 
     cy.visit("/rooms");
 
@@ -153,6 +153,152 @@ describe("General", function () {
       'app.flash.server_error.message_{"message":["Test"]}',
       'app.flash.server_error.error_code_{"statusCode":500}',
     ]);
+  });
+
+  it("PrimeVue uses locale with exact match", function () {
+    // Intercept locale change request
+    cy.intercept("POST", "/api/v1/locale", {
+      statusCode: 200,
+    }).as("localeChange");
+
+    // Intercept German locale request
+    cy.intercept("GET", "api/v1/locale/de", { fixture: "en.json" }).as(
+      "deLocale",
+    );
+
+    cy.visit("/rooms");
+    cy.wait("@roomRequest");
+
+    // Change to German locale
+    cy.get('[data-test="navbar-locale"]').click();
+    cy.get('[data-test="submenu"]')
+      .eq(1)
+      .should("be.visible")
+      .within(() => {
+        cy.get('[data-test="navbar-locale-de"]')
+          .should("exist")
+          .should("have.text", "Deutsch")
+          .click();
+      });
+
+    cy.wait("@localeChange");
+    cy.wait("@deLocale");
+
+    // Check that PrimeVue pagination uses German locale
+    // Check "Next Page" button aria-label
+    cy.get('[data-test="paginator-next-button"]')
+      .first()
+      .should("have.attr", "aria-label", "Nächste Seite");
+
+    // Check page number aria-label (should be "Seite 1")
+    cy.get('[data-test="paginator-page"]')
+      .first()
+      .should("have.attr", "aria-label", "Seite 1");
+  });
+
+  it("PrimeVue uses parent locale for invalid language-region codes (de-XX -> de)", function () {
+    // Test loading an (imaginary) region-specific locale that is supported by the backend but not by PrimeLocale (de-XX)
+
+    // Add de-XX to enabled locales in config
+    cy.fixture("config.json").then((config) => {
+      config.data.general.enabled_locales = {
+        en: "English",
+        "de-xx": "Deutsch",
+      };
+
+      cy.intercept("GET", "api/v1/config", {
+        statusCode: 200,
+        body: config,
+      });
+    });
+
+    // Intercept locale change request
+    cy.intercept("POST", "/api/v1/locale", {
+      statusCode: 200,
+    }).as("localeChange");
+
+    // Intercept invalid regional German locale request
+    cy.intercept("GET", "api/v1/locale/de-xx", { fixture: "en.json" }).as(
+      "de-xxLocale",
+    );
+
+    cy.visit("/rooms");
+    cy.wait("@roomRequest");
+
+    // Change to invalid regional German locale
+    cy.get('[data-test="navbar-locale"]').click();
+    cy.get('[data-test="submenu"]')
+      .eq(1)
+      .should("be.visible")
+      .within(() => {
+        cy.get('[data-test="navbar-locale-de-xx"]').click();
+      });
+
+    cy.wait("@localeChange");
+    cy.wait("@de-xxLocale");
+
+    // Verify that PrimeVue uses German locale as fallback for the unsupported regional German locale (de-XX)
+    cy.get('[data-test="paginator-next-button"]')
+      .first()
+      .should("have.attr", "aria-label", "Nächste Seite");
+
+    cy.get('[data-test="paginator-page"]')
+      .first()
+      .should("have.attr", "aria-label", "Seite 1");
+  });
+
+  it("PrimeVue uses local fallback (en) for unsupported PrimeLocale locales", function () {
+    // Add xx to enabled locales in config
+    cy.fixture("config.json").then((config) => {
+      config.data.general.enabled_locales = {
+        en: "English",
+        xx: "Invalid locale",
+      };
+
+      cy.intercept("GET", "api/v1/config", {
+        statusCode: 200,
+        body: config,
+      });
+    });
+
+    // Intercept locale change request
+    cy.intercept("POST", "/api/v1/locale", {
+      statusCode: 200,
+    }).as("localeChange");
+
+    // Intercept Invalid locale request
+    cy.intercept("GET", "api/v1/locale/xx", { fixture: "en.json" }).as(
+      "xxLocale",
+    );
+
+    cy.visit("/rooms");
+    cy.wait("@roomRequest");
+
+    // Change to Invalid locale
+    cy.get('[data-test="navbar-locale"]').click();
+    cy.get('[data-test="submenu"]')
+      .eq(1)
+      .should("be.visible")
+      .within(() => {
+        cy.get('[data-test="navbar-locale-xx"]')
+          .should("exist")
+          .should("have.text", "Invalid locale")
+          .click();
+      });
+
+    cy.wait("@localeChange");
+    cy.wait("@xxLocale");
+
+    // Check that PrimeVue pagination uses English locale as fallback
+    // Check "Next Page" button aria-label - should be in English
+    cy.get('[data-test="paginator-next-button"]')
+      .last()
+      .should("have.attr", "aria-label", "Next Page");
+
+    // Check page number aria-label (should be "Page 1")
+    cy.get('[data-test="paginator-page"]')
+      .last()
+      .should("have.attr", "aria-label", "Page 1");
   });
 
   it("disabled welcome page redirect unauthenticated users to login", function () {

--- a/tests/Frontend/e2e/GeneralApplication.cy.js
+++ b/tests/Frontend/e2e/GeneralApplication.cy.js
@@ -231,7 +231,10 @@ describe("General", function () {
       .eq(1)
       .should("be.visible")
       .within(() => {
-        cy.get('[data-test="navbar-locale-de-xx"]').click();
+        cy.get('[data-test="navbar-locale-de-xx"]')
+          .should("exist")
+          .should("have.text", "Deutsch")
+          .click();
       });
 
     cy.wait("@localeChange");


### PR DESCRIPTION
# Fixes #2856

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **A11y & i18n**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fixed missing aria labels for PrimeVue UI components

## Other information
These language strings are maintained in the https://github.com/primefaces/primelocale repo to always be up-to-date and not part of the PILOS localisation project.

**Before (German locale selected)**
<img width="1268" height="544" alt="Image" src="https://github.com/user-attachments/assets/0c1f4c1d-070f-4faf-a538-9e627337a3ad" />

**After (German locale selected)**
<img width="1268" height="544" alt="image" src="https://github.com/user-attachments/assets/8d5eae57-1929-4f07-b321-e836298bb46f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PrimeVue components now follow the app locale with automatic fallback to language-only and to English when needed.

* **Bug Fixes**
  * Restored localized aria-labels for UI components (paginator and similar controls).

* **Tests**
  * Added end-to-end tests covering exact, parent-language, and fallback locale behaviors.

* **Chores**
  * Added a locale helper dependency to support PrimeVue locale mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->