### PR TITLE
Fix deprecations (phpunit & laravel)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -8,6 +8,7 @@ use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\EnsureModelNotStale;
 use App\Http\Middleware\LogContext;
 use App\Http\Middleware\LoggedInUser;
+use App\Http\Middleware\PreventRequestForgery;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\RequestMetricsMiddleware;
@@ -19,7 +20,6 @@ use App\Http\Middleware\StoreSessionData;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustHosts;
 use App\Http\Middleware\TrustProxies;
-use App\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
@@ -69,7 +69,7 @@ class Kernel extends HttpKernel
             AddQueuedCookiesToResponse::class,
             StartSession::class,
             ShareErrorsFromSession::class,
-            VerifyCsrfToken::class,
+            PreventRequestForgery::class,
             SubstituteBindings::class,
             SetApplicationLocale::class,
             'shibboleth',

--- a/app/Http/Middleware/PreventRequestForgery.php
+++ b/app/Http/Middleware/PreventRequestForgery.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery as Middleware;
 
-class VerifyCsrfToken extends Middleware
+class PreventRequestForgery extends Middleware
 {
     /**
      * The URIs that should be excluded from CSRF verification.

--- a/app/Rules/Password.php
+++ b/app/Rules/Password.php
@@ -2,30 +2,20 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class Password implements Rule
+class Password implements ValidationRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         // Password should contain at least 1 uppercase letter, 1 lowercase letter, 1 symbol, 1 number
-        return preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(_|[^\w])).+$/', $value) !== 0;
-    }
+        $valid = preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(_|[^\w])).+$/', $value) !== 0;
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return __('validation.custom.password');
+        if ($valid) {
+            return;
+        }
+
+        $fail(__('validation.custom.password'));
     }
 }

--- a/app/Rules/ValidName.php
+++ b/app/Rules/ValidName.php
@@ -2,50 +2,26 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class ValidName implements Rule
+class ValidName implements ValidationRule
 {
-    private $failedChars;
-
-    private $attribute;
-
-    public function __construct()
-    {
-        //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (preg_match('/^['.config('bigbluebutton.allowed_name_characters').']+$/u', $value)) {
-            return true;
+            return;
         }
-        $this->attribute = $attribute;
-        $this->failedChars = array_unique(str_split(preg_replace('/['.config('bigbluebutton.allowed_name_characters').']+/u', '', $value)));
 
-        return false;
-    }
+        $failedChars = array_unique(str_split(preg_replace('/['.config('bigbluebutton.allowed_name_characters').']+/u', '', $value)));
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        $invalidChars = implode('', $this->failedChars);
+        $invalidChars = implode('', $failedChars);
         $validUTF8 = mb_check_encoding($invalidChars, 'UTF-8');
         if ($validUTF8) {
-            return __('validation.validname', ['attribute' => __('validation.attributes.'.$this->attribute), 'chars' => $invalidChars]);
+            $fail(__('validation.validname', ['attribute' => __('validation.attributes.'.$attribute), 'chars' => $invalidChars]));
         } else {
-            return __('validation.validname_error', ['attribute' => __('validation.attributes.'.$this->attribute)]);
+            $fail(__('validation.validname_error', ['attribute' => __('validation.attributes.'.$attribute)]));
         }
+
     }
 }

--- a/app/Rules/ValidRoomType.php
+++ b/app/Rules/ValidRoomType.php
@@ -5,9 +5,10 @@ namespace App\Rules;
 use App\Models\Room;
 use App\Models\RoomType;
 use App\Models\User;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class ValidRoomType implements Rule
+class ValidRoomType implements ValidationRule
 {
     /**
      * @var User The owner of the room.
@@ -24,26 +25,12 @@ class ValidRoomType implements Rule
         $this->owner = $owner;
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! is_numeric($value)) {
-            return false;
+        if (is_numeric($value) && Room::roomTypePermitted($this->owner, RoomType::find($value))) {
+            return;
         }
 
-        return Room::roomTypePermitted($this->owner, RoomType::find($value));
-    }
-
-    /**
-     * Get the validation error message.
-     */
-    public function message(): string
-    {
-        return __('validation.custom.invalid_room_type');
+        $fail(__('validation.custom.invalid_room_type'));
     }
 }

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Laravel\Sanctum\Sanctum;
 
 return [
@@ -49,7 +49,7 @@ return [
 
     'middleware' => [
         'encrypt_cookies' => EncryptCookies::class,
-        'validate_csrf_token' => ValidateCsrfToken::class,
+        'validate_csrf_token' => PreventRequestForgery::class,
     ],
 
     'guard' => env('SANCTUM_AUTH_GUARD', 'api'),

--- a/tests/Backend/Unit/OpenIDConnectClientTest.php
+++ b/tests/Backend/Unit/OpenIDConnectClientTest.php
@@ -960,7 +960,7 @@ class OpenIDConnectClientTest extends TestCase
             ],
         ];
 
-        $clientMockBuilder = $this->getStubBuilder(OpenIDConnectClient::class)
+        $clientMockBuilder = $this->getMockBuilder(OpenIDConnectClient::class)
             ->setConstructorArgs(['https://example.org',
                 'fake-client-id',
                 'fake-client-secret',
@@ -973,16 +973,16 @@ class OpenIDConnectClientTest extends TestCase
         ]);
 
         // Check if the jwks are correctly fetched
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(0);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
         Http::assertSentCount(1);
 
         // Call again to check if the jwks are not fetched again, but returned from cache
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(0);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
@@ -992,8 +992,8 @@ class OpenIDConnectClientTest extends TestCase
         $this->travel(3601)->seconds();
 
         // Call again to check if the jwks are fetched again
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(0);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
@@ -1020,7 +1020,7 @@ class OpenIDConnectClientTest extends TestCase
             ],
         ];
 
-        $clientMockBuilder = $this->getStubBuilder(OpenIDConnectClient::class)
+        $clientMockBuilder = $this->getMockBuilder(OpenIDConnectClient::class)
             ->setConstructorArgs(['https://example.org',
                 'fake-client-id',
                 'fake-client-secret',
@@ -1033,32 +1033,32 @@ class OpenIDConnectClientTest extends TestCase
         ]);
 
         // Check if the jwks are correctly fetched
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(0);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
         Http::assertSentCount(1);
 
         // Call again to check if jwks are correctly fetched again
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(0);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
         Http::assertSentCount(2);
 
         // Call again but setting a custom cache max age
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(60);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
         Http::assertSentCount(3);
 
         // Call again to check if the jwks are not fetched again but returned from cache
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(60);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));
@@ -1066,8 +1066,8 @@ class OpenIDConnectClientTest extends TestCase
 
         // Travel forward in time to invalidate the cache
         $this->travel(61)->seconds();
-        $client = $clientMockBuilder->getStub();
-        $client->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
+        $client = $clientMockBuilder->getMock();
+        $client->expects($this->once())->method('getWellKnownConfigValue')->with('jwks_uri')->willReturn('https://example.org/jwks');
         $client->setCacheJwksMaxAge(60);
         $jwksSet = $client->getJwkSet();
         $this->assertEquals($privateKey->thumbprint('sha256'), $jwksSet->get($kid)->thumbprint('sha256'));

--- a/tests/Backend/Unit/Rules/PasswordTest.php
+++ b/tests/Backend/Unit/Rules/PasswordTest.php
@@ -3,29 +3,24 @@
 namespace Tests\Backend\Unit\Rules;
 
 use App\Rules\Password;
+use Illuminate\Support\Facades\Validator;
 use Tests\Backend\TestCase;
 
 class PasswordTest extends TestCase
 {
-    /**
-     * A basic unit test example.
-     *
-     * @return void
-     */
     public function test_passes()
     {
-        $pw = new Password;
-
-        $this->assertTrue($pw->passes('', '1_aA'));
-        $this->assertTrue($pw->passes('', 'A_a1'));
-        $this->assertTrue($pw->passes('', 'Aa_1Aa1_'));
-        $this->assertFalse($pw->passes('', 'Aa1'));
-        $this->assertFalse($pw->passes('', 'äA'));
-        $this->assertFalse($pw->passes('', '1_a'));
+        $this->assertTrue(Validator::make(['password' => '1_aA'], ['password' => new Password])->passes());
+        $this->assertTrue(Validator::make(['password' => 'A_a1'], ['password' => new Password])->passes());
+        $this->assertTrue(Validator::make(['password' => 'Aa_1Aa1_'], ['password' => new Password])->passes());
+        $this->assertFalse(Validator::make(['password' => 'Aa1'], ['password' => new Password])->passes());
+        $this->assertFalse(Validator::make(['password' => 'äA'], ['password' => new Password])->passes());
+        $this->assertFalse(Validator::make(['password' => '1_a'], ['password' => new Password])->passes());
     }
 
     public function test_message()
     {
-        $this->assertEquals(__('validation.custom.password'), (new Password)->message());
+        $message = Validator::make(['password' => 'Aa1'], ['password' => new Password])->errors()->first('password');
+        $this->assertEquals(__('validation.custom.password'), $message);
     }
 }

--- a/tests/Backend/Unit/Rules/ValidRoomTypeTest.php
+++ b/tests/Backend/Unit/Rules/ValidRoomTypeTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Rules\ValidRoomType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
 use Tests\Backend\TestCase;
 
 class ValidRoomTypeTest extends TestCase
@@ -31,18 +32,17 @@ class ValidRoomTypeTest extends TestCase
         $roomTypeC = RoomType::factory()->create();
         $roomTypeC->roles()->sync([$roleA->id]);
 
-        $validRoomType = new ValidRoomType($user);
-
-        $this->assertFalse($validRoomType->passes('', null));
-        $this->assertFalse($validRoomType->passes('', 1337));
-        $this->assertFalse($validRoomType->passes('', $roomTypeA->id));
-        $this->assertTrue($validRoomType->passes('', $roomTypeB->id));
-        $this->assertTrue($validRoomType->passes('', $roomTypeC->id));
+        $this->assertFalse(Validator::make(['room_type' => null], ['room_type' => new ValidRoomType($user)])->passes());
+        $this->assertFalse(Validator::make(['room_type' => 1337], ['room_type' => new ValidRoomType($user)])->passes());
+        $this->assertFalse(Validator::make(['room_type' => $roomTypeA->id], ['room_type' => new ValidRoomType($user)])->passes());
+        $this->assertTrue(Validator::make(['room_type' => $roomTypeB->id], ['room_type' => new ValidRoomType($user)])->passes());
+        $this->assertTrue(Validator::make(['room_type' => $roomTypeC->id], ['room_type' => new ValidRoomType($user)])->passes());
     }
 
     public function test_message()
     {
         $user = User::factory()->create();
-        $this->assertEquals(__('validation.custom.invalid_room_type'), (new ValidRoomType($user))->message());
+        $message = Validator::make(['room_type' => null], ['room_type' => new ValidRoomType($user)])->errors()->first('room_type');
+        $this->assertEquals(__('validation.custom.invalid_room_type'), $message);
     }
 }


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Refactor laravel form validation rules (old extended class was deprecated)
- Refactor CRSF middleware (old extended class was deprecated)
- Refactor usage of mocks/stubs

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated validation rules to use latest framework patterns for password, name, and room type validations.
  * Modernized cross-site request forgery protection to use updated security middleware.
  * Updated configuration and tests to align with framework changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->