### PR TITLE
Greenlight 2/3 Import: Preparations for import of recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Docs: Import of existing Greenlight v2/v3 recordings ([#2877], [#3034])
+
 ### Changed
 
 - Improved error handling when a room requires an access code but none was provided ([#3035])
@@ -14,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved 404 error messages for better readability and clarity ([#86], [#3036])
 - Standardized 404 error handling on admin pages ([#1676], [#3036])
 - Improved and standardized room not found error handling in the room view ([#3036])
-- GL2- / GL3-Import commands now prepare import of existing recordings ([#2877], ([#3034])
+- Greenlight v2/v3 import commands now prepares import of existing recordings ([#2877], ([#3034])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved 404 error messages for better readability and clarity ([#86], [#3036])
 - Standardized 404 error handling on admin pages ([#1676], [#3036])
 - Improved and standardized room not found error handling in the room view ([#3036])
+- GL2- / GL3-Import commands now prepare import of existing recordings ([#2877], ([#3034])
 
 ### Fixed
 
@@ -767,6 +768,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#2857]: https://github.com/THM-Health/PILOS/pull/2857
 [#2873]: https://github.com/THM-Health/PILOS/issues/2873
 [#2874]: https://github.com/THM-Health/PILOS/pull/2874
+[#2877]: https://github.com/THM-Health/PILOS/issues/2877
 [#2879]: https://github.com/THM-Health/PILOS/issues/2879
 [#2880]: https://github.com/THM-Health/PILOS/pull/2880
 [#2901]: https://github.com/THM-Health/PILOS/pull/2901
@@ -784,6 +786,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3014]: https://github.com/THM-Health/PILOS/pull/3014
 [#3028]: https://github.com/THM-Health/PILOS/issues/3028
 [#3029]: https://github.com/THM-Health/PILOS/pull/3029
+[#3034]: https://github.com/THM-Health/PILOS/pull/3034
 [#3035]: https://github.com/THM-Health/PILOS/pull/3035
 [#3036]: https://github.com/THM-Health/PILOS/pull/3036
 [#3039]: https://github.com/THM-Health/PILOS/issues/3039

--- a/app/Console/Commands/ImportGreenlight2Command.php
+++ b/app/Console/Commands/ImportGreenlight2Command.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Enums\RoomLobby;
 use App\Enums\RoomUserRole;
+use App\Models\Meeting;
 use App\Models\Role;
 use App\Models\Room;
 use App\Models\RoomFile;
@@ -126,7 +127,7 @@ class ImportGreenlight2Command extends Command
 
         $requireAuth = DB::connection('greenlight')->table('features')->where('name', 'Room Authentication')->first('value')?->value == true;
         $users = DB::connection('greenlight')->table('users')->where('deleted', false)->get(['id', 'provider', 'username', 'social_uid', 'email', 'name', 'password_digest']);
-        $rooms = DB::connection('greenlight')->table('rooms')->where('deleted', false)->get(['id', 'uid', 'user_id', 'name', 'room_settings', 'access_code']);
+        $rooms = DB::connection('greenlight')->table('rooms')->where('deleted', false)->get(['id', 'uid', 'bbb_id', 'user_id', 'name', 'room_settings', 'access_code']);
         $sharedAccesses = DB::connection('greenlight')->table('shared_accesses')->get(['room_id', 'user_id']);
 
         $socialProviders = DB::connection('greenlight')->table('users')->select('provider')->whereNotIn('provider', ['greenlight', 'ldap'])->distinct()->get();
@@ -386,6 +387,12 @@ class ImportGreenlight2Command extends Command
             // set room type to given roomType for this import batch
             $dbRoom->roomType()->associate($roomType);
             $dbRoom->save();
+
+            // Create meeting
+            $dbMeeting = new Meeting;
+            $dbMeeting->id = $room->bbb_id;
+            $dbMeeting->room()->associate($dbRoom);
+            $dbMeeting->save();
 
             // increase counter and add room to room map (key = greenlight db id, value = new db id)
             $created++;

--- a/app/Console/Commands/ImportGreenlight3Command.php
+++ b/app/Console/Commands/ImportGreenlight3Command.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Enums\RoomLobby;
 use App\Enums\RoomUserRole;
+use App\Models\Meeting;
 use App\Models\Role;
 use App\Models\Room;
 use App\Models\RoomFile;
@@ -108,7 +109,7 @@ class ImportGreenlight3Command extends Command
         ]]);
 
         $users = DB::connection('greenlight')->table('users')->where('provider', 'greenlight')->get(['id', 'name', 'email', 'external_id', 'password_digest']);
-        $rooms = DB::connection('greenlight')->table('rooms')->get(['id', 'friendly_id', 'user_id', 'name']);
+        $rooms = DB::connection('greenlight')->table('rooms')->get(['id', 'friendly_id', 'meeting_id', 'user_id', 'name']);
         $sharedAccesses = DB::connection('greenlight')->table('shared_accesses')->get(['room_id', 'user_id']);
 
         // Start transaction to rollback if import fails or user cancels
@@ -300,6 +301,12 @@ class ImportGreenlight3Command extends Command
             // set room type to given roomType for this import batch
             $dbRoom->roomType()->associate($roomType);
             $dbRoom->save();
+
+            // Create meeting
+            $dbMeeting = new Meeting;
+            $dbMeeting->id = $room->meeting_id;
+            $dbMeeting->room()->associate($dbRoom);
+            $dbMeeting->save();
 
             // increase counter and add room to room map (key = greenlight db id, value = new db id)
             $created++;

--- a/app/Console/Commands/ImportRecordingsCommand.php
+++ b/app/Console/Commands/ImportRecordingsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Enums\RecordingAccess;
 use App\Jobs\ProcessRecording;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
@@ -36,6 +37,15 @@ class ImportRecordingsCommand extends Command
             }
 
             ProcessRecording::dispatch($file);
+        }
+
+        $files = Storage::disk('recordings-spool')->files('public');
+        foreach ($files as $file) {
+            if (! Str::endsWith($file, '.tar')) {
+                continue;
+            }
+
+            ProcessRecording::dispatch($file, RecordingAccess::EVERYONE);
         }
     }
 }

--- a/app/Jobs/ProcessRecording.php
+++ b/app/Jobs/ProcessRecording.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Enums\RecordingAccess;
 use App\Exceptions\RecordingExtractionFailed;
 use App\Models\RecordingFormat;
 use DateTime;
@@ -32,15 +33,18 @@ class ProcessRecording implements ShouldBeUnique, ShouldQueue
 
     protected string $file;
 
+    protected RecordingAccess $access;
+
     protected string $tempPath;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(string $file)
+    public function __construct(string $file, RecordingAccess $access = RecordingAccess::OWNER)
     {
         $this->onQueue('recordings');
         $this->file = $file;
+        $this->access = $access;
         $filename = pathinfo($this->file, PATHINFO_FILENAME);
         $this->tempPath = 'temp/'.$filename;
     }
@@ -140,11 +144,14 @@ class ProcessRecording implements ShouldBeUnique, ShouldQueue
                 // Create or update the recording format in the database
                 $recordingFormat = RecordingFormat::createFromRecordingXML($xml);
 
-                $formatDirectory = dirname($metadataFile);
-
                 // Recording format was created or updated (found the corresponding room)
                 if ($recordingFormat != null) {
+                    // Set visibility
+                    $recordingFormat->recording->access = $this->access;
+                    $recordingFormat->recording->save();
+
                     // Move the recording to the final destination
+                    $formatDirectory = dirname($metadataFile);
                     Storage::disk('recordings')->move($formatDirectory, $recordingFormat->recording->id.'/'.$recordingFormat->format);
                 } else {
                     // No room found for the recording format, fail whole file

--- a/app/Jobs/ProcessRecording.php
+++ b/app/Jobs/ProcessRecording.php
@@ -194,4 +194,14 @@ class ProcessRecording implements ShouldBeUnique, ShouldQueue
     {
         Storage::disk('recordings')->deleteDirectory($this->tempPath);
     }
+
+    public function getFile(): string
+    {
+        return $this->file;
+    }
+
+    public function getAccess(): RecordingAccess
+    {
+        return $this->access;
+    }
 }

--- a/app/Models/RecordingFormat.php
+++ b/app/Models/RecordingFormat.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Date;
 use SimpleXMLElement;
@@ -44,20 +45,11 @@ class RecordingFormat extends Model
         $meetingId = (string) $xml->meta->meetingId;
         $meetingName = (string) $xml->meta->meetingName;
 
-        // Find the meeting with the given id
-        $meeting = Meeting::where('id', $meetingId)->first();
-
-        // If the meeting exists, get the room from the meeting
-        // Otherwise, find the room with the given id
-        if ($meeting != null) {
-            $room = $meeting->room;
-        } else {
-            // Fallback to greenlight behaviour (using the persistent room id as meeting id)
-            $room = Room::where('id', $meetingId)->first();
-        }
-
-        // If the room does not exist, we can't associate the recording format with a room
-        if ($room == null) {
+        try {
+            // Find the meeting with the given id
+            $meeting = Meeting::findOrFail($meetingId);
+        } catch (ModelNotFoundException) {
+            // If the meeting does not exist, we can't associate the recording format with anything
             return null;
         }
 
@@ -69,7 +61,7 @@ class RecordingFormat extends Model
             $recording->description = $meetingName;
             $recording->start = $start;
             $recording->end = $end;
-            $recording->room()->associate($room);
+            $recording->room()->associate($meeting->room);
             $recording->meeting()->associate($meeting);
             $recording->save();
         }

--- a/docs/docs/administration/08-advanced/03-recording.md
+++ b/docs/docs/administration/08-advanced/03-recording.md
@@ -208,7 +208,11 @@ The script will try to extract the archive file to a temporary directory, import
 
 If the import was successful, the archive file will be deleted.
 
-By default all recording files are only visible to the meeting owner. The owner can change the visibility of the recordings in the UI.
+By default, all recording files are only visible to the meeting owner. The owner can change the visibility of the recordings in the UI.
+
+:::tip Public recordings by default
+If you want imported recordings to be visible to everyone, put them in a subfolder `public` in the `recordings-spool` directory.
+:::
 
 ### Failed imports
 

--- a/docs/docs/administration/08-advanced/06-migrate-greenlight.md
+++ b/docs/docs/administration/08-advanced/06-migrate-greenlight.md
@@ -3,7 +3,7 @@ title: Migrate from Greenlight
 description: Step by step guide to migrate from Greenlight to PILOS
 ---
 
-PILOS provides an easy to use command to import all Greenlight users (incl. ldap), rooms and shared accesses.
+PILOS provides an easy-to-use command to import all Greenlight users (incl. ldap), rooms (incl. default presentation) and shared accesses.
 
 ## Preparing migration from other host
 
@@ -31,9 +31,9 @@ Successfully imported presentation files will be copied to a different location.
 
 ## Running migration command
 
-The command will output the process of the import and informs about failed user, room and shared access import.
+The command will output the process of the import and informs about failed user, room, room presentation and shared access import.
 
-**Note** If a room with the same room id already exists in PILOS it will NOT be imported and the shared accesses are ignored.
+**Note** If a room with the same room id already exists in PILOS it will NOT be imported and its default presentation and shared accesses are ignored.
 
 ### Greenlight 2
 
@@ -134,6 +134,25 @@ docker compose exec app pilos-cli import:greenlight-v3 \
     postgres \
     12345678
 ```
+
+## Importing recordings
+
+You can also import recordings for existing rooms. To make this possible the import command creates a meeting with the BBB meeting ID for every imported room.
+This meeting does not have a start- or end timestamp, so it not visible in the frontend. Associated recordings _will_ be listed, however.
+
+To import existing recordings, you have to
+
+1. find the meeting ID (column `bbb_id` (GL2) or `meeting_id` (GL3) in the `rooms` table)
+2. find all recordings with this meeting ID (XPath: `/recording/meta/meetingId` in metadata.xml)
+3. pack matching recordings into tar files and
+4. move or copy those tar files to PILOS' `recordings-spool` directory.
+
+Existing recordings prepared like this will be imported just like new ones would.
+
+**Note** You _may_ have to temporarily increase RAM allocated to horizon if it is limited.
+
+**Note** YMMV, depending on your BBB loadbalancer. If, for example, you run b3scale, you need to extract the "simple" Greenlight meeting ID from the
+more complex b3scale meeting ID.
 
 ## Adjust nginx
 

--- a/docs/docs/administration/08-advanced/06-migrate-greenlight.md
+++ b/docs/docs/administration/08-advanced/06-migrate-greenlight.md
@@ -137,8 +137,8 @@ docker compose exec app pilos-cli import:greenlight-v3 \
 
 ## Importing recordings
 
-You can also import recordings for existing rooms. To make this possible the import command creates a meeting with the BBB meeting ID for every imported room.
-This meeting does not have a start- or end timestamp, so it not visible in the frontend. Associated recordings _will_ be listed, however.
+You can also import recordings for existing rooms. To make this possible the import command creates a meeting with the BBB meeting ID for every
+imported room. This meeting does not have a start- or end timestamp, so it is not visible in the frontend but associated recordings _will_ be listed.
 
 To import existing recordings, you have to
 
@@ -148,6 +148,9 @@ To import existing recordings, you have to
 4. move or copy those tar files to PILOS' `recordings-spool` directory.
 
 Existing recordings prepared like this will be imported just like new ones would.
+
+Imported recordings will be visible only to room owners, who may of course change this, if they so choose. If you want imported recordings to be
+visible to everyone, put them in a subfolder `public` in the `recordings-spool` directory.
 
 **Note** You _may_ have to temporarily increase RAM allocated to horizon if it is limited.
 

--- a/tests/Backend/Unit/Console/ImportGreenlight2Test.php
+++ b/tests/Backend/Unit/Console/ImportGreenlight2Test.php
@@ -6,6 +6,7 @@ namespace Tests\Backend\Unit\Console;
 
 use App\Enums\RoomLobby;
 use App\Enums\RoomUserRole;
+use App\Models\Meeting;
 use App\Models\Role;
 use App\Models\Room;
 use App\Models\RoomType;
@@ -99,7 +100,7 @@ class ImportGreenlight2Test extends TestCase
                             ->with('deleted', false)
                             ->andReturn(Mockery::mock('Illuminate\Database\Query\Builder', function ($mock) use ($rooms) {
                                 $mock->shouldReceive('get')
-                                    ->with(['id', 'uid', 'user_id', 'name', 'room_settings', 'access_code'])
+                                    ->with(['id', 'uid', 'bbb_id', 'user_id', 'name', 'room_settings', 'access_code'])
                                     ->andReturn($rooms);
                             }));
                     }));
@@ -238,17 +239,17 @@ class ImportGreenlight2Test extends TestCase
 
         // Create fake rooms
         $rooms = [];
-        $rooms[] = new Greenlight2Room(1, $users[0]->id, 'Test Room 1', 'abc-def-xyz-123');
-        $rooms[] = new Greenlight2Room(2, $users[1]->id, 'Test Room 2', 'abc-def-xyz-234');
-        $rooms[] = new Greenlight2Room(3, $users[2]->id, 'Test Room 3', 'abc-def-xyz-345');
-        $rooms[] = new Greenlight2Room(4, $users[3]->id, 'Test Room 4', 'abc-def-xyz-456');
-        $rooms[] = new Greenlight2Room(5, $users[4]->id, 'Test Room 5', 'abc-def-xyz-567');
-        $rooms[] = new Greenlight2Room(6, $users[5]->id, 'Test Room 6', 'abc-def-xyz-678');
+        $rooms[] = new Greenlight2Room(1, 'abc-def-xyz-123', 'thue5aivaiyohreetu1zaipe4iez7eengoopoohi', 'Test Room 1', $users[0]->id);
+        $rooms[] = new Greenlight2Room(2, 'abc-def-xyz-234', 'aef9eiquoo8oph9oon4oovit8oid9ree7caigahw', 'Test Room 2', $users[1]->id);
+        $rooms[] = new Greenlight2Room(3, 'abc-def-xyz-345', 'iekoongaicahhaivah0xaud3tha3iem8eathoaxu', 'Test Room 3', $users[2]->id);
+        $rooms[] = new Greenlight2Room(4, 'abc-def-xyz-456', 'oeph7ohhoochoy7ruoshae9uephie0tha8aup3oo', 'Test Room 4', $users[3]->id);
+        $rooms[] = new Greenlight2Room(5, 'abc-def-xyz-567', 'eecae0kugoo3aes2aiquaif8aeraiy1aiva2ohje', 'Test Room 5', $users[4]->id);
+        $rooms[] = new Greenlight2Room(6, 'abc-def-xyz-678', 'eizaipaikohheizohvaehiech5ach3el9haech5g', 'Test Room 6', $users[5]->id);
 
-        $rooms[] = new Greenlight2Room(7, $users[0]->id, 'Test Room 7', 'hij-klm-xyz-123', '012345', ['muteOnStart' => false, 'requireModeratorApproval' => true, 'anyoneCanStart' => false, 'joinModerator' => true]);
-        $rooms[] = new Greenlight2Room(8, $users[0]->id, 'Test Room 8', 'hij-klm-xyz-234', null, ['muteOnStart' => true, 'requireModeratorApproval' => false, 'anyoneCanStart' => true, 'joinModerator' => false]);
-        $rooms[] = new Greenlight2Room(9, 99, 'Test Room 9', 'hij-klm-xyz-456', '012345');
-        $rooms[] = new Greenlight2Room(10, $users[0]->id, 'Test Room 10', $existingRoom->id);
+        $rooms[] = new Greenlight2Room(7, 'hij-klm-xyz-123', 'aebaoj6phak4eaghoizeiwaecudei6hishochua7', 'Test Room 7', $users[0]->id, '012345', ['muteOnStart' => false, 'requireModeratorApproval' => true, 'anyoneCanStart' => false, 'joinModerator' => true]);
+        $rooms[] = new Greenlight2Room(8, 'hij-klm-xyz-234', 'aicha2vahw1zei7aecoo1ainoph1ietei3nei4la', 'Test Room 8', $users[0]->id, null, ['muteOnStart' => true, 'requireModeratorApproval' => false, 'anyoneCanStart' => true, 'joinModerator' => false]);
+        $rooms[] = new Greenlight2Room(9, 'hij-klm-xyz-456', 'quohseseey2aheicoc3eedaedei4kif8zo4xaiki', 'Test Room 9', 99, '012345');
+        $rooms[] = new Greenlight2Room(10, $existingRoom->id, 'aima0eiv6uyaif6ien8ahchoothohkeiphaegh0u', 'Test Room 10', $users[0]->id);
 
         // Create fake presentations
         $presentations = [];
@@ -286,6 +287,7 @@ class ImportGreenlight2Test extends TestCase
 
         // check amount of rooms and users
         $this->assertCount(9, Room::all());
+        $this->assertCount(8, Meeting::all());
         $this->assertCount(2, User::where('authenticator', 'local')->get());
         $this->assertCount(2, User::where('authenticator', 'ldap')->get());
         $this->assertCount(1, User::where('authenticator', 'shibboleth')->get());
@@ -295,6 +297,21 @@ class ImportGreenlight2Test extends TestCase
         $this->assertEqualsCanonicalizing(
             [$existingRoom->id, 'abc-def-xyz-123', 'abc-def-xyz-234', 'abc-def-xyz-345', 'abc-def-xyz-456', 'abc-def-xyz-567', 'abc-def-xyz-678', 'hij-klm-xyz-123', 'hij-klm-xyz-234'],
             Room::all()->pluck('id')->toArray()
+        );
+
+        // check if all meetings are created
+        $this->assertEqualsCanonicalizing(
+            [
+                'thue5aivaiyohreetu1zaipe4iez7eengoopoohi',
+                'aef9eiquoo8oph9oon4oovit8oid9ree7caigahw',
+                'iekoongaicahhaivah0xaud3tha3iem8eathoaxu',
+                'oeph7ohhoochoy7ruoshae9uephie0tha8aup3oo',
+                'eecae0kugoo3aes2aiquaif8aeraiy1aiva2ohje',
+                'eizaipaikohheizohvaehiech5ach3el9haech5g',
+                'aebaoj6phak4eaghoizeiwaecudei6hishochua7',
+                'aicha2vahw1zei7aecoo1ainoph1ietei3nei4la',
+            ],
+            Meeting::all()->pluck('id')->toArray()
         );
 
         // check if allow guest setting is correct
@@ -398,11 +415,7 @@ class ImportGreenlight2Test extends TestCase
                 ->expectsOutput('Importing rooms')
                 ->expectsOutput('8 created, 1 skipped (already existed)')
                 ->expectsOutput('Room import failed for the following 1 rooms, because no room owner was found:')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Name        | ID              | Access code |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Test Room 9 | hij-klm-xyz-456 | 012345      |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
+                ->expectsTable(['Name', 'ID', 'Access code'], [['Test Room 9', 'hij-klm-xyz-456', '012345']])
                 ->expectsOutput('Importing presentations for rooms')
                 ->expectsOutput('2 created, 1 skipped (file not found)')
                 ->expectsOutput('Importing shared room accesses')
@@ -430,11 +443,7 @@ class ImportGreenlight2Test extends TestCase
                 ->expectsOutput('Importing rooms')
                 ->expectsOutput('8 created, 1 skipped (already existed)')
                 ->expectsOutput('Room import failed for the following 1 rooms, because no room owner was found:')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Name        | ID              | Access code |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Test Room 9 | hij-klm-xyz-456 | 012345      |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
+                ->expectsTable(['Name', 'ID', 'Access code'], [['Test Room 9', 'hij-klm-xyz-456', '012345']])
                 ->expectsOutput('Importing presentations for rooms')
                 ->expectsOutput('2 created, 1 skipped (file not found)')
                 ->expectsOutput('Importing shared room accesses')
@@ -478,11 +487,7 @@ class ImportGreenlight2Test extends TestCase
                 ->expectsOutput('Importing rooms')
                 ->expectsOutput('8 created, 1 skipped (already existed)')
                 ->expectsOutput('Room import failed for the following 1 rooms, because no room owner was found:')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Name        | ID              | Access code |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
-                ->expectsOutput('| Test Room 9 | hij-klm-xyz-456 | 012345      |')
-                ->expectsOutput('+-------------+-----------------+-------------+')
+                ->expectsTable(['Name', 'ID', 'Access code'], [['Test Room 9', 'hij-klm-xyz-456', '012345']])
                 ->expectsOutput('Importing presentations for rooms')
                 ->expectsOutput('2 created, 1 skipped (file not found)')
                 ->expectsOutput('Importing shared room accesses')

--- a/tests/Backend/Unit/Console/ImportGreenlight3Test.php
+++ b/tests/Backend/Unit/Console/ImportGreenlight3Test.php
@@ -6,6 +6,7 @@ namespace Tests\Backend\Unit\Console;
 
 use App\Enums\RoomLobby;
 use App\Enums\RoomUserRole;
+use App\Models\Meeting;
 use App\Models\Role;
 use App\Models\Room;
 use App\Models\RoomType;
@@ -80,7 +81,7 @@ class ImportGreenlight3Test extends TestCase
                     ->once()
                     ->andReturn(Mockery::mock('Illuminate\Database\Query\Builder', function ($mock) use ($rooms) {
                         $mock->shouldReceive('get')
-                            ->with(['id', 'friendly_id', 'user_id', 'name'])
+                            ->with(['id', 'friendly_id', 'meeting_id', 'user_id', 'name'])
                             ->andReturn($rooms);
                     }));
 
@@ -237,15 +238,14 @@ class ImportGreenlight3Test extends TestCase
 
         // Create fake rooms
         $rooms = [];
-        $rooms[] = new Greenlight3Room('1', 'abc-def-xyz-123', $users[0]->id, 'Test Room 1');
-        $rooms[] = new Greenlight3Room('2', 'abc-def-xyz-234', $users[1]->id, 'Test Room 2');
-        $rooms[] = new Greenlight3Room('3', 'abc-def-xyz-345', $users[2]->id, 'Test Room 3');
-        $rooms[] = new Greenlight3Room('4', 'abc-def-xyz-456', $users[3]->id, 'Test Room 4');
-
-        $rooms[] = new Greenlight3Room('5', 'hij-klm-xyz-123', $users[0]->id, 'Test Room 5');
-        $rooms[] = new Greenlight3Room('6', 'hij-klm-xyz-234', $users[0]->id, 'Test Room 6');
-        $rooms[] = new Greenlight3Room('7', 'hij-klm-xyz-456', '99', 'Test Room 9', true);
-        $rooms[] = new Greenlight3Room('8', $existingRoom->id, $users[0]->id, 'Test Room 10');
+        $rooms[] = new Greenlight3Room('1', 'abc-def-xyz-123', 'kah3caebohzosei4ohd5vadai5xeech4iephieha', 'Test Room 1', $users[0]->id);
+        $rooms[] = new Greenlight3Room('2', 'abc-def-xyz-234', 'shuuchuk3ahchu2xai3hienae1eghohngueleih9', 'Test Room 2', $users[1]->id);
+        $rooms[] = new Greenlight3Room('3', 'abc-def-xyz-345', 'aepoh2etaira5ahjootoh2naedahno6fieghaibi', 'Test Room 3', $users[2]->id);
+        $rooms[] = new Greenlight3Room('4', 'abc-def-xyz-456', 'jee8sha6koh9iechik4thohjahv2biedua8shiep', 'Test Room 4', $users[3]->id);
+        $rooms[] = new Greenlight3Room('5', 'hij-klm-xyz-123', 'jiel3oe0gohvohmei2aew0ooghahwiejaileeghu', 'Test Room 5', $users[0]->id);
+        $rooms[] = new Greenlight3Room('6', 'hij-klm-xyz-234', 'ies7oroizuulaiqu3cheeshoogahh1mae1aew0ee', 'Test Room 6', $users[0]->id);
+        $rooms[] = new Greenlight3Room('7', 'hij-klm-xyz-456', 'eu6ahs7eephahhain6thae6thodu7xoophooghei', 'Test Room 9', '99');
+        $rooms[] = new Greenlight3Room('8', $existingRoom->id, 'gaezohvohsh6lougho8coongaebiech0wu6jukia', 'Test Room 10', $users[0]->id);
 
         // Create fake presentations
         $presentations = [];
@@ -303,6 +303,19 @@ class ImportGreenlight3Test extends TestCase
         $this->assertEqualsCanonicalizing(
             [$existingRoom->id, 'abc-def-xyz-123', 'abc-def-xyz-234', 'abc-def-xyz-345', 'abc-def-xyz-456', 'hij-klm-xyz-123', 'hij-klm-xyz-234'],
             Room::all()->pluck('id')->toArray()
+        );
+
+        // Check if all meetings are created
+        $this->assertEqualsCanonicalizing(
+            [
+                'kah3caebohzosei4ohd5vadai5xeech4iephieha',
+                'shuuchuk3ahchu2xai3hienae1eghohngueleih9',
+                'aepoh2etaira5ahjootoh2naedahno6fieghaibi',
+                'jee8sha6koh9iechik4thohjahv2biedua8shiep',
+                'jiel3oe0gohvohmei2aew0ooghahwiejaileeghu',
+                'ies7oroizuulaiqu3cheeshoogahh1mae1aew0ee',
+            ],
+            Meeting::all()->pluck('id')->toArray()
         );
 
         // Check access code

--- a/tests/Backend/Unit/Console/ImportRecordingsCommandTest.php
+++ b/tests/Backend/Unit/Console/ImportRecordingsCommandTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Backend\Unit\Console;
 
+use App\Enums\RecordingAccess;
+use App\Jobs\ProcessRecording;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Tests\Backend\TestCase;
 
 class ImportRecordingsCommandTest extends TestCase
@@ -16,10 +19,48 @@ class ImportRecordingsCommandTest extends TestCase
     public function test_import_recording()
     {
         Queue::fake();
+        Storage::fake('recordings-spool');
 
-        config(['filesystems.disks.recordings-spool.root' => 'tests/Backend/Fixtures/Recordings']);
+        copy(base_path('tests/Backend/Fixtures/Recordings/invalid-recording.tar'), Storage::disk('recordings-spool')->path('invalid-recording.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/multiple.tar'), Storage::disk('recordings-spool')->path('multiple.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/notes.tar'), Storage::disk('recordings-spool')->path('notes.tar'));
 
         $this->artisan('import:recordings')->assertSuccessful();
+
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'invalid-recording.tar' && $job->getAccess() === RecordingAccess::OWNER;
+        });
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'multiple.tar' && $job->getAccess() === RecordingAccess::OWNER;
+        });
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'notes.tar' && $job->getAccess() === RecordingAccess::OWNER;
+        });
+
+        Queue::assertCount(3);
+    }
+
+    public function test_import_public_recording()
+    {
+        Queue::fake();
+        Storage::fake('recordings-spool');
+        Storage::disk('recordings-spool')->makeDirectory('public');
+
+        copy(base_path('tests/Backend/Fixtures/Recordings/invalid-recording.tar'), Storage::disk('recordings-spool')->path('invalid-recording.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/multiple.tar'), Storage::disk('recordings-spool')->path('public/multiple.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/notes.tar'), Storage::disk('recordings-spool')->path('public/notes.tar'));
+
+        $this->artisan('import:recordings')->assertSuccessful();
+
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'invalid-recording.tar' && $job->getAccess() === RecordingAccess::OWNER;
+        });
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'public/multiple.tar' && $job->getAccess() === RecordingAccess::EVERYONE;
+        });
+        Queue::assertPushed(ProcessRecording::class, function ($job) {
+            return $job->getFile() === 'public/notes.tar' && $job->getAccess() === RecordingAccess::EVERYONE;
+        });
 
         Queue::assertCount(3);
     }
@@ -28,7 +69,11 @@ class ImportRecordingsCommandTest extends TestCase
     {
         Queue::fake();
 
-        config(['filesystems.disks.recordings-spool.root' => 'tests/Backend/Fixtures/Recordings']);
+        Storage::fake('recordings-spool');
+
+        copy(base_path('tests/Backend/Fixtures/Recordings/invalid-recording.tar'), Storage::disk('recordings-spool')->path('invalid-recording.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/multiple.tar'), Storage::disk('recordings-spool')->path('multiple.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/notes.tar'), Storage::disk('recordings-spool')->path('notes.tar'));
 
         // Import hook command to write "OK" to a temp file
         $tempFile = tempnam(sys_get_temp_dir(), 'recording-import-hook-test');
@@ -49,7 +94,11 @@ class ImportRecordingsCommandTest extends TestCase
     {
         Queue::fake();
 
-        config(['filesystems.disks.recordings-spool.root' => 'tests/Backend/Fixtures/Recordings']);
+        Storage::fake('recordings-spool');
+
+        copy(base_path('tests/Backend/Fixtures/Recordings/invalid-recording.tar'), Storage::disk('recordings-spool')->path('invalid-recording.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/multiple.tar'), Storage::disk('recordings-spool')->path('multiple.tar'));
+        copy(base_path('tests/Backend/Fixtures/Recordings/notes.tar'), Storage::disk('recordings-spool')->path('notes.tar'));
 
         // Import hook command to write "OK" to a file that does not exist
         $file = '/invalidPath/invalidFile';

--- a/tests/Backend/Unit/Console/helper/Greenlight2Room.php
+++ b/tests/Backend/Unit/Console/helper/Greenlight2Room.php
@@ -14,6 +14,8 @@ class Greenlight2Room
 
     public $uid;
 
+    public $bbb_id;
+
     public $room_settings;
 
     public $access_code;
@@ -23,14 +25,15 @@ class Greenlight2Room
     /**
      * Greenlight2Room constructor.
      */
-    public function __construct(int $id, int $user_id, string $name, string $uid, ?string $access_code = null, array $room_settings = [], bool $deleted = false)
+    public function __construct(int $id, string $uid, string $bbb_id, string $name, int $user_id, ?string $access_code = null, array $room_settings = [], bool $deleted = false)
     {
         $this->id = $id;
-        $this->user_id = $user_id;
-        $this->name = $name;
         $this->uid = $uid;
-        $this->room_settings = json_encode($room_settings);
+        $this->bbb_id = $bbb_id;
+        $this->name = $name;
+        $this->user_id = $user_id;
         $this->access_code = $access_code;
+        $this->room_settings = json_encode($room_settings);
         $this->deleted = $deleted;
     }
 }

--- a/tests/Backend/Unit/Console/helper/Greenlight3Room.php
+++ b/tests/Backend/Unit/Console/helper/Greenlight3Room.php
@@ -10,6 +10,8 @@ class Greenlight3Room
 
     public $friendly_id;
 
+    public $meeting_id;
+
     public $user_id;
 
     public $name;
@@ -17,11 +19,12 @@ class Greenlight3Room
     /**
      * Greenlight3Room constructor.
      */
-    public function __construct(string $id, string $friendly_id, string $user_id, string $name)
+    public function __construct(string $id, string $friendly_id, string $meeting_id, string $name, string $user_id)
     {
         $this->id = $id;
         $this->friendly_id = $friendly_id;
-        $this->user_id = $user_id;
+        $this->meeting_id = $meeting_id;
         $this->name = $name;
+        $this->user_id = $user_id;
     }
 }

--- a/tests/Backend/Unit/Jobs/ProcessRecordingTest.php
+++ b/tests/Backend/Unit/Jobs/ProcessRecordingTest.php
@@ -228,4 +228,50 @@ class ProcessRecordingTest extends TestCase
         $this->assertFileExists(Storage::disk('recordings')->path(self::INTERNAL_MEETING_ID.'/presentation/video/webcams.webm'));
         $this->assertFileExists(Storage::disk('recordings')->path(self::INTERNAL_MEETING_ID.'/video/video-0.m4v'));
     }
+
+    public function test_public()
+    {
+        Storage::fake('recordings');
+        Storage::fake('recordings-spool');
+
+        $meeting = Meeting::factory()->create([
+            'id' => self::EXTERNAL_MEETING_ID,
+        ]);
+
+        Log::swap(new LogFake);
+        Queue::fake();
+
+        Storage::disk('recordings-spool')->makeDirectory('public');
+        copy(base_path('tests/Backend/Fixtures/Recordings/notes.tar'), Storage::disk('recordings-spool')->path('public/notes.tar'));
+
+        $this->assertCount(1, Storage::disk('recordings-spool')->files('public'));
+
+        $job = (new ProcessRecording('public/notes.tar', RecordingAccess::EVERYONE))->withFakeQueueInteractions();
+
+        $job->handle();
+
+        $this->assertCount(0, Storage::disk('recordings-spool')->files(''));
+        $this->assertCount(0, Storage::disk('recordings-spool')->files('failed'));
+
+        // Check if recording was added
+        $this->assertCount(1, $meeting->room->recordings);
+        $recording = $meeting->room->recordings->first();
+        $this->assertEquals(self::TITLE, $recording->description);
+        $this->assertEquals(RecordingAccess::EVERYONE, $recording->access);
+        $this->assertEquals(self::START, $recording->start->getTimestamp());
+        $this->assertEquals(self::END, $recording->end->getTimestamp());
+
+        // Check if formats were added to the database
+        $formats = $recording->formats;
+        $this->assertCount(1, $formats);
+
+        // Check if formats are disabled and have the correct URL (from the metadata.xml)
+        $notes = $formats->firstWhere('format', 'notes');
+        $this->assertFalse($notes->disabled);
+        $this->assertEquals('/notes/'.self::INTERNAL_MEETING_ID.'/notes.pdf', $notes->url);
+
+        // Check if files are correctly extracted (list incomplete)
+        $this->assertTrue(Storage::disk('recordings')->directoryExists(self::INTERNAL_MEETING_ID));
+        $this->assertFileExists(Storage::disk('recordings')->path(self::INTERNAL_MEETING_ID.'/notes/notes.pdf'));
+    }
 }

--- a/tests/Backend/Unit/Jobs/ProcessRecordingTest.php
+++ b/tests/Backend/Unit/Jobs/ProcessRecordingTest.php
@@ -170,7 +170,7 @@ class ProcessRecordingTest extends TestCase
         $formats = $recording->formats;
         $this->assertCount(1, $formats);
 
-        // Check if formats are disabled and have the correct URL (from the metadata.xml)
+        // Check if formats are enabled and have the correct URL (from the metadata.xml)
         $notes = $formats->firstWhere('format', 'notes');
         $this->assertFalse($notes->disabled);
         $this->assertEquals('/notes/'.self::INTERNAL_MEETING_ID.'/notes.pdf', $notes->url);
@@ -215,7 +215,7 @@ class ProcessRecordingTest extends TestCase
         $formats = $recording->formats;
         $this->assertCount(5, $formats);
 
-        // Check if formats are disabled and have the correct URL (from the metadata.xml)
+        // Check if formats are enabled and have the correct URL (from the metadata.xml)
         $notes = $formats->firstWhere('format', 'notes');
         $this->assertFalse($notes->disabled);
         $this->assertEquals('/notes/'.self::INTERNAL_MEETING_ID.'/notes.pdf', $notes->url);
@@ -265,7 +265,7 @@ class ProcessRecordingTest extends TestCase
         $formats = $recording->formats;
         $this->assertCount(1, $formats);
 
-        // Check if formats are disabled and have the correct URL (from the metadata.xml)
+        // Check if formats are enabled and have the correct URL (from the metadata.xml)
         $notes = $formats->firstWhere('format', 'notes');
         $this->assertFalse($notes->disabled);
         $this->assertEquals('/notes/'.self::INTERNAL_MEETING_ID.'/notes.pdf', $notes->url);


### PR DESCRIPTION
# Partially resolves  #2877

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- When running a Greenlight 2 / Greenlight 3 import command, a meeting (without timestamps) is created for every imported room so that recordings can be associated later on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Greenlight v2/v3 room imports now create Meeting records and link imported recordings via meetings to rooms for more reliable association.
* **Tests**
  * Updated import tests and fixtures to assert meeting creation and streamlined CLI output assertions.
* **Documentation**
  * Migration guide expanded with presentation import details and step-by-step recording-import instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->