### PR TITLE
Prevent zoom on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing aria-label for recording edit button ([#2906], [#2911])
 - Greenlight v2 imported room settings not applied due to disabled expert mode ([#2665])
 - Missing aria-labels for running meetings table header icons ([#2905], [#2910])
+- Input zooming on iOS devices when focusing input fields ([#3028], [#3029])
 
 ## [v4.13.0] - 2026-02-23
 
@@ -738,6 +739,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2913]: https://github.com/THM-Health/PILOS/pull/2913
 [#2998]: https://github.com/THM-Health/PILOS/issues/2998
 [#2999]: https://github.com/THM-Health/PILOS/pull/2999
+[#3028]: https://github.com/THM-Health/PILOS/issues/3028
+[#3029]: https://github.com/THM-Health/PILOS/pull/3029
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.13.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -74,3 +74,12 @@ if (
   app = createApp(App);
   setupApp(app);
 }
+
+// preventing iOS input auto zooming
+if (navigator.userAgent.indexOf("iPhone") > -1) {
+  const querySelector = document.querySelector("[name=viewport]");
+  querySelector.setAttribute(
+    "content",
+    querySelector.getAttribute("content") + ", maximum-scale=1",
+  );
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -77,9 +77,9 @@ if (
 
 // preventing iOS input auto zooming
 if (navigator.userAgent.indexOf("iPhone") > -1) {
-  const querySelector = document.querySelector("[name=viewport]");
-  querySelector.setAttribute(
+  const viewportMetaTag = document.querySelector("[name=viewport]");
+  viewportMetaTag.setAttribute(
     "content",
-    querySelector.getAttribute("content") + ", maximum-scale=1",
+    viewportMetaTag.getAttribute("content") + ", maximum-scale=1",
   );
 }


### PR DESCRIPTION
# Fixes #3028 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Adjust viewport metadata for iOS to prevent zoom on input focus

## Other information

Considered alternatives increasing font-size. This make the whole UI much bigger, looks bad on Desktop.
Increasing font size for mobile only is not easy to do. If a desktop user is resizing the browser to a narrow window it would also trigger it.
Nextcloud Forms is injecting the same viewport, but server side.
The maximum-scale=1 viewport setting on iOS still allows user zoom gestures on iOS >= 10 (2016)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted viewport zoom levels on iOS devices to optimize viewing experience and prevent unintended scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->