### PR TITLE
Remove unused loading state in RoomTabFilesViewButton

### DIFF
--- a/resources/js/components/RoomTabFilesViewButton.vue
+++ b/resources/js/components/RoomTabFilesViewButton.vue
@@ -6,7 +6,6 @@
     v-tooltip="$t('rooms.files.view')"
     :aria-label="$t('rooms.files.view')"
     :disabled="disabled"
-    :loading="loading"
     icon="fa-solid fa-eye"
     data-test="room-files-view-button"
     @click="toggleTermsOfUsePopover"
@@ -20,7 +19,6 @@
     target="_blank"
     rel="opener"
     :href="downloadUrl"
-    :loading="loading"
     icon="fa-solid fa-eye"
     data-test="room-files-view-button"
     as="a"
@@ -59,7 +57,6 @@ const props = defineProps({
   },
 });
 
-const loading = ref(false);
 const op = ref();
 
 const downloadUrl = computed(() => {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code works and all tests pass
- Write useful descriptions and titles.
- Address review comments with additional commits, do not rewrite commit / force push
- Read and follow the developer docs: https://thm-health.github.io/PILOS/docs/next/development/workflow

-->

<!--
List here all the issues closed by this pull request.
Use keyword `fixes`  or `closes` before each issue number, e.g. Fixes #123456 or Closes #123456
-->

# Fixes \#

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Remove unused loading state in RoomTabFilesButton



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the loading indicator from the file view button component, streamlining the interface while maintaining all core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->