### PR TITLE
Fix breadcrumbs typo

### DIFF
--- a/lang/ar/admin.php
+++ b/lang/ar/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => 'تعديل :name',
             'index' => 'الأدوار',

--- a/lang/de-gender/admin.php
+++ b/lang/de-gender/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => ':name bearbeiten',
             'index' => 'Rollen',

--- a/lang/de/admin.php
+++ b/lang/de/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => ':name bearbeiten',
             'index' => 'Rollen',

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => 'Edit :name',
             'index' => 'Roles',

--- a/lang/fa/admin.php
+++ b/lang/fa/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => 'ویرایش :name',
             'index' => 'نقش‌ها',

--- a/lang/fr/admin.php
+++ b/lang/fr/admin.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'breakcrumbs' => [
+    'breadcrumbs' => [
         'roles' => [
             'edit' => 'Modifier :name',
             'index' => 'Rôles',

--- a/resources/js/views/AdminLayout.vue
+++ b/resources/js/views/AdminLayout.vue
@@ -8,10 +8,10 @@
           </h1>
 
           <Breadcrumb
-            v-if="breakcrumbs.length > 0"
+            v-if="breadcrumbs.length > 0"
             :home="home"
             class="px-0 py-2"
-            :model="breakcrumbs"
+            :model="breadcrumbs"
             data-test="admin-breadcrumb"
           >
             <template #item="{ item, props }">
@@ -61,114 +61,114 @@ const home = ref({
   route: { name: "admin" },
 });
 
-const breakcrumbs = computed(() => {
+const breadcrumbs = computed(() => {
   const routes = {
     "admin.settings": {
-      title: t("admin.breakcrumbs.settings"),
+      title: t("admin.breadcrumbs.settings"),
       previous: null,
     },
     "admin.users": {
-      title: t("admin.breakcrumbs.users.index"),
+      title: t("admin.breadcrumbs.users.index"),
       previous: null,
     },
     "admin.users.new": {
-      title: t("admin.breakcrumbs.users.new"),
+      title: t("admin.breadcrumbs.users.new"),
       previous: "admin.users",
     },
     "admin.users.view": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.users.view", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.users.view", breakcrumbLabelData.value)
         : "",
       previous: "admin.users",
     },
     "admin.users.edit": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.users.edit", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.users.edit", breakcrumbLabelData.value)
         : "",
       previous: "admin.users",
     },
     "admin.roles": {
-      title: t("admin.breakcrumbs.roles.index"),
+      title: t("admin.breadcrumbs.roles.index"),
       previous: null,
     },
     "admin.roles.new": {
-      title: t("admin.breakcrumbs.roles.new"),
+      title: t("admin.breadcrumbs.roles.new"),
       previous: "admin.roles",
     },
     "admin.roles.view": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.roles.view", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.roles.view", breakcrumbLabelData.value)
         : "",
       previous: "admin.roles",
     },
     "admin.roles.edit": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.roles.edit", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.roles.edit", breakcrumbLabelData.value)
         : "",
       previous: "admin.roles",
     },
     "admin.room_types": {
-      title: t("admin.breakcrumbs.room_types.index"),
+      title: t("admin.breadcrumbs.room_types.index"),
       previous: null,
     },
     "admin.room_types.new": {
-      title: t("admin.breakcrumbs.room_types.new"),
+      title: t("admin.breadcrumbs.room_types.new"),
       previous: "admin.room_types",
     },
     "admin.room_types.view": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.room_types.view", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.room_types.view", breakcrumbLabelData.value)
         : "",
       previous: "admin.room_types",
     },
     "admin.room_types.edit": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.room_types.edit", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.room_types.edit", breakcrumbLabelData.value)
         : "",
       previous: "admin.room_types",
     },
     "admin.servers": {
-      title: t("admin.breakcrumbs.servers.index"),
+      title: t("admin.breadcrumbs.servers.index"),
       previous: null,
     },
     "admin.servers.new": {
-      title: t("admin.breakcrumbs.servers.new"),
+      title: t("admin.breadcrumbs.servers.new"),
       previous: "admin.servers",
     },
     "admin.servers.view": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.servers.view", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.servers.view", breakcrumbLabelData.value)
         : "",
       previous: "admin.servers",
     },
     "admin.servers.edit": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.servers.edit", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.servers.edit", breakcrumbLabelData.value)
         : "",
       previous: "admin.servers",
     },
     "admin.server_pools": {
-      title: t("admin.breakcrumbs.server_pools.index"),
+      title: t("admin.breadcrumbs.server_pools.index"),
       previous: null,
     },
     "admin.server_pools.new": {
-      title: t("admin.breakcrumbs.server_pools.new"),
+      title: t("admin.breadcrumbs.server_pools.new"),
       previous: "admin.server_pools",
     },
     "admin.server_pools.view": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.server_pools.view", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.server_pools.view", breakcrumbLabelData.value)
         : "",
       previous: "admin.server_pools",
     },
     "admin.server_pools.edit": {
       title: !isEmpty(breakcrumbLabelData.value)
-        ? t("admin.breakcrumbs.server_pools.edit", breakcrumbLabelData.value)
+        ? t("admin.breadcrumbs.server_pools.edit", breakcrumbLabelData.value)
         : "",
       previous: "admin.server_pools",
     },
     "admin.streaming_settings": {
-      title: t("admin.breakcrumbs.streaming_settings"),
+      title: t("admin.breadcrumbs.streaming_settings"),
       previous: null,
     },
   };
@@ -176,20 +176,20 @@ const breakcrumbs = computed(() => {
   const currentRoute = routes[route.name];
   if (!currentRoute) return [];
   let previousRoute = currentRoute.previous;
-  const breakcrumbs = [
+  const breadcrumbs = [
     {
       label: currentRoute.title,
     },
   ];
   while (routes[previousRoute]) {
-    breakcrumbs.unshift({
+    breadcrumbs.unshift({
       label: routes[previousRoute].title,
       route: { name: previousRoute },
     });
     previousRoute = previousRoute.previous;
   }
 
-  return breakcrumbs;
+  return breadcrumbs;
 });
 
 function isEmpty(obj) {

--- a/tests/Frontend/e2e/AdminRolesEdit.cy.js
+++ b/tests/Frontend/e2e/AdminRolesEdit.cy.js
@@ -91,8 +91,8 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
-      .should("include.text", 'admin.breakcrumbs.roles.edit_{"name":"Staff"}');
+      .should("include.text", "admin.breadcrumbs.roles.index")
+      .should("include.text", 'admin.breadcrumbs.roles.edit_{"name":"Staff"}');
 
     // Change role settings
     cy.get('[data-test="name-field"]')
@@ -106,8 +106,8 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs stays the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
-      .should("include.text", 'admin.breakcrumbs.roles.edit_{"name":"Staff"}');
+      .should("include.text", "admin.breadcrumbs.roles.index")
+      .should("include.text", 'admin.breadcrumbs.roles.edit_{"name":"Staff"}');
 
     cy.get('[data-test="roles-room-limit-help-dialog"]').should("not.exist");
     cy.get('[data-test="room-limit-field"]')
@@ -510,10 +510,10 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
+      .should("include.text", "admin.breadcrumbs.roles.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.roles.view_{"name":"Standard role"}',
+        'admin.breadcrumbs.roles.view_{"name":"Standard role"}',
       );
   });
 
@@ -1386,8 +1386,8 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
-      .should("include.text", 'admin.breakcrumbs.roles.edit_{"name":"Staff"}');
+      .should("include.text", "admin.breadcrumbs.roles.index")
+      .should("include.text", 'admin.breadcrumbs.roles.edit_{"name":"Staff"}');
 
     // Check with 422 error
     cy.intercept("PUT", "api/v1/roles/2", {
@@ -1488,10 +1488,10 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs is updated
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
+      .should("include.text", "admin.breadcrumbs.roles.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.roles.edit_{"name":"Standard role"}',
+        'admin.breadcrumbs.roles.edit_{"name":"Standard role"}',
       );
 
     // Check that correct data is shown
@@ -1615,10 +1615,10 @@ describe("Admin roles edit", function () {
     // Check that breadcrumbs stays the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
+      .should("include.text", "admin.breadcrumbs.roles.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.roles.view_{"name":"Standard role"}',
+        'admin.breadcrumbs.roles.view_{"name":"Standard role"}',
       );
 
     // Reload

--- a/tests/Frontend/e2e/AdminRolesIndex.cy.js
+++ b/tests/Frontend/e2e/AdminRolesIndex.cy.js
@@ -79,7 +79,7 @@ describe("Admin roles index", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index");
+      .should("include.text", "admin.breadcrumbs.roles.index");
 
     // Check that table headers are shown correctly
     cy.get('[data-test="role-header-cell"]').should("have.length", 1);

--- a/tests/Frontend/e2e/AdminRolesNew.cy.js
+++ b/tests/Frontend/e2e/AdminRolesNew.cy.js
@@ -56,8 +56,8 @@ describe("Admin roles new", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
-      .should("include.text", "admin.breakcrumbs.roles.new");
+      .should("include.text", "admin.breadcrumbs.roles.index")
+      .should("include.text", "admin.breadcrumbs.roles.new");
 
     cy.get('[data-test="name-field"]')
       .should("be.visible")
@@ -483,10 +483,10 @@ describe("Admin roles new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
+      .should("include.text", "admin.breadcrumbs.roles.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.roles.view_{"name":"Standard role"}',
+        'admin.breadcrumbs.roles.view_{"name":"Standard role"}',
       );
   });
 

--- a/tests/Frontend/e2e/AdminRolesView.cy.js
+++ b/tests/Frontend/e2e/AdminRolesView.cy.js
@@ -77,8 +77,8 @@ describe("Admin roles view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.roles.index")
-      .should("include.text", 'admin.breakcrumbs.roles.view_{"name":"Staff"}');
+      .should("include.text", "admin.breadcrumbs.roles.index")
+      .should("include.text", 'admin.breadcrumbs.roles.view_{"name":"Staff"}');
 
     // Check that role data is shown correctly
     cy.get('[data-test="name-field"]')

--- a/tests/Frontend/e2e/AdminRoomTypesEdit.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesEdit.cy.js
@@ -89,10 +89,10 @@ describe("Admin room types edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.edit_{"name":"Exam"}',
+        'admin.breadcrumbs.room_types.edit_{"name":"Exam"}',
       );
 
     // Change room type settings
@@ -108,10 +108,10 @@ describe("Admin room types edit", function () {
 
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.edit_{"name":"Exam"}',
+        'admin.breadcrumbs.room_types.edit_{"name":"Exam"}',
       );
 
     cy.get('[data-test="description-field"]')
@@ -855,10 +855,10 @@ describe("Admin room types edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.view_{"name":"Exam 01"}',
+        'admin.breadcrumbs.room_types.view_{"name":"Exam 01"}',
       );
   });
 
@@ -1196,10 +1196,10 @@ describe("Admin room types edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.edit_{"name":"Exam"}',
+        'admin.breadcrumbs.room_types.edit_{"name":"Exam"}',
       );
 
     // Check with 422 error
@@ -1753,10 +1753,10 @@ describe("Admin room types edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.edit_{"name":"Exam 01"}',
+        'admin.breadcrumbs.room_types.edit_{"name":"Exam 01"}',
       );
 
     // Check that correct data is shown
@@ -2053,10 +2053,10 @@ describe("Admin room types edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.view_{"name":"Exam 01"}',
+        'admin.breadcrumbs.room_types.view_{"name":"Exam 01"}',
       );
 
     // Reload

--- a/tests/Frontend/e2e/AdminRoomTypesIndex.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesIndex.cy.js
@@ -58,7 +58,7 @@ describe("Admin room types index", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index");
+      .should("include.text", "admin.breadcrumbs.room_types.index");
 
     // Check that table headers are displayed correctly
     cy.get('[data-test="room-type-header-cell"]').should("have.length", 1);

--- a/tests/Frontend/e2e/AdminRoomTypesNew.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesNew.cy.js
@@ -59,8 +59,8 @@ describe("Admin room types new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
-      .should("include.text", "admin.breakcrumbs.room_types.new");
+      .should("include.text", "admin.breadcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.new");
 
     cy.get('[data-test="room-type-name-field"]')
       .should("be.visible")
@@ -72,8 +72,8 @@ describe("Admin room types new", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
-      .should("include.text", "admin.breakcrumbs.room_types.new");
+      .should("include.text", "admin.breadcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.new");
 
     cy.get('[data-test="description-field"]')
       .should("be.visible")
@@ -736,10 +736,10 @@ describe("Admin room types new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.view_{"name":"Exam 01"}',
+        'admin.breadcrumbs.room_types.view_{"name":"Exam 01"}',
       );
   });
 

--- a/tests/Frontend/e2e/AdminRoomTypesView.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesView.cy.js
@@ -74,10 +74,10 @@ describe("Admin room types view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.room_types.index")
+      .should("include.text", "admin.breadcrumbs.room_types.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.room_types.view_{"name":"Exam"}',
+        'admin.breadcrumbs.room_types.view_{"name":"Exam"}',
       );
 
     // Check that room type data is shown correctly

--- a/tests/Frontend/e2e/AdminServerPoolsEdit.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsEdit.cy.js
@@ -106,10 +106,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.edit_{"name":"Test"}',
+        'admin.breadcrumbs.server_pools.edit_{"name":"Test"}',
       );
 
     // Change server pool settings
@@ -124,10 +124,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.edit_{"name":"Test"}',
+        'admin.breadcrumbs.server_pools.edit_{"name":"Test"}',
       );
 
     cy.get('[data-test="description-field"]')
@@ -370,10 +370,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.view_{"name":"Server Pool 1"}',
+        'admin.breadcrumbs.server_pools.view_{"name":"Server Pool 1"}',
       );
   });
 
@@ -383,10 +383,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.edit_{"name":"Test"}',
+        'admin.breadcrumbs.server_pools.edit_{"name":"Test"}',
       );
 
     // Set values
@@ -512,10 +512,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.edit_{"name":"Server Pool 1"}',
+        'admin.breadcrumbs.server_pools.edit_{"name":"Server Pool 1"}',
       );
 
     // Check that correct data is shown
@@ -596,10 +596,10 @@ describe("Admin server pools edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.view_{"name":"Server Pool 1"}',
+        'admin.breadcrumbs.server_pools.view_{"name":"Server Pool 1"}',
       );
 
     // Reload

--- a/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsIndex.cy.js
@@ -78,7 +78,7 @@ describe("Admin server pools index", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index");
+      .should("include.text", "admin.breadcrumbs.server_pools.index");
 
     // Check that table headers are displayed correctly
     cy.get('[data-test="server-pool-header-cell"]').should("have.length", 2);

--- a/tests/Frontend/e2e/AdminServerPoolsNew.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsNew.cy.js
@@ -61,8 +61,8 @@ describe("Admin server pools new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
-      .should("include.text", "admin.breakcrumbs.server_pools.new");
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.new");
 
     cy.get('[data-test="name-field"]')
       .should("be.visible")
@@ -74,8 +74,8 @@ describe("Admin server pools new", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
-      .should("include.text", "admin.breakcrumbs.server_pools.new");
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.new");
 
     cy.get('[data-test="description-field"]')
       .should("be.visible")

--- a/tests/Frontend/e2e/AdminServerPoolsView.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsView.cy.js
@@ -78,10 +78,10 @@ describe("Admin server pools view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.server_pools.index")
+      .should("include.text", "admin.breadcrumbs.server_pools.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.server_pools.view_{"name":"Test"}',
+        'admin.breadcrumbs.server_pools.view_{"name":"Test"}',
       );
 
     // Check that server pool data is shown correctly

--- a/tests/Frontend/e2e/AdminServersEdit.cy.js
+++ b/tests/Frontend/e2e/AdminServersEdit.cy.js
@@ -92,10 +92,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.edit_{"name":"Server 01"}',
+        'admin.breadcrumbs.servers.edit_{"name":"Server 01"}',
       );
 
     // Change server settings
@@ -110,10 +110,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.edit_{"name":"Server 01"}',
+        'admin.breadcrumbs.servers.edit_{"name":"Server 01"}',
       );
 
     cy.get('[data-test="description-field"]')
@@ -321,10 +321,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.view_{"name":"Server 02"}',
+        'admin.breadcrumbs.servers.view_{"name":"Server 02"}',
       );
   });
 
@@ -334,10 +334,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.edit_{"name":"Server 01"}',
+        'admin.breadcrumbs.servers.edit_{"name":"Server 01"}',
       );
 
     // Check with 422 error
@@ -510,10 +510,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.edit_{"name":"Server 03"}',
+        'admin.breadcrumbs.servers.edit_{"name":"Server 03"}',
       );
 
     // Check that correct data is shown
@@ -608,10 +608,10 @@ describe("Admin servers edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.view_{"name":"Server 03"}',
+        'admin.breadcrumbs.servers.view_{"name":"Server 03"}',
       );
 
     // Reload

--- a/tests/Frontend/e2e/AdminServersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminServersIndex.cy.js
@@ -80,7 +80,7 @@ describe("Admin servers index", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index");
+      .should("include.text", "admin.breadcrumbs.servers.index");
 
     // Check that loading is over
     cy.get('[data-test="overlay"]').should("not.exist");

--- a/tests/Frontend/e2e/AdminServersNew.cy.js
+++ b/tests/Frontend/e2e/AdminServersNew.cy.js
@@ -60,8 +60,8 @@ describe("Admin servers view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
-      .should("include.text", "admin.breakcrumbs.servers.new");
+      .should("include.text", "admin.breadcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.new");
 
     cy.get('[data-test="name-field"]')
       .should("be.visible")
@@ -73,8 +73,8 @@ describe("Admin servers view", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
-      .should("include.text", "admin.breakcrumbs.servers.new");
+      .should("include.text", "admin.breadcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.new");
 
     cy.get('[data-test="description-field"]')
       .should("be.visible")
@@ -285,10 +285,10 @@ describe("Admin servers view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.view_{"name":"Server 01"}',
+        'admin.breadcrumbs.servers.view_{"name":"Server 01"}',
       );
   });
 

--- a/tests/Frontend/e2e/AdminServersView.cy.js
+++ b/tests/Frontend/e2e/AdminServersView.cy.js
@@ -77,10 +77,10 @@ describe("Admin servers view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.servers.index")
+      .should("include.text", "admin.breadcrumbs.servers.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.servers.view_{"name":"Server 01"}',
+        'admin.breadcrumbs.servers.view_{"name":"Server 01"}',
       );
 
     // Check that server data is shown correctly

--- a/tests/Frontend/e2e/AdminSettingsGeneral.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsGeneral.cy.js
@@ -78,7 +78,7 @@ describe("Admin settings general", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.settings");
+      .should("include.text", "admin.breadcrumbs.settings");
   });
 
   it("check loading with edit permission", function () {
@@ -111,7 +111,7 @@ describe("Admin settings general", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.settings");
+      .should("include.text", "admin.breadcrumbs.settings");
   });
 
   it("load settings errors", function () {

--- a/tests/Frontend/e2e/AdminUsersEdit.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEdit.cy.js
@@ -180,10 +180,10 @@ describe("Admin users edit", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
+        'admin.breadcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
       );
 
     cy.get('[data-test="base-tab-button"]').should("be.visible");

--- a/tests/Frontend/e2e/AdminUsersEditBase.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEditBase.cy.js
@@ -42,10 +42,10 @@ describe("Admin users edit base", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
+        'admin.breadcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
       );
 
     cy.get('[data-test="default-profile-image-preview"]')
@@ -79,10 +79,10 @@ describe("Admin users edit base", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
+        'admin.breadcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
       );
 
     // Check authenticator setting
@@ -433,10 +433,10 @@ describe("Admin users edit base", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.view_{"firstname":"Juan","lastname":"Walter"}',
+        'admin.breadcrumbs.users.view_{"firstname":"Juan","lastname":"Walter"}',
       );
 
     cy.wait("@userRequest");
@@ -562,10 +562,10 @@ describe("Admin users edit base", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
+        'admin.breadcrumbs.users.edit_{"firstname":"Laura","lastname":"Rivera"}',
       );
 
     // Check with 422 error
@@ -686,10 +686,10 @@ describe("Admin users edit base", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.view_{"firstname":"Juan","lastname":"Walter"}',
+        'admin.breadcrumbs.users.view_{"firstname":"Juan","lastname":"Walter"}',
       );
 
     // Visit edit page again

--- a/tests/Frontend/e2e/AdminUsersIndex.cy.js
+++ b/tests/Frontend/e2e/AdminUsersIndex.cy.js
@@ -111,7 +111,7 @@ describe("Admin users index", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index");
+      .should("include.text", "admin.breadcrumbs.users.index");
 
     // Check that headers are displayed correctly
     cy.get('[data-test="user-header-cell"]').should("have.length", 9);

--- a/tests/Frontend/e2e/AdminUsersNew.cy.js
+++ b/tests/Frontend/e2e/AdminUsersNew.cy.js
@@ -77,8 +77,8 @@ describe("Admin users new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
-      .should("include.text", "admin.breakcrumbs.users.new");
+      .should("include.text", "admin.breadcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.new");
 
     cy.get('[data-test="firstname-field"]')
       .should("be.visible")
@@ -97,8 +97,8 @@ describe("Admin users new", function () {
     // Check that breadcrumbs stay the same
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
-      .should("include.text", "admin.breakcrumbs.users.new");
+      .should("include.text", "admin.breadcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.new");
 
     cy.get('[data-test="email-field"]')
       .should("be.visible")
@@ -375,10 +375,10 @@ describe("Admin users new", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.view_{"firstname":"Max","lastname":"Doe"}',
+        'admin.breadcrumbs.users.view_{"firstname":"Max","lastname":"Doe"}',
       );
   });
 

--- a/tests/Frontend/e2e/AdminUsersView.cy.js
+++ b/tests/Frontend/e2e/AdminUsersView.cy.js
@@ -104,10 +104,10 @@ describe("Admin users view", function () {
     // Check that breadcrumbs are shown correctly
     cy.get('[data-test="admin-breadcrumb"]')
       .should("be.visible")
-      .should("include.text", "admin.breakcrumbs.users.index")
+      .should("include.text", "admin.breadcrumbs.users.index")
       .should(
         "include.text",
-        'admin.breakcrumbs.users.view_{"firstname":"Laura","lastname":"Rivera"}',
+        'admin.breadcrumbs.users.view_{"firstname":"Laura","lastname":"Rivera"}',
       );
 
     // Check that user data is shown and all inputs are disabled


### PR DESCRIPTION
## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [ ] Code updated to current develop branch head
- [ ] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Fix typo in locale string key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected breadcrumb navigation translation key references across all supported language files (English, German, German gender-neutral, Arabic, Farsi, and French). Updated the admin interface layout component and comprehensive end-to-end test coverage for all admin sections including roles, room types, server pools, servers, users, and settings to ensure consistent breadcrumb display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->