### PR TITLE
Use same method to get and set config

### DIFF
--- a/app/Auth/LDAP/LDAPServiceProvider.php
+++ b/app/Auth/LDAP/LDAPServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Auth\LDAP;
 
 use Illuminate\Log\LogManager;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use LdapRecord\Connection;
@@ -16,7 +15,7 @@ class LDAPServiceProvider extends ServiceProvider
         $this->registerLogging();
 
         Container::setDefaultConnection('default');
-        Container::addConnection(new Connection(Config::get('ldap.connection')));
+        Container::addConnection(new Connection(config('ldap.connection')));
     }
 
     /**
@@ -26,7 +25,7 @@ class LDAPServiceProvider extends ServiceProvider
      */
     protected function registerLogging()
     {
-        if (! Config::get('ldap.logging.enabled', false)) {
+        if (! config('ldap.logging.enabled', false)) {
             return;
         }
 

--- a/app/Console/Commands/ImportGreenlight2Command.php
+++ b/app/Console/Commands/ImportGreenlight2Command.php
@@ -13,7 +13,6 @@ use App\Settings\GeneralSettings;
 use Illuminate\Console\Command;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
@@ -109,7 +108,7 @@ class ImportGreenlight2Command extends Command
             return 2;
         }
 
-        Config::set('database.connections.greenlight', [
+        config(['database.connections.greenlight' => [
             'driver' => 'pgsql',
             'host' => $this->argument('host'),
             'database' => $this->argument('database'),
@@ -121,7 +120,7 @@ class ImportGreenlight2Command extends Command
             'prefix_indexes' => true,
             'schema' => 'public',
             'sslmode' => 'prefer',
-        ]);
+        ]]);
 
         $requireAuth = DB::connection('greenlight')->table('features')->where('name', 'Room Authentication')->first('value')?->value == true;
         $users = DB::connection('greenlight')->table('users')->where('deleted', false)->get(['id', 'provider', 'username', 'social_uid', 'email', 'name', 'password_digest']);

--- a/app/Console/Commands/ImportGreenlight3Command.php
+++ b/app/Console/Commands/ImportGreenlight3Command.php
@@ -13,7 +13,6 @@ use App\Settings\GeneralSettings;
 use Illuminate\Console\Command;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
@@ -92,7 +91,7 @@ class ImportGreenlight3Command extends Command
         }
 
         // Read Greenlight 3 data from database
-        Config::set('database.connections.greenlight', [
+        config(['database.connections.greenlight' => [
             'driver' => 'pgsql',
             'host' => $this->argument('host'),
             'database' => $this->argument('database'),
@@ -104,7 +103,7 @@ class ImportGreenlight3Command extends Command
             'prefix_indexes' => true,
             'schema' => 'public',
             'sslmode' => 'prefer',
-        ]);
+        ]]);
 
         $users = DB::connection('greenlight')->table('users')->where('provider', 'greenlight')->get(['id', 'name', 'email', 'external_id', 'password_digest']);
         $rooms = DB::connection('greenlight')->table('rooms')->get(['id', 'friendly_id', 'user_id', 'name']);

--- a/app/Console/Commands/ImportRecordingsCommand.php
+++ b/app/Console/Commands/ImportRecordingsCommand.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use App\Jobs\ProcessRecording;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -17,7 +16,7 @@ class ImportRecordingsCommand extends Command
 
     public function handle()
     {
-        $hook_script_path = Config::get('recording.import_before_hook');
+        $hook_script_path = config('recording.import_before_hook');
         if ($hook_script_path) {
             $this->info('Invoking recording import before hook '.$hook_script_path);
             $result = Process::run($hook_script_path);

--- a/tests/Backend/Feature/api/v1/LdapLoginTest.php
+++ b/tests/Backend/Feature/api/v1/LdapLoginTest.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use LdapRecord\Container;
@@ -95,8 +94,8 @@ class LdapLoginTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Config::set('ldap.enabled', true);
-        Config::set('ldap.mapping', json_decode($this->ldapMapping));
+        config(['ldap.enabled' => true]);
+        config(['ldap.mapping' => json_decode($this->ldapMapping)]);
 
         Container::getConnection('default')->getConfiguration()->set('use_tls', false);
         Container::getConnection('default')->getConfiguration()->set('use_ssl', false);
@@ -136,7 +135,7 @@ class LdapLoginTest extends TestCase
      */
     public function test_login_route()
     {
-        Config::set('ldap.enabled', false);
+        config(['ldap.enabled' => false]);
         $response = $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
             'password' => 'secret',
@@ -183,7 +182,7 @@ class LdapLoginTest extends TestCase
     public function test_attribute_mapping()
     {
         Log::swap(new LogFake);
-        Config::set('ldap.logging.enabled', false);
+        config(['ldap.logging.enabled' => false]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -217,7 +216,7 @@ class LdapLoginTest extends TestCase
     public function test_attribute_mapping_logging()
     {
         Log::swap(new LogFake);
-        Config::set('ldap.logging.enabled', true);
+        config(['ldap.logging.enabled' => true]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -252,7 +251,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         unset($newAttributeConf->attributes->first_name);
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -269,7 +270,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->attributes->first_name = 'wrongAttribute';
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -286,7 +289,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->attributes->new_attribute = 'givenName';
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -327,7 +332,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->roles[0]->rules[0]->attribute = 'notExistingAttribute';
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -352,7 +359,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->roles[0]->name = 'notExistingRole';
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -377,7 +386,9 @@ class LdapLoginTest extends TestCase
     {
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->roles = [];
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $this->from(config('app.url'))->postJson(route('api.v1.login.ldap'), [
             'username' => $this->ldapUser->uid[0],
@@ -531,7 +542,9 @@ class LdapLoginTest extends TestCase
 
         $newAttributeConf = json_decode($this->ldapMapping);
         $newAttributeConf->attributes->image = 'jpegphoto';
-        Config::set('ldap.mapping', $newAttributeConf);
+        config([
+            'ldap.mapping' => $newAttributeConf,
+        ]);
 
         $pathProfileImage1 = __DIR__.'/../../../Fixtures/profileImage-1.jpg';
         $profileImage = file_get_contents($pathProfileImage1);

--- a/tests/Backend/Feature/api/v1/LocalesTest.php
+++ b/tests/Backend/Feature/api/v1/LocalesTest.php
@@ -6,7 +6,6 @@ use App\Models\User;
 use App\Services\LocaleService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 use LdapRecord\Container;
 use LdapRecord\Laravel\Testing\DirectoryEmulator;
@@ -37,8 +36,10 @@ class LocalesTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Config::set('ldap.enabled', true);
-        Config::set('ldap.mapping', json_decode($this->ldapMapping));
+        config([
+            'ldap.enabled' => true,
+            'ldap.mapping' => json_decode($this->ldapMapping),
+        ]);
         $this->withoutMix();
 
         config([

--- a/tests/Backend/Feature/api/v1/OIDCTest.php
+++ b/tests/Backend/Feature/api/v1/OIDCTest.php
@@ -7,7 +7,6 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
@@ -174,19 +173,21 @@ class OIDCTest extends TestCase
     {
         parent::setUp();
         Http::preventStrayRequests();
-        Config::set('services.oidc.enabled', true);
-        Config::set('services.oidc.client_id', 'fake-client-id');
-        Config::set('services.oidc.client_secret', 'fake-client-secret');
-        Config::set('services.oidc.issuer', 'https://example.org');
-        Config::set('services.oidc.scopes', ['profile', 'email']);
+        config([
+            'services.oidc.enabled' => true,
+            'services.oidc.client_id' => 'fake-client-id',
+            'services.oidc.client_secret' => 'fake-client-secret',
+            'services.oidc.issuer' => 'https://example.org',
+            'services.oidc.scopes' => ['profile', 'email'],
 
-        Config::set('services.oidc.leeway', 60);
-        Config::set('services.oidc.timeout', 10);
-        Config::set('services.oidc.cache_config_max_age', 0);
-        Config::set('services.oidc.cache_jwks_max_age', 0);
+            'services.oidc.leeway' => 60,
+            'services.oidc.timeout' => 10,
+            'services.oidc.cache_config_max_age' => 0,
+            'services.oidc.cache_jwks_max_age' => 0,
 
-        Config::set('services.oidc.mapping', json_decode($this->mapping));
-        Config::set('app.enabled_locales', ['de' => ['name' => 'Deutsch', 'dateTimeFormat' => []], 'en' => ['name' => 'English', 'dateTimeFormat' => []], 'fr' => ['name' => 'Français', 'dateTimeFormat' => []]]);
+            'services.oidc.mapping' => json_decode($this->mapping),
+            'app.enabled_locales' => ['de' => ['name' => 'Deutsch', 'dateTimeFormat' => []], 'en' => ['name' => 'English', 'dateTimeFormat' => []], 'fr' => ['name' => 'Français', 'dateTimeFormat' => []]],
+        ]);
 
         Role::factory()->create(['name' => 'admin']);
         Role::factory()->create(['name' => 'user']);
@@ -200,7 +201,7 @@ class OIDCTest extends TestCase
      */
     public function test_redirect_route_disabled()
     {
-        Config::set('services.oidc.enabled', false);
+        config(['services.oidc.enabled' => false]);
         $response = $this->get(route('auth.oidc.redirect'));
         $response->assertNotFound();
     }
@@ -281,7 +282,7 @@ class OIDCTest extends TestCase
      */
     public function test_callback_route_disabled()
     {
-        Config::set('services.oidc.enabled', false);
+        config(['services.oidc.enabled' => false]);
         $response = $this->get(route('auth.oidc.callback'));
         $response->assertNotFound();
     }
@@ -595,8 +596,8 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        Config::set('services.oidc.mapping', $mapping);
-        Config::set('services.oidc.profile_image_trusted_hosts', ['example.org']);
+        config(['services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
 
         // Generate random values
         $code = Str::random();
@@ -739,8 +740,8 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        Config::set('services.oidc.mapping', $mapping);
-        Config::set('services.oidc.profile_image_trusted_hosts', ['example.org']);
+        config(['services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
 
         // Generate random values
         $code = Str::random();
@@ -790,8 +791,8 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        Config::set('services.oidc.mapping', $mapping);
-        Config::set('services.oidc.profile_image_trusted_hosts', ['example.com']);
+        config(['services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
 
         // Generate random values
         $code = Str::random();
@@ -855,7 +856,7 @@ class OIDCTest extends TestCase
         Auth::logout();
 
         // Test with empty list of trusted hosts
-        Config::set('services.oidc.profile_image_trusted_hosts', []);
+        config(['services.oidc.profile_image_trusted_hosts' => []]);
 
         // Simulate the state and nonce have been set in the session
         Session::put('openid_connect_state', $state);
@@ -2454,7 +2455,7 @@ class OIDCTest extends TestCase
 
     public function test_back_channel_logout_disabled()
     {
-        Config::set('services.oidc.enabled', false);
+        config(['services.oidc.enabled' => false]);
         $this->post(route('auth.oidc.logout'))
             ->assertNotFound();
     }

--- a/tests/Backend/Feature/api/v1/OIDCTest.php
+++ b/tests/Backend/Feature/api/v1/OIDCTest.php
@@ -596,8 +596,10 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        config(['services.oidc.mapping' => $mapping,
-            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
+        config([
+            'services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => ['example.org'],
+        ]);
 
         // Generate random values
         $code = Str::random();
@@ -740,8 +742,10 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        config(['services.oidc.mapping' => $mapping,
-            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
+        config([
+            'services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => ['example.org'],
+        ]);
 
         // Generate random values
         $code = Str::random();
@@ -791,8 +795,10 @@ class OIDCTest extends TestCase
         $mapping = json_decode($this->mapping);
         $mapping->attributes->image = 'picture';
 
-        config(['services.oidc.mapping' => $mapping,
-            'services.oidc.profile_image_trusted_hosts' => 'example.org']);
+        config([
+            'services.oidc.mapping' => $mapping,
+            'services.oidc.profile_image_trusted_hosts' => ['example.com'],
+        ]);
 
         // Generate random values
         $code = Str::random();

--- a/tests/Backend/Feature/api/v1/Room/FileTest.php
+++ b/tests/Backend/Feature/api/v1/Room/FileTest.php
@@ -18,7 +18,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
@@ -131,12 +130,16 @@ class FileTest extends TestCase
         Storage::disk('local')->assertMissing($this->room->id.'/'.$this->file_toobig->hashName());
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $this->actingAs($this->room->owner)->postJson(route('api.v1.rooms.files.add', ['room' => $this->room]), ['file' => UploadedFile::fake()->create('virus.txt')])
             ->assertJsonValidationErrors('file');
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
     }
 
     /**

--- a/tests/Backend/Feature/api/v1/Room/FileTest.php
+++ b/tests/Backend/Feature/api/v1/Room/FileTest.php
@@ -132,7 +132,7 @@ class FileTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $this->actingAs($this->room->owner)->postJson(route('api.v1.rooms.files.add', ['room' => $this->room]), ['file' => UploadedFile::fake()->create('virus.txt')])

--- a/tests/Backend/Feature/api/v1/Room/RoomStreamingTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomStreamingTest.php
@@ -325,7 +325,7 @@ class RoomStreamingTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['pause_image'] = $this->file_valid;

--- a/tests/Backend/Feature/api/v1/Room/RoomStreamingTest.php
+++ b/tests/Backend/Feature/api/v1/Room/RoomStreamingTest.php
@@ -19,7 +19,6 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -324,15 +323,19 @@ class RoomStreamingTest extends TestCase
         $this->assertNull($this->room->streaming->pause_image_url);
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['pause_image'] = $this->file_valid;
         $this->actingAs($this->room->owner)
             ->putJson(route('api.v1.rooms.streaming.config.update', ['room' => $this->room]), $data)
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['pause_image']);
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
     }
 
     /**

--- a/tests/Backend/Feature/api/v1/SettingsTest.php
+++ b/tests/Backend/Feature/api/v1/SettingsTest.php
@@ -17,7 +17,6 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Tests\Backend\TestCase;
@@ -1234,8 +1233,10 @@ class SettingsTest extends TestCase
 
     public function test_virus_files()
     {
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav.url' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
 
         $role = Role::factory()->create();

--- a/tests/Backend/Feature/api/v1/ShibbolethTest.php
+++ b/tests/Backend/Feature/api/v1/ShibbolethTest.php
@@ -9,7 +9,6 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Tests\Backend\TestCase;
 use TiMacDonald\Log\LogEntry;
@@ -87,9 +86,11 @@ class ShibbolethTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Config::set('services.shibboleth.enabled', true);
-        Config::set('services.shibboleth.mapping', json_decode($this->mapping));
-        Config::set('app.enabled_locales', ['de' => ['name' => 'Deutsch', 'dateTimeFormat' => []], 'en' => ['name' => 'English', 'dateTimeFormat' => []], 'fr' => ['name' => 'Français', 'dateTimeFormat' => []]]);
+        config([
+            'services.shibboleth.enabled' => true,
+            'services.shibboleth.mapping' => json_decode($this->mapping),
+            'app.enabled_locales' => ['de' => ['name' => 'Deutsch', 'dateTimeFormat' => []], 'en' => ['name' => 'English', 'dateTimeFormat' => []], 'fr' => ['name' => 'Français', 'dateTimeFormat' => []]],
+        ]);
 
         Role::factory()->create(['name' => 'admin']);
         Role::factory()->create(['name' => 'user']);
@@ -103,7 +104,9 @@ class ShibbolethTest extends TestCase
      */
     public function test_redirect_route_disabled()
     {
-        Config::set('services.shibboleth.enabled', false);
+        config([
+            'services.shibboleth.enabled' => false,
+        ]);
         $response = $this->get(route('auth.shibboleth.redirect'));
         $response->assertNotFound();
     }
@@ -126,7 +129,9 @@ class ShibbolethTest extends TestCase
      */
     public function test_callback_route_disabled()
     {
-        Config::set('services.shibboleth.enabled', false);
+        config([
+            'services.shibboleth.enabled' => false,
+        ]);
         $response = $this->get(route('auth.shibboleth.callback'));
         $response->assertNotFound();
     }
@@ -462,7 +467,9 @@ class ShibbolethTest extends TestCase
      */
     public function test_logout_route_disabled()
     {
-        Config::set('services.shibboleth.enabled', false);
+        config([
+            'services.shibboleth.enabled' => false,
+        ]);
         $response = $this->get(route('auth.shibboleth.logout'));
         $response->assertNotFound();
     }

--- a/tests/Backend/Feature/api/v1/StreamingTest.php
+++ b/tests/Backend/Feature/api/v1/StreamingTest.php
@@ -274,7 +274,7 @@ class StreamingTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $this->actingAs($this->user)
@@ -329,7 +329,7 @@ class StreamingTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['css_file'] = UploadedFile::fake()->create('streaming.css', 100, 'text/css');
@@ -545,7 +545,7 @@ class StreamingTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['default_pause_image'] = $this->file_valid;

--- a/tests/Backend/Feature/api/v1/StreamingTest.php
+++ b/tests/Backend/Feature/api/v1/StreamingTest.php
@@ -10,7 +10,6 @@ use Database\Seeders\RolesAndPermissionsSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Tests\Backend\TestCase;
 
@@ -273,8 +272,10 @@ class StreamingTest extends TestCase
         $this->assertNull($this->streamingSettings->default_pause_image);
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $this->actingAs($this->user)
             ->putJson(route('api.v1.streaming.update'), [
@@ -282,7 +283,9 @@ class StreamingTest extends TestCase
             ])
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['default_pause_image']);
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
 
         // Upload css file
         $data['css_file'] = UploadedFile::fake()->create('streaming.css', 100, 'text/css');
@@ -324,15 +327,19 @@ class StreamingTest extends TestCase
         $this->assertNull($this->streamingSettings->css_file);
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['css_file'] = UploadedFile::fake()->create('streaming.css', 100, 'text/css');
         $this->actingAs($this->user)
             ->putJson(route('api.v1.streaming.update'), $data)
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['css_file']);
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
 
         // Add valid join parameters
         $data['join_parameters'] = "enforceLayout=PRESENTATION_FOCUS\nuserdata-bbb_hide_nav_bar=true\nuserdata-bbb_show_participants_on_login=false\nuserdata-bbb_show_public_chat_on_login=false";
@@ -536,15 +543,19 @@ class StreamingTest extends TestCase
         $this->assertNull($lecture->streamingSettings->default_pause_image);
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $data['default_pause_image'] = $this->file_valid;
         $this->actingAs($this->user)
             ->putJson(route('api.v1.roomTypes.streaming.update', ['roomType' => $lecture]), $data)
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['default_pause_image']);
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
 
         // Disable streaming globally, route should be disabled
         config(['streaming.enabled' => false]);

--- a/tests/Backend/Feature/api/v1/UserTest.php
+++ b/tests/Backend/Feature/api/v1/UserTest.php
@@ -19,7 +19,6 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
@@ -1363,15 +1362,19 @@ class UserTest extends TestCase
         $this->assertNull($user->image);
 
         // Virus file
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $changes['image'] = $file;
         $changes['updated_at'] = $user->updated_at;
         $this->actingAs($user)->putJson(route('api.v1.users.update', ['user' => $user]), $changes)
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['image']);
-        Config::set('antivirus.enabled', false);
+        config([
+            'antivirus.enabled' => false,
+        ]);
     }
 
     public function test_show()

--- a/tests/Backend/Feature/api/v1/UserTest.php
+++ b/tests/Backend/Feature/api/v1/UserTest.php
@@ -1364,7 +1364,7 @@ class UserTest extends TestCase
         // Virus file
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         Http::fake(['http://clamav' => Http::response([['Description' => 'Eicar-Test-Signature']], 406)]);
         $changes['image'] = $file;

--- a/tests/Backend/Unit/Rules/AntivirusTest.php
+++ b/tests/Backend/Unit/Rules/AntivirusTest.php
@@ -6,7 +6,6 @@ use App\Rules\Antivirus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Tests\Backend\TestCase;
@@ -26,8 +25,10 @@ class AntivirusTest extends TestCase
 
     public function test_validation_skipped_if_disabled()
     {
-        Config::set('antivirus.enabled', false);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => false,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
 
         Http::fake();
 
@@ -51,8 +52,10 @@ class AntivirusTest extends TestCase
 
     public function test_validation_passes_for_clean_file()
     {
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         $file = UploadedFile::fake()->create('clean.txt');
         Http::fake([
             'http://clamav' => Http::response([], 200),
@@ -83,8 +86,10 @@ class AntivirusTest extends TestCase
 
     public function test_validation_fails_for_infected_file()
     {
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         $file = UploadedFile::fake()->create('virus.txt');
         Http::fake([
             'http://clamav' => Http::response([
@@ -119,8 +124,10 @@ class AntivirusTest extends TestCase
 
     public function test_validation_fails_for_clamav_error()
     {
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
         $file = UploadedFile::fake()->create('virus.txt');
         Http::fake([
             'http://clamav' => Http::response([], 500),
@@ -150,8 +157,11 @@ class AntivirusTest extends TestCase
 
     public function test_validation_fails_on_exception()
     {
-        Config::set('antivirus.enabled', true);
-        Config::set('antivirus.clamav.url', 'http://clamav');
+        config([
+            'antivirus.enabled' => true,
+            'antivirus.clamav' => 'http://clamav',
+        ]);
+
         $file = UploadedFile::fake()->create('virus.txt');
         Http::fake([
             'http://clamav' => Http::failedConnection('timeout'),

--- a/tests/Backend/Unit/Rules/AntivirusTest.php
+++ b/tests/Backend/Unit/Rules/AntivirusTest.php
@@ -27,7 +27,7 @@ class AntivirusTest extends TestCase
     {
         config([
             'antivirus.enabled' => false,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
 
         Http::fake();
@@ -54,7 +54,7 @@ class AntivirusTest extends TestCase
     {
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         $file = UploadedFile::fake()->create('clean.txt');
         Http::fake([
@@ -88,7 +88,7 @@ class AntivirusTest extends TestCase
     {
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         $file = UploadedFile::fake()->create('virus.txt');
         Http::fake([
@@ -126,7 +126,7 @@ class AntivirusTest extends TestCase
     {
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
         $file = UploadedFile::fake()->create('virus.txt');
         Http::fake([
@@ -159,7 +159,7 @@ class AntivirusTest extends TestCase
     {
         config([
             'antivirus.enabled' => true,
-            'antivirus.clamav' => 'http://clamav',
+            'antivirus.clamav.url' => 'http://clamav',
         ]);
 
         $file = UploadedFile::fake()->create('virus.txt');


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- **Refactoring** (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Refactor code base to use the same method to set/get laravel config variables

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how application configuration is read and applied across authentication, import, antivirus, and runtime connection flows with no change to user-facing behavior.
* **Tests**
  * Updated test setups to use the new, consistent configuration approach so tests reflect the same runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->