### PR TITLE
Improve form validation error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -799,6 +799,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3034]: https://github.com/THM-Health/PILOS/pull/3034
 [#3035]: https://github.com/THM-Health/PILOS/pull/3035
 [#3036]: https://github.com/THM-Health/PILOS/pull/3036
+[#3038]: https://github.com/THM-Health/PILOS/issues/3038
 [#3039]: https://github.com/THM-Health/PILOS/issues/3039
 [#3040]: https://github.com/THM-Health/PILOS/pull/3040
 [#3056]: https://github.com/THM-Health/PILOS/pull/3056

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Docs: Import of existing Greenlight v2/v3 recordings ([#2877], [#3034])
+- Toast notification for form validation errors in non-dialog forms ([#3056])
+- Auto-scroll to the first form validation error ([#3056])
 
 ### Changed
 
@@ -799,6 +801,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3036]: https://github.com/THM-Health/PILOS/pull/3036
 [#3039]: https://github.com/THM-Health/PILOS/issues/3039
 [#3040]: https://github.com/THM-Health/PILOS/pull/3040
+[#3056]: https://github.com/THM-Health/PILOS/pull/3056
 [#3078]: https://github.com/THM-Health/PILOS/issues/3078
 [#3079]: https://github.com/THM-Health/PILOS/pull/3079
 [#3128]: https://github.com/THM-Health/PILOS/pull/3128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Docs: Import of existing Greenlight v2/v3 recordings ([#2877], [#3034])
 - Toast notification for form validation errors in non-dialog forms ([#3056])
-- Auto-scroll to the first form validation error ([#3056])
+- Auto-scroll to the first form validation error ([#3038], [#3056])
+- Required attribute to more form fields to improve accessibility ([#3056])
 
 ### Changed
 
@@ -24,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved and standardized room not found error handling in the room view ([#3036])
 - Greenlight v2/v3 import commands now prepares import of existing recordings ([#2877], ([#3034])
 - Bump base PHP image to 8.5 ([#2814])
+- Form validation error handling ([#3056])
+- Add several users to room dialog no longer has a role preselected ([#3056])
 
 ### Fixed
 

--- a/app/Providers/TranslationServiceProvider.php
+++ b/app/Providers/TranslationServiceProvider.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Translation\FileLoader;
 use Illuminate\Translation\TranslationServiceProvider as BaseTranslationServiceProvider;
 
 class TranslationServiceProvider extends BaseTranslationServiceProvider
 {
+
+    public function register()
+    {
+        parent::register();
+        $this->app->make(Translator::class)->handleMissingKeysUsing(function ($key, $replace, $locale, $fallback) {
+            return match ($key) {
+                '(and :count more error)' => __('validation.one_more_error'),
+                '(and :count more errors)' => __('validation.several_errors'),
+                default => $key,
+            };
+        });
+    }
+
     /**
      * Register the translation line loader.
      *

--- a/app/Providers/TranslationServiceProvider.php
+++ b/app/Providers/TranslationServiceProvider.php
@@ -10,7 +10,6 @@ use Illuminate\Translation\TranslationServiceProvider as BaseTranslationServiceP
 
 class TranslationServiceProvider extends BaseTranslationServiceProvider
 {
-
     public function register()
     {
         parent::register();

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 return [
+    'one_more_error' => '(and :count more error)',
+    'several_errors' => '(and :count more errors)',
     'accepted' => 'The :attribute must be accepted.',
     'accepted_if' => 'The :attribute must be accepted when :other is :value.',
     'active_url' => 'The :attribute is not a valid URL.',

--- a/resources/css/app/_general.css
+++ b/resources/css/app/_general.css
@@ -84,3 +84,24 @@ a.p-button-link {
         text-decoration: underline;
     }
 }
+
+fieldset.field,
+.field {
+    padding: 0.5rem;
+    margin-left: -0.5rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+fieldset.field:has(.form-error),
+.field:has(.form-error) {
+    background: var(--color-red-500) / 0.2;
+    @apply rounded-border;
+}
+
+.dark {
+    fieldset.field:has(.form-error),
+    .field:has(.form-error) {
+        background: var(--color-red-500 / 0.2);
+    }
+}

--- a/resources/css/app/_general.css
+++ b/resources/css/app/_general.css
@@ -84,24 +84,3 @@ a.p-button-link {
         text-decoration: underline;
     }
 }
-
-fieldset.field,
-.field {
-    padding: 0.5rem;
-    margin-left: -0.5rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-
-fieldset.field:has(.form-error),
-.field:has(.form-error) {
-    background: var(--color-red-500) / 0.2;
-    @apply rounded-border;
-}
-
-.dark {
-    fieldset.field:has(.form-error),
-    .field:has(.form-error) {
-        background: var(--color-red-500 / 0.2);
-    }
-}

--- a/resources/css/app/_room.css
+++ b/resources/css/app/_room.css
@@ -54,6 +54,12 @@
         padding: 0 1rem;
     }
 }
+.is-invalid {
+    .ProseMirror:not(:focus) {
+        @apply outline;
+        outline-color: var(--p-form-field-invalid-border-color) !important;
+    }
+}
 
 .room-description {
     img {

--- a/resources/css/override/_animations.css
+++ b/resources/css/override/_animations.css
@@ -8,3 +8,9 @@
         animation-duration: 0s !important;
     }
 }
+
+@media (prefers-reduced-motion: no-preference) {
+    :root {
+        scroll-behavior: smooth;
+    }
+}

--- a/resources/css/override/_toast.css
+++ b/resources/css/override/_toast.css
@@ -9,7 +9,7 @@
 
 .p-toast-message-icon {
     overflow: visible;
-    margin-top: 0.4rem;
+    margin-top: 0.2rem;
 }
 
 @media (max-width: 639px) {

--- a/resources/js/components/AdminStreamingRoomTypeEditButton.vue
+++ b/resources/js/components/AdminStreamingRoomTypeEditButton.vue
@@ -44,7 +44,8 @@
           :loading="isLoadingAction"
           :disabled="isLoadingAction || loadingError"
           data-test="dialog-save-button"
-          @click="save"
+          form="admin-streaming-room-type-edit-form"
+          type="submit"
         />
       </div>
     </template>
@@ -58,9 +59,15 @@
         <LoadingRetryButton :error="loadingError" @reload="loadSettings()" />
       </template>
 
-      <form v-if="settings != null" class="flex flex-col gap-4">
+      <Form
+        v-if="settings != null"
+        id="admin-streaming-room-type-edit-form"
+        :disabled="isLoadingAction || loadingError"
+        class="flex flex-col gap-4"
+        @submit="save"
+      >
         <div
-          class="col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
+          class="field col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
           data-test="streaming-enabled-field"
         >
           <label for="streaming-enabled" class="flex items-center">
@@ -77,7 +84,7 @@
         </div>
 
         <fieldset
-          class="grid-rows grid gap-2"
+          class="field grid-rows grid gap-2"
           data-test="streaming-default-pause-image-field"
         >
           <legend
@@ -106,7 +113,7 @@
             <small>{{ $t("rooms.streaming.config.pause_image_format") }}</small>
           </div>
         </fieldset>
-      </form>
+      </Form>
     </OverlayComponent>
   </Dialog>
 </template>

--- a/resources/js/components/AdminStreamingRoomTypeEditButton.vue
+++ b/resources/js/components/AdminStreamingRoomTypeEditButton.vue
@@ -213,6 +213,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/AdminStreamingRoomTypeEditButton.vue
+++ b/resources/js/components/AdminStreamingRoomTypeEditButton.vue
@@ -213,7 +213,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/Form.vue
+++ b/resources/js/components/Form.vue
@@ -1,0 +1,23 @@
+<script setup>
+const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(["submit"]);
+
+function onSubmit() {
+  if (props.disabled) return;
+  emit("submit");
+}
+</script>
+
+<template>
+  <form novalidate @submit.prevent="onSubmit">
+    <slot></slot>
+  </form>
+</template>
+
+<style scoped></style>

--- a/resources/js/components/Form.vue
+++ b/resources/js/components/Form.vue
@@ -15,7 +15,7 @@ function onSubmit() {
 </script>
 
 <template>
-  <form novalidate @submit.prevent="onSubmit" class="form">
+  <form novalidate class="form" @submit.prevent="onSubmit">
     <slot></slot>
   </form>
 </template>

--- a/resources/js/components/Form.vue
+++ b/resources/js/components/Form.vue
@@ -15,7 +15,7 @@ function onSubmit() {
 </script>
 
 <template>
-  <form novalidate @submit.prevent="onSubmit">
+  <form novalidate @submit.prevent="onSubmit" class="form">
     <slot></slot>
   </form>
 </template>

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -43,9 +43,9 @@ onMounted(async () => {
 <template>
   <p
     v-if="hasError"
+    ref="formError"
     class="form-error text-red-500"
     role="alert"
-    ref="formError"
   >
     <template v-for="(error, index) in props.errors" :key="index">
       {{ error }}

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -9,7 +9,11 @@ const props = defineProps({
 </script>
 
 <template>
-  <p class="text-red-500" role="alert">
+  <p
+    v-if="props.errors != null && Object.keys(props.errors).length > 0"
+    class="form-error text-red-500"
+    role="alert"
+  >
     <template v-for="(error, index) in props.errors" :key="index">
       {{ error }}
       <br v-if="index < props.errors.length - 1" />

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+
 const props = defineProps({
   errors: {
     type: [Object, null],
@@ -6,13 +8,44 @@ const props = defineProps({
     default: null,
   },
 });
+
+const formError = ref(null);
+
+const hasError = computed(() => {
+  return props.errors != null && Object.keys(props.errors).length > 0;
+});
+
+async function scrollToFirstError() {
+  await nextTick();
+
+  const selfDomElement = formError.value;
+  const firstDomElement = document.getElementsByClassName("form-error")[0];
+
+  // Only scroll into view, if this form error is the first form error rendered on the page
+  if (selfDomElement != null && selfDomElement === firstDomElement) {
+    selfDomElement.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+// Scroll to error if errors visible state changes
+watch(hasError, async () => {
+  await scrollToFirstError();
+});
+
+// Scroll to error if the component is mounted with errors present
+onMounted(async () => {
+  if (hasError.value) {
+    await scrollToFirstError();
+  }
+});
 </script>
 
 <template>
   <p
-    v-if="props.errors != null && Object.keys(props.errors).length > 0"
+    v-if="hasError"
     class="form-error text-red-500"
     role="alert"
+    ref="formError"
   >
     <template v-for="(error, index) in props.errors" :key="index">
       {{ error }}

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -23,7 +23,7 @@ async function scrollToFirstError() {
 
   // Only scroll into view, if this form error is the first form error rendered on the page
   if (selfDomElement != null && selfDomElement === firstDomElement) {
-    selfDomElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    selfDomElement.scrollIntoView({ behavior: "auto", block: "center" });
   }
 }
 

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { isElementInViewport } from "../utils/viewport";
 
 const props = defineProps({
   errors: {
@@ -15,23 +16,7 @@ const hasError = computed(() => {
   return props.errors != null && Object.keys(props.errors).length > 0;
 });
 
-function isElementInViewport(el) {
-  var rect = el.getBoundingClientRect();
-
-  return (
-    rect.top >= 0 &&
-    rect.left >= 0 &&
-    rect.bottom <=
-      (window.innerHeight ||
-        document.documentElement.clientHeight) /*or $(window).height() */ &&
-    rect.right <=
-      (window.innerWidth ||
-        document.documentElement.clientWidth) /*or $(window).width() */
-  );
-}
-
 async function scrollToFirstError() {
-  await nextTick();
   await nextTick();
 
   const selfDomElement = formError.value;

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -40,7 +40,7 @@ async function scrollToFirstError() {
     return;
   }
 
-  const formElement = selfDomElement.closest("form");
+  const formElement = selfDomElement.closest(".form");
   if (formElement == null) {
     return;
   }

--- a/resources/js/components/FormError.vue
+++ b/resources/js/components/FormError.vue
@@ -15,15 +15,47 @@ const hasError = computed(() => {
   return props.errors != null && Object.keys(props.errors).length > 0;
 });
 
+function isElementInViewport(el) {
+  var rect = el.getBoundingClientRect();
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight ||
+        document.documentElement.clientHeight) /*or $(window).height() */ &&
+    rect.right <=
+      (window.innerWidth ||
+        document.documentElement.clientWidth) /*or $(window).width() */
+  );
+}
+
 async function scrollToFirstError() {
+  await nextTick();
   await nextTick();
 
   const selfDomElement = formError.value;
-  const firstDomElement = document.getElementsByClassName("form-error")[0];
+
+  if (selfDomElement == null) {
+    return;
+  }
+
+  const formElement = selfDomElement.closest("form");
+  if (formElement == null) {
+    return;
+  }
+
+  const firstErrorInForm = formElement.getElementsByClassName("form-error")[0];
 
   // Only scroll into view, if this form error is the first form error rendered on the page
-  if (selfDomElement != null && selfDomElement === firstDomElement) {
-    selfDomElement.scrollIntoView({ behavior: "auto", block: "center" });
+  if (selfDomElement != null && selfDomElement === firstErrorInForm) {
+    // Scroll to error if not already in viewport
+    if (!isElementInViewport(selfDomElement)) {
+      selfDomElement.scrollIntoView({ behavior: "auto", block: "center" });
+    }
+
+    // Focus on error container for better accessibility
+    selfDomElement.focus();
   }
 }
 
@@ -41,15 +73,23 @@ onMounted(async () => {
 </script>
 
 <template>
-  <p
+  <div
     v-if="hasError"
     ref="formError"
-    class="form-error text-red-500"
+    tabindex="-1"
+    class="form-error mt-2 flex flex-col font-semibold text-red-500 dark:text-red-300"
     role="alert"
   >
-    <template v-for="(error, index) in props.errors" :key="index">
-      {{ error }}
-      <br v-if="index < props.errors.length - 1" />
-    </template>
-  </p>
+    <div
+      v-for="(error, index) in props.errors"
+      :key="index"
+      class="flex items-baseline gap-1"
+    >
+      <i
+        class="fas fa-exclamation-circle shrink-0 grow-0"
+        aria-hidden="true"
+      ></i>
+      <span>{{ error }}</span>
+    </div>
+  </div>
 </template>

--- a/resources/js/components/LoginTabLdap.vue
+++ b/resources/js/components/LoginTabLdap.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <form @submit.prevent="submit">
-      <div class="flex flex-col gap-2" data-test="username-field">
+    <Form @submit="submit">
+      <div class="field flex flex-col gap-2" data-test="username-field">
         <label :for="`${props.id}-username`">{{ props.usernameLabel }}</label>
         <InputText
           :id="`${props.id}-username`"
@@ -25,7 +25,7 @@
         <FormError :errors="props.errors?.username" />
       </div>
 
-      <div class="mt-6 flex flex-col gap-2" data-test="password-field">
+      <div class="field mt-6 flex flex-col gap-2" data-test="password-field">
         <label :for="`${props.id}-password`">{{ props.passwordLabel }}</label>
         <Password
           v-model="password"
@@ -53,7 +53,7 @@
         icon="fa-solid fa-right-to-bracket"
         :label="props.submitLabel"
       />
-    </form>
+    </Form>
   </div>
 </template>
 

--- a/resources/js/components/LoginTabLdap.vue
+++ b/resources/js/components/LoginTabLdap.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <Form @submit="submit">
+    <Form @submit="submit" :disabled="props.loading">
       <div class="field flex flex-col gap-2" data-test="username-field">
         <label :for="`${props.id}-username`">{{ props.usernameLabel }}</label>
         <InputText

--- a/resources/js/components/LoginTabLdap.vue
+++ b/resources/js/components/LoginTabLdap.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <Form @submit="submit" :disabled="props.loading">
+    <Form :disabled="props.loading" @submit="submit">
       <div class="field flex flex-col gap-2" data-test="username-field">
         <label :for="`${props.id}-username`">{{ props.usernameLabel }}</label>
         <InputText

--- a/resources/js/components/LoginTabLocal.vue
+++ b/resources/js/components/LoginTabLocal.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <form @submit.prevent="submit">
-      <div class="flex flex-col gap-2" data-test="email-field">
+    <Form @submit="submit">
+      <div class="field flex flex-col gap-2" data-test="email-field">
         <label :for="`${props.id}-email`">{{ props.emailLabel }}</label>
         <InputText
           :id="`${props.id}-email`"
@@ -22,7 +22,7 @@
         <FormError :errors="props.errors?.email" />
       </div>
 
-      <div class="mt-6 flex flex-col gap-2" data-test="password-field">
+      <div class="field mt-6 flex flex-col gap-2" data-test="password-field">
         <label :for="`${props.id}-password`">{{ props.passwordLabel }}</label>
         <Password
           v-model="password"
@@ -62,7 +62,7 @@
         :label="props.submitLabel"
         icon="fa-solid fa-right-to-bracket"
       />
-    </form>
+    </Form>
   </div>
 </template>
 

--- a/resources/js/components/LoginTabLocal.vue
+++ b/resources/js/components/LoginTabLocal.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <Form @submit="submit" :disabled="props.loading">
+    <Form :disabled="props.loading" @submit="submit">
       <div class="field flex flex-col gap-2" data-test="email-field">
         <label :for="`${props.id}-email`">{{ props.emailLabel }}</label>
         <InputText

--- a/resources/js/components/LoginTabLocal.vue
+++ b/resources/js/components/LoginTabLocal.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <h1 class="p-card-title">{{ props.title }}</h1>
-    <Form @submit="submit">
+    <Form @submit="submit" :disabled="props.loading">
       <div class="field flex flex-col gap-2" data-test="email-field">
         <label :for="`${props.id}-email`">{{ props.emailLabel }}</label>
         <InputText

--- a/resources/js/components/RoleSelect.vue
+++ b/resources/js/components/RoleSelect.vue
@@ -8,6 +8,7 @@
       :model-value="selectedRoles"
       track-by="id"
       open-direction="bottom"
+      :required="required"
       :multiple="true"
       :searchable="false"
       :internal-search="false"
@@ -114,6 +115,10 @@ const props = defineProps({
     default: false,
   },
   disabled: {
+    type: Boolean,
+    default: false,
+  },
+  required: {
     type: Boolean,
     default: false,
   },

--- a/resources/js/components/RoomCreateComponent.vue
+++ b/resources/js/components/RoomCreateComponent.vue
@@ -169,6 +169,7 @@ function handleOk() {
           }
 
           formErrors.set(error.response.data.errors);
+          formErrors.scrollToFirstError();
           return;
         }
         // permission denied

--- a/resources/js/components/RoomCreateComponent.vue
+++ b/resources/js/components/RoomCreateComponent.vue
@@ -28,22 +28,29 @@
           {{ $t("rooms.create.title") }}
         </h2>
       </template>
-      <div>
+      <Form
+        id="room-create-form"
+        :disabled="
+          roomTypeSelectLoadingError || isLoadingAction || roomTypeSelectBusy
+        "
+        @submit="handleOk"
+      >
         <!-- Room name -->
-        <div class="mt-6 flex flex-col gap-2">
+        <div class="field mt-6 flex flex-col gap-2">
           <label for="room-name">{{ $t("rooms.name") }}</label>
           <InputText
             id="room-name"
             v-model="room.name"
             :disabled="isLoadingAction"
             autofocus
+            required
             :invalid="formErrors.fieldInvalid('name')"
           />
           <FormError :errors="formErrors.fieldError('name')" />
         </div>
 
         <!-- Room type -->
-        <div class="flex flex-col gap-2">
+        <div class="field flex flex-col gap-2">
           <label id="room-type-label">{{
             $t("rooms.settings.general.type")
           }}</label>
@@ -58,7 +65,7 @@
           />
           <FormError :errors="formErrors.fieldError('room_type')" />
         </div>
-      </div>
+      </Form>
       <template #footer>
         <div class="flex justify-end gap-2">
           <Button
@@ -77,7 +84,8 @@
               isLoadingAction ||
               roomTypeSelectBusy
             "
-            @click="handleOk"
+            form="room-create-form"
+            type="submit"
           />
         </div>
       </template>

--- a/resources/js/components/RoomCreateComponent.vue
+++ b/resources/js/components/RoomCreateComponent.vue
@@ -169,7 +169,6 @@ function handleOk() {
           }
 
           formErrors.set(error.response.data.errors);
-          formErrors.scrollToFirstError();
           return;
         }
         // permission denied

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -411,9 +411,7 @@ function getJoinUrl() {
         if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
           formErrors.set(error.response.data.errors);
 
-          loadStartJoinRequirements().then(() => {
-            formErrors.scrollToFirstError();
-          });
+          loadStartJoinRequirements();
           return;
         }
 

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -410,8 +410,10 @@ function getJoinUrl() {
         // Form validation error
         if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
           formErrors.set(error.response.data.errors);
-          formErrors.scrollToFirstError();
-          loadStartJoinRequirements();
+
+          loadStartJoinRequirements().then(() => {
+            formErrors.scrollToFirstError();
+          });
           return;
         }
 

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -39,7 +39,7 @@
     <Message v-if="showRunningMessage" class="mb-4" severity="warn">{{
       $t("app.errors.room_already_running")
     }}</Message>
-    <form ref="joinForm" @submit.prevent="getJoinUrl">
+    <Form :disabled="isLoadingAction || loadingError" @submit="getJoinUrl">
       <OverlayComponent :show="isLoadingAction || loadingError" :opacity="0">
         <template #overlay>
           <LoadingRetryButton
@@ -165,7 +165,7 @@
           type="submit"
         />
       </div>
-    </form>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomJoinButton.vue
+++ b/resources/js/components/RoomJoinButton.vue
@@ -410,6 +410,7 @@ function getJoinUrl() {
         // Form validation error
         if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
           formErrors.set(error.response.data.errors);
+          formErrors.scrollToFirstError();
           loadStartJoinRequirements();
           return;
         }

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -224,6 +224,7 @@ function save() {
       // Description couldn't be saved due to validation errors
       if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
+        api.validationError(error);
         return;
       }
       // Description couldn't be saved due to missing permission, close the editor

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -234,7 +234,6 @@ function save() {
     .finally(() => {
       // Disable saving indicator
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -36,16 +36,18 @@
         </div>
       </div>
 
-      <div v-else>
-        <TipTapEditor
-          v-model="newContent"
-          :class="{
-            'is-invalid': formErrors.fieldInvalid('description') === false,
-          }"
-          :disabled="isBusy"
-        />
-        <FormError :errors="formErrors.fieldError('description')" />
-      </div>
+      <Form v-else id="room-description-form" :disabled="isBusy" @submit="save">
+        <div class="field">
+          <TipTapEditor
+            v-model="newContent"
+            :class="{
+              'is-invalid': formErrors.fieldInvalid('description') === false,
+            }"
+            :disabled="isBusy"
+          />
+          <FormError :errors="formErrors.fieldError('description')" />
+        </div>
+      </Form>
     </OverlayComponent>
     <div class="mt-2 flex justify-end">
       <Button
@@ -54,7 +56,8 @@
         icon="fa-solid fa-save"
         :label="$t('rooms.description.save')"
         data-test="room-description-save-button"
-        @click="save"
+        form="room-description-form"
+        type="submit"
       />
     </div>
   </div>

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -41,7 +41,7 @@
           <TipTapEditor
             v-model="newContent"
             :class="{
-              'is-invalid': formErrors.fieldInvalid('description') === false,
+              'is-invalid': formErrors.fieldInvalid('description'),
             }"
             :disabled="isBusy"
           />

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -234,6 +234,7 @@ function save() {
     .finally(() => {
       // Disable saving indicator
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabDescription.vue
+++ b/resources/js/components/RoomTabDescription.vue
@@ -36,7 +36,7 @@
         </div>
       </div>
 
-      <Form v-else id="room-description-form" :disabled="isBusy" @submit="save">
+      <div v-else class="form">
         <div class="field">
           <TipTapEditor
             v-model="newContent"
@@ -47,7 +47,7 @@
           />
           <FormError :errors="formErrors.fieldError('description')" />
         </div>
-      </Form>
+      </div>
     </OverlayComponent>
     <div class="mt-2 flex justify-end">
       <Button
@@ -56,8 +56,7 @@
         icon="fa-solid fa-save"
         :label="$t('rooms.description.save')"
         data-test="room-description-save-button"
-        form="room-description-form"
-        type="submit"
+        @click="save"
       />
     </div>
   </div>

--- a/resources/js/components/RoomTabFilesEditButton.vue
+++ b/resources/js/components/RoomTabFilesEditButton.vue
@@ -215,7 +215,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabFilesEditButton.vue
+++ b/resources/js/components/RoomTabFilesEditButton.vue
@@ -215,6 +215,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabFilesEditButton.vue
+++ b/resources/js/components/RoomTabFilesEditButton.vue
@@ -37,60 +37,66 @@
           severity="success"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-files-edit-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <div class="field grid grid-cols-12 gap-4" data-test="download-field">
-      <label for="download" class="col-span-12 mb-2 md:col-span-6 md:mb-0">{{
-        $t("rooms.files.downloadable")
-      }}</label>
-      <div class="col-span-12 md:col-span-6">
-        <ToggleSwitch
-          v-model="newDownload"
-          input-id="download"
-          required
-          :disabled="isLoadingAction"
-          :invalid="formErrors.fieldInvalid('download')"
-        />
-        <FormError :errors="formErrors.fieldError('download')" />
+    <Form id="room-files-edit-form" @submit="save">
+      <div class="field grid grid-cols-12 gap-4" data-test="download-field">
+        <label for="download" class="col-span-12 mb-2 md:col-span-6 md:mb-0">
+          {{ $t("rooms.files.downloadable") }}
+        </label>
+        <div class="col-span-12 md:col-span-6">
+          <ToggleSwitch
+            v-model="newDownload"
+            input-id="download"
+            required
+            :disabled="isLoadingAction"
+            :invalid="formErrors.fieldInvalid('download')"
+          />
+          <FormError :errors="formErrors.fieldError('download')" />
+        </div>
       </div>
-    </div>
 
-    <div class="field grid grid-cols-12 gap-4" data-test="use-in-meeting-field">
-      <label
-        for="use_in_meeting"
-        class="col-span-12 mb-2 md:col-span-6 md:mb-0"
-        >{{ $t("rooms.files.use_in_next_meeting") }}</label
+      <div
+        class="field grid grid-cols-12 gap-4"
+        data-test="use-in-meeting-field"
       >
-      <div class="col-span-12 md:col-span-6">
-        <ToggleSwitch
-          v-model="newUseInMeeting"
-          input-id="use_in_meeting"
-          required
-          :disabled="isLoadingAction"
-          :invalid="formErrors.fieldInvalid('use_in_meeting')"
-        />
-        <FormError :errors="formErrors.fieldError('use_in_meeting')" />
+        <label
+          for="use_in_meeting"
+          class="col-span-12 mb-2 md:col-span-6 md:mb-0"
+          >{{ $t("rooms.files.use_in_next_meeting") }}</label
+        >
+        <div class="col-span-12 md:col-span-6">
+          <ToggleSwitch
+            v-model="newUseInMeeting"
+            input-id="use_in_meeting"
+            required
+            :disabled="isLoadingAction"
+            :invalid="formErrors.fieldInvalid('use_in_meeting')"
+          />
+          <FormError :errors="formErrors.fieldError('use_in_meeting')" />
+        </div>
       </div>
-    </div>
 
-    <div class="field grid grid-cols-12 gap-4" data-test="default-field">
-      <label for="default" class="col-span-12 mb-2 md:col-span-6 md:mb-0">{{
-        $t("rooms.files.default")
-      }}</label>
-      <div class="col-span-12 md:col-span-6">
-        <ToggleSwitch
-          v-model="newDefault"
-          input-id="default"
-          required
-          :disabled="isLoadingAction"
-          :invalid="formErrors.fieldInvalid('default')"
-        />
-        <FormError :errors="formErrors.fieldError('default')" />
+      <div class="field grid grid-cols-12 gap-4" data-test="default-field">
+        <label for="default" class="col-span-12 mb-2 md:col-span-6 md:mb-0">
+          {{ $t("rooms.files.default") }}
+        </label>
+        <div class="col-span-12 md:col-span-6">
+          <ToggleSwitch
+            v-model="newDefault"
+            input-id="default"
+            required
+            :disabled="isLoadingAction"
+            :invalid="formErrors.fieldInvalid('default')"
+          />
+          <FormError :errors="formErrors.fieldError('default')" />
+        </div>
       </div>
-    </div>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomTabFilesEditButton.vue
+++ b/resources/js/components/RoomTabFilesEditButton.vue
@@ -43,7 +43,7 @@
       </div>
     </template>
 
-    <Form id="room-files-edit-form" @submit="save" :disabled="isLoadingAction">
+    <Form id="room-files-edit-form" :disabled="isLoadingAction" @submit="save">
       <div class="field grid grid-cols-12 gap-4" data-test="download-field">
         <label for="download" class="col-span-12 mb-2 md:col-span-6 md:mb-0">
           {{ $t("rooms.files.downloadable") }}

--- a/resources/js/components/RoomTabFilesEditButton.vue
+++ b/resources/js/components/RoomTabFilesEditButton.vue
@@ -43,7 +43,7 @@
       </div>
     </template>
 
-    <Form id="room-files-edit-form" @submit="save">
+    <Form id="room-files-edit-form" @submit="save" :disabled="isLoadingAction">
       <div class="field grid grid-cols-12 gap-4" data-test="download-field">
         <label for="download" class="col-span-12 mb-2 md:col-span-6 md:mb-0">
           {{ $t("rooms.files.downloadable") }}

--- a/resources/js/components/RoomTabFilesUploadButton.vue
+++ b/resources/js/components/RoomTabFilesUploadButton.vue
@@ -266,9 +266,6 @@ function uploadFile(file) {
         }
       }
       api.error(error, { redirectOnUnauthenticated: false });
-    })
-    .finally(() => {
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabFilesUploadButton.vue
+++ b/resources/js/components/RoomTabFilesUploadButton.vue
@@ -251,8 +251,10 @@ function uploadFile(file) {
       // Fetch successful
       uploadedFiles.value.push(file);
       emit("uploaded");
+      reset();
     })
     .catch((error) => {
+      reset();
       if (error.response) {
         if (error.response.status === env.HTTP_PAYLOAD_TOO_LARGE) {
           formErrors.set({ file: [t("app.validation.too_large")] });
@@ -266,7 +268,6 @@ function uploadFile(file) {
       api.error(error, { redirectOnUnauthenticated: false });
     })
     .finally(() => {
-      reset();
       formErrors.scrollToFirstError();
     });
 }

--- a/resources/js/components/RoomTabFilesUploadButton.vue
+++ b/resources/js/components/RoomTabFilesUploadButton.vue
@@ -251,23 +251,23 @@ function uploadFile(file) {
       // Fetch successful
       uploadedFiles.value.push(file);
       emit("uploaded");
-      reset();
     })
     .catch((error) => {
-      reset();
       if (error.response) {
         if (error.response.status === env.HTTP_PAYLOAD_TOO_LARGE) {
           formErrors.set({ file: [t("app.validation.too_large")] });
-          formErrors.scrollToFirstError();
           return;
         }
         if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
           formErrors.set(error.response.data.errors);
-          formErrors.scrollToFirstError();
           return;
         }
       }
       api.error(error, { redirectOnUnauthenticated: false });
+    })
+    .finally(() => {
+      reset();
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabFilesUploadButton.vue
+++ b/resources/js/components/RoomTabFilesUploadButton.vue
@@ -30,7 +30,7 @@
       },
     }"
   >
-    <div class="flex flex-col gap-2">
+    <div class="field flex flex-col gap-2">
       <label
         for="file"
         class="p-button p-component flex flex-row justify-center gap-2 rounded-border"

--- a/resources/js/components/RoomTabFilesUploadButton.vue
+++ b/resources/js/components/RoomTabFilesUploadButton.vue
@@ -258,10 +258,12 @@ function uploadFile(file) {
       if (error.response) {
         if (error.response.status === env.HTTP_PAYLOAD_TOO_LARGE) {
           formErrors.set({ file: [t("app.validation.too_large")] });
+          formErrors.scrollToFirstError();
           return;
         }
         if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
           formErrors.set(error.response.data.errors);
+          formErrors.scrollToFirstError();
           return;
         }
       }

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -94,7 +94,7 @@
               :disabled="isLoadingAction"
               input-id="participant-role"
               name="role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               :value="1"
             />
@@ -109,7 +109,7 @@
               :disabled="isLoadingAction"
               input-id="moderator-role"
               name="role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               :value="2"
             />
@@ -124,7 +124,7 @@
               :disabled="isLoadingAction"
               input-id="co_owner-role"
               name="role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               :value="3"
             />

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -25,109 +25,118 @@
           :label="$t('rooms.members.modals.add.add')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-members-add-single-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- select user -->
-    <div class="relative mt-2 flex flex-col gap-2 overflow-visible">
-      <label id="user-label">{{ $t("app.user") }}</label>
-      <multiselect
-        v-model="user"
-        aria-labelledby="user-label"
-        autofocus
-        data-test="select-user-dropdown"
-        label="lastname"
-        track-by="id"
-        :placeholder="$t('rooms.members.modals.add.placeholder')"
-        open-direction="bottom"
-        :options="users"
-        :multiple="false"
-        :searchable="true"
-        :loading="isLoadingSearch"
-        :disabled="isLoadingAction"
-        :internal-search="false"
-        :clear-on-select="false"
-        :preserve-search="true"
-        :close-on-select="true"
-        :options-limit="300"
-        :max-height="150"
-        :show-no-results="true"
-        :show-labels="false"
-        :invalid="formErrors.fieldInvalid('user')"
-        @search-change="asyncFind"
-      >
-        <template #noResult>
-          <span v-if="tooManyResults" class="whitespace-normal">
-            {{ $t("rooms.members.modals.add.too_many_results") }}
-          </span>
-          <span v-else>
-            {{ $t("rooms.members.modals.add.no_result") }}
-          </span>
-        </template>
-        <template #noOptions>
-          {{ $t("rooms.members.modals.add.no_options") }}
-        </template>
-        <template #option="{ option }">
-          {{ option.firstname }} {{ option.lastname }}<br /><small>{{
-            option.email
-          }}</small>
-        </template>
-        <template #singleLabel="{ option }">
-          {{ option.firstname }} {{ option.lastname }}
-        </template>
-      </multiselect>
-      <FormError :errors="formErrors.fieldError('user')" />
-    </div>
+    <Form id="room-members-add-single-form" @submit="save">
+      <!-- select user -->
+      <div class="field relative mt-2 flex flex-col gap-2 overflow-visible">
+        <label id="user-label">{{ $t("app.user") }}</label>
+        <multiselect
+          v-model="user"
+          aria-labelledby="user-label"
+          autofocus
+          data-test="select-user-dropdown"
+          label="lastname"
+          track-by="id"
+          :placeholder="$t('rooms.members.modals.add.placeholder')"
+          open-direction="bottom"
+          :options="users"
+          :multiple="false"
+          :searchable="true"
+          :loading="isLoadingSearch"
+          :disabled="isLoadingAction"
+          :internal-search="false"
+          :clear-on-select="false"
+          :preserve-search="true"
+          :close-on-select="true"
+          :options-limit="300"
+          :max-height="150"
+          :show-no-results="true"
+          :show-labels="false"
+          :invalid="formErrors.fieldInvalid('user')"
+          @search-change="asyncFind"
+        >
+          <template #noResult>
+            <span v-if="tooManyResults" class="whitespace-normal">
+              {{ $t("rooms.members.modals.add.too_many_results") }}
+            </span>
+            <span v-else>
+              {{ $t("rooms.members.modals.add.no_result") }}
+            </span>
+          </template>
+          <template #noOptions>
+            {{ $t("rooms.members.modals.add.no_options") }}
+          </template>
+          <template #option="{ option }">
+            {{ option.firstname }} {{ option.lastname }}<br /><small>{{
+              option.email
+            }}</small>
+          </template>
+          <template #singleLabel="{ option }">
+            {{ option.firstname }} {{ option.lastname }}
+          </template>
+        </multiselect>
+        <FormError :errors="formErrors.fieldError('user')" />
+      </div>
 
-    <!-- select role -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.role") }}</legend>
+      <!-- select role -->
+      <div class="field mt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="role"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="participant-role-group">
+            <RadioButton
+              v-model="role"
+              :disabled="isLoadingAction"
+              input-id="participant-role"
+              name="role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              :value="1"
+            />
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="role"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="role"
+              :disabled="isLoadingAction"
+              input-id="moderator-role"
+              name="role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="co-owner-role-group">
-          <RadioButton
-            v-model="role"
-            :disabled="isLoadingAction"
-            input-id="co_owner-role"
-            name="role"
-            :value="3"
-          />
-          <label for="co_owner-role" class="ml-2"
-            ><RoomRoleBadge :role="3"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="co-owner-role-group">
+            <RadioButton
+              v-model="role"
+              :disabled="isLoadingAction"
+              input-id="co_owner-role"
+              name="role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              :value="3"
+            />
+            <label for="co_owner-role" class="ml-2"
+              ><RoomRoleBadge :role="3"
+            /></label>
+          </div>
 
-        <FormError :errors="formErrors.fieldError('role')" />
-      </fieldset>
-    </div>
+          <FormError :errors="formErrors.fieldError('role')" />
+        </fieldset>
+      </div>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -243,6 +243,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -243,7 +243,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -31,7 +31,11 @@
       </div>
     </template>
 
-    <Form id="room-members-add-single-form" @submit="save">
+    <Form
+      id="room-members-add-single-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- select user -->
       <div class="field relative mt-2 flex flex-col gap-2 overflow-visible">
         <label id="user-label">{{ $t("app.user") }}</label>

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -33,8 +33,8 @@
 
     <Form
       id="room-members-add-single-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- select user -->
       <div class="field relative mt-2 flex flex-col gap-2 overflow-visible">

--- a/resources/js/components/RoomTabMembersAddSingleModal.vue
+++ b/resources/js/components/RoomTabMembersAddSingleModal.vue
@@ -57,7 +57,7 @@
           :max-height="150"
           :show-no-results="true"
           :show-labels="false"
-          :invalid="formErrors.fieldInvalid('user')"
+          :class="{ 'is-invalid': formErrors.fieldInvalid('user') }"
           @search-change="asyncFind"
         >
           <template #noResult>

--- a/resources/js/components/RoomTabMembersBulkDeleteButton.vue
+++ b/resources/js/components/RoomTabMembersBulkDeleteButton.vue
@@ -134,6 +134,7 @@ function deleteMembers() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkDeleteButton.vue
+++ b/resources/js/components/RoomTabMembersBulkDeleteButton.vue
@@ -134,7 +134,6 @@ function deleteMembers() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkDeleteButton.vue
+++ b/resources/js/components/RoomTabMembersBulkDeleteButton.vue
@@ -53,7 +53,7 @@
       </div>
     </template>
 
-    <div class="flex flex-col gap-2">
+    <div class="field flex flex-col gap-2">
       <span>
         {{
           $t("rooms.members.modals.remove.confirm_bulk", {

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -172,6 +172,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -53,7 +53,11 @@
       </div>
     </template>
 
-    <Form id="room-members-bulk-edit-form" @submit="save">
+    <Form
+      id="room-members-bulk-edit-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- select role -->
       <div class="field mt-6 flex flex-col gap-2">
         <fieldset class="flex w-full flex-col gap-2">

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -64,7 +64,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="participant-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="1"
@@ -79,7 +79,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="moderator-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="2"
@@ -94,7 +94,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="co_owner-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="3"

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -47,59 +47,68 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-members-bulk-edit-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- select role -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.role") }}</legend>
+    <Form id="room-members-bulk-edit-form" @submit="save">
+      <!-- select role -->
+      <div class="field mt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="participant-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="participant-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="1"
+            />
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="moderator-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="co-owner-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="co_owner-role"
-            name="role"
-            :value="3"
-          />
-          <label for="co_owner-role" class="ml-2"
-            ><RoomRoleBadge :role="3"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="co-owner-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="co_owner-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="3"
+            />
+            <label for="co_owner-role" class="ml-2"
+              ><RoomRoleBadge :role="3"
+            /></label>
+          </div>
 
-        <FormError :errors="formErrors.fieldError('role')" />
-      </fieldset>
-      <FormError :errors="formErrors.fieldError('users', true)" />
-    </div>
+          <FormError :errors="formErrors.fieldError('role')" />
+        </fieldset>
+        <FormError :errors="formErrors.fieldError('users', true)" />
+      </div>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -172,7 +172,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkEditButton.vue
+++ b/resources/js/components/RoomTabMembersBulkEditButton.vue
@@ -55,8 +55,8 @@
 
     <Form
       id="room-members-bulk-edit-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- select role -->
       <div class="field mt-6 flex flex-col gap-2">

--- a/resources/js/components/RoomTabMembersBulkImportModal.vue
+++ b/resources/js/components/RoomTabMembersBulkImportModal.vue
@@ -76,6 +76,7 @@
     </template>
 
     <Form
+      v-if="step === 0"
       id="room-members-bulk-import-form"
       :disabled="isLoadingAction"
       @submit="importUsers(true)"

--- a/resources/js/components/RoomTabMembersBulkImportModal.vue
+++ b/resources/js/components/RoomTabMembersBulkImportModal.vue
@@ -308,7 +308,6 @@ function importUsers(firstRound = false) {
           // check for role errors
           if (error.response.data.errors.role) {
             formErrors.set(error.response.data.errors);
-
             return;
           }
           // check for general errors with user list (empty, too long)
@@ -316,7 +315,6 @@ function importUsers(firstRound = false) {
             formErrors.set({
               user_emails: error.response.data.errors.user_emails,
             });
-
             return;
           }
 
@@ -345,7 +343,6 @@ function importUsers(firstRound = false) {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkImportModal.vue
+++ b/resources/js/components/RoomTabMembersBulkImportModal.vue
@@ -345,6 +345,7 @@ function importUsers(firstRound = false) {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersBulkImportModal.vue
+++ b/resources/js/components/RoomTabMembersBulkImportModal.vue
@@ -112,7 +112,7 @@
               :disabled="isLoadingAction"
               input-id="participant-role"
               :invalid="formErrors.fieldInvalid('role')"
-              pt:input:required="required"
+              pt:input:required
               name="role"
               :value="1"
             />
@@ -126,7 +126,7 @@
               v-model="newUsersRole"
               :disabled="isLoadingAction"
               input-id="moderator-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="2"
@@ -141,7 +141,7 @@
               v-model="newUsersRole"
               :disabled="isLoadingAction"
               input-id="co_owner-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="3"

--- a/resources/js/components/RoomTabMembersBulkImportModal.vue
+++ b/resources/js/components/RoomTabMembersBulkImportModal.vue
@@ -25,11 +25,12 @@
         class="flex w-full flex-col justify-end gap-2 sm:flex-row"
       >
         <Button
-          :disabled="rawList.length === 0 || isLoadingAction"
+          :disabled="isLoadingAction"
           :loading="isLoadingAction"
           :label="$t('rooms.members.modals.add.add')"
           data-test="dialog-continue-button"
-          @click="importUsers(true)"
+          form="room-members-bulk-import-form"
+          type="submit"
         />
       </div>
 
@@ -74,8 +75,12 @@
       </div>
     </template>
 
-    <div v-if="step === 0">
-      <div class="mt-6 flex flex-col gap-2">
+    <Form
+      id="room-members-bulk-import-form"
+      :disabled="isLoadingAction"
+      @submit="importUsers(true)"
+    >
+      <div class="field mt-6 flex flex-col gap-2">
         <label for="user-emails">{{
           $t("rooms.members.modals.bulk_import.label")
         }}</label>
@@ -83,6 +88,7 @@
           id="user-emails"
           v-model="rawList"
           autofocus
+          required
           aria-describedby="user-emails-help"
           :disabled="isLoadingAction"
           :placeholder="$t('rooms.members.modals.bulk_import.list_placeholder')"
@@ -95,7 +101,7 @@
         <FormError :errors="formErrors.fieldError('user_emails')" />
       </div>
       <!-- select role -->
-      <div class="mt-6 flex flex-col gap-2">
+      <div class="field mt-6 flex flex-col gap-2">
         <fieldset class="flex w-full flex-col gap-2">
           <legend>{{ $t("rooms.role") }}</legend>
 
@@ -104,6 +110,8 @@
               v-model="newUsersRole"
               :disabled="isLoadingAction"
               input-id="participant-role"
+              :invalid="formErrors.fieldInvalid('role')"
+              pt:input:required="required"
               name="role"
               :value="1"
             />
@@ -117,6 +125,8 @@
               v-model="newUsersRole"
               :disabled="isLoadingAction"
               input-id="moderator-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="2"
             />
@@ -130,6 +140,8 @@
               v-model="newUsersRole"
               :disabled="isLoadingAction"
               input-id="co_owner-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="3"
             />
@@ -141,7 +153,7 @@
           <FormError :errors="formErrors.fieldError('role')" />
         </fieldset>
       </div>
-    </div>
+    </Form>
 
     <div v-if="step === 1">
       <RoomTabMembersBulkImportList
@@ -206,7 +218,7 @@ const emit = defineEmits(["imported"]);
 
 const step = ref(0);
 const rawList = ref("");
-const newUsersRole = ref(1);
+const newUsersRole = ref(null);
 const modalVisible = ref(false);
 
 const validUsers = ref([]);

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -57,7 +57,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="participant-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="1"
@@ -72,7 +72,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="moderator-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="2"
@@ -87,7 +87,7 @@
               v-model="newRole"
               :disabled="isLoadingAction"
               input-id="co_owner-role"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
               :value="3"

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -192,6 +192,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -46,7 +46,11 @@
       </div>
     </template>
 
-    <Form id="room-members-edit-form" @submit="save">
+    <Form
+      id="room-members-edit-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- select role -->
       <div class="field mt-6 flex flex-col gap-2">
         <fieldset class="flex w-full flex-col gap-2">

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -40,58 +40,67 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-members-edit-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- select role -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.role") }}</legend>
+    <Form id="room-members-edit-form" @submit="save">
+      <!-- select role -->
+      <div class="field mt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="participant-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="participant-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="1"
+            />
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="moderator-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="co-owner-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="co_owner-role"
-            name="role"
-            :value="3"
-          />
-          <label for="co_owner-role" class="ml-2"
-            ><RoomRoleBadge :role="3"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="co-owner-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              input-id="co_owner-role"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="3"
+            />
+            <label for="co_owner-role" class="ml-2"
+              ><RoomRoleBadge :role="3"
+            /></label>
+          </div>
 
-        <FormError :errors="formErrors.fieldError('role')" />
-      </fieldset>
-    </div>
+          <FormError :errors="formErrors.fieldError('role')" />
+        </fieldset>
+      </div>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -192,7 +192,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabMembersEditButton.vue
+++ b/resources/js/components/RoomTabMembersEditButton.vue
@@ -48,8 +48,8 @@
 
     <Form
       id="room-members-edit-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- select role -->
       <div class="field mt-6 flex flex-col gap-2">

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -77,7 +77,7 @@
               v-model="role"
               :disabled="isLoadingAction"
               input-id="participant-role"
-              pt:input:required="required"
+              pt:input:required
               name="role"
               :invalid="formErrors.fieldInvalid('role')"
               :value="1"
@@ -92,7 +92,7 @@
               v-model="role"
               :disabled="isLoadingAction"
               :invalid="formErrors.fieldInvalid('role')"
-              pt:input:required="required"
+              pt:input:required
               input-id="moderator-role"
               name="role"
               :value="2"

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -176,6 +176,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -176,7 +176,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -43,8 +43,8 @@
 
     <Form
       id="room-personalized-links-add-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- first name -->
       <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -35,70 +35,77 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-personalized-links-add-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- first name -->
-    <div class="mt-6 flex flex-col gap-2" data-test="firstname-field">
-      <label for="firstname">{{ $t("app.firstname") }}</label>
-      <InputText
-        id="firstname"
-        v-model.trim="firstname"
-        autofocus
-        :disabled="isLoadingAction"
-        :invalid="formErrors.fieldInvalid('firstname')"
-      />
-      <FormError :errors="formErrors.fieldError('firstname')" />
-    </div>
+    <Form id="room-personalized-links-add-form" @submit="save">
+      <!-- first name -->
+      <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">
+        <label for="firstname">{{ $t("app.firstname") }}</label>
+        <InputText
+          id="firstname"
+          v-model.trim="firstname"
+          autofocus
+          :disabled="isLoadingAction"
+          :invalid="formErrors.fieldInvalid('firstname')"
+        />
+        <FormError :errors="formErrors.fieldError('firstname')" />
+      </div>
 
-    <!-- last name -->
-    <div class="mt-6 flex flex-col gap-2" data-test="lastname-field">
-      <label for="lastname">{{ $t("app.lastname") }}</label>
-      <InputText
-        id="lastname"
-        v-model.trim="lastname"
-        :disabled="isLoadingAction"
-        :invalid="formErrors.fieldInvalid('lastname')"
-      />
-      <FormError :errors="formErrors.fieldError('lastname')" />
-    </div>
+      <!-- last name -->
+      <div class="field mt-6 flex flex-col gap-2" data-test="lastname-field">
+        <label for="lastname">{{ $t("app.lastname") }}</label>
+        <InputText
+          id="lastname"
+          v-model.trim="lastname"
+          :disabled="isLoadingAction"
+          :invalid="formErrors.fieldInvalid('lastname')"
+        />
+        <FormError :errors="formErrors.fieldError('lastname')" />
+      </div>
 
-    <!-- select role -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.role") }}</legend>
+      <!-- select role -->
+      <div class="field mt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="role"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="participant-role-group">
+            <RadioButton
+              v-model="role"
+              :disabled="isLoadingAction"
+              input-id="participant-role"
+              pt:input:required="required"
+              name="role"
+              :invalid="formErrors.fieldInvalid('role')"
+              :value="1"
+            />
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="role"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="role"
+              :disabled="isLoadingAction"
+              :invalid="formErrors.fieldInvalid('role')"
+              pt:input:required="required"
+              input-id="moderator-role"
+              name="role"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
 
-        <FormError :errors="formErrors.fieldError('role')" />
-      </fieldset>
-    </div>
+          <FormError :errors="formErrors.fieldError('role')" />
+        </fieldset>
+      </div>
+    </Form>
   </Dialog>
 </template>
 

--- a/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksAddButton.vue
@@ -41,7 +41,11 @@
       </div>
     </template>
 
-    <Form id="room-personalized-links-add-form" @submit="save">
+    <Form
+      id="room-personalized-links-add-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- first name -->
       <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">
         <label for="firstname">{{ $t("app.firstname") }}</label>

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -36,70 +36,77 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-personalized-links-edit-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- first name -->
-    <div class="mt-6 flex flex-col gap-2" data-test="firstname-field">
-      <label for="firstname">{{ $t("app.firstname") }}</label>
-      <InputText
-        id="firstname"
-        v-model.trim="newFirstname"
-        autofocus
-        :disabled="isLoadingAction"
-        :invalid="formErrors.fieldInvalid('firstname')"
-      />
-      <FormError :errors="formErrors.fieldError('firstname')" />
-    </div>
+    <Form id="room-personalized-links-edit-form" @submit="save">
+      <!-- first name -->
+      <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">
+        <label for="firstname">{{ $t("app.firstname") }}</label>
+        <InputText
+          id="firstname"
+          v-model.trim="newFirstname"
+          autofocus
+          :disabled="isLoadingAction"
+          :invalid="formErrors.fieldInvalid('firstname')"
+        />
+        <FormError :errors="formErrors.fieldError('firstname')" />
+      </div>
 
-    <!-- last name -->
-    <div class="mt-6 flex flex-col gap-2" data-test="lastname-field">
-      <label for="lastname">{{ $t("app.lastname") }}</label>
-      <InputText
-        id="lastname"
-        v-model.trim="newLastname"
-        :disabled="isLoadingAction"
-        :invalid="formErrors.fieldInvalid('lastname')"
-      />
-      <FormError :errors="formErrors.fieldError('lastname')" />
-    </div>
+      <!-- last name -->
+      <div class="field mt-6 flex flex-col gap-2" data-test="lastname-field">
+        <label for="lastname">{{ $t("app.lastname") }}</label>
+        <InputText
+          id="lastname"
+          v-model.trim="newLastname"
+          :disabled="isLoadingAction"
+          :invalid="formErrors.fieldInvalid('lastname')"
+        />
+        <FormError :errors="formErrors.fieldError('lastname')" />
+      </div>
 
-    <!-- select role -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.role") }}</legend>
+      <!-- select role -->
+      <div class="fieldmt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
+          <div class="flex items-center" data-test="participant-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              pt:input:required="required"
+              input-id="participant-role"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="1"
+            />
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
+          </div>
 
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="newRole"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
-      </fieldset>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="newRole"
+              :disabled="isLoadingAction"
+              pt:input:required="required"
+              input-id="moderator-role"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
+        </fieldset>
 
-      <FormError :errors="formErrors.fieldError('role')" />
-    </div>
+        <FormError :errors="formErrors.fieldError('role')" />
+      </div>
+    </Form>
   </Dialog>
 </template>
 

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -77,7 +77,7 @@
             <RadioButton
               v-model="newRole"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               input-id="participant-role"
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
@@ -92,7 +92,7 @@
             <RadioButton
               v-model="newRole"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               input-id="moderator-role"
               :invalid="formErrors.fieldInvalid('role')"
               name="role"

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -69,7 +69,7 @@
       </div>
 
       <!-- select role -->
-      <div class="fieldmt-6 flex flex-col gap-2">
+      <div class="field mt-6 flex flex-col gap-2">
         <fieldset class="flex w-full flex-col gap-2">
           <legend>{{ $t("rooms.role") }}</legend>
 

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -209,6 +209,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -209,7 +209,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -44,8 +44,8 @@
 
     <Form
       id="room-personalized-links-edit-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- first name -->
       <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">

--- a/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
+++ b/resources/js/components/RoomTabPersonalizedLinksEditButton.vue
@@ -42,7 +42,11 @@
       </div>
     </template>
 
-    <Form id="room-personalized-links-edit-form" @submit="save">
+    <Form
+      id="room-personalized-links-edit-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- first name -->
       <div class="field mt-6 flex flex-col gap-2" data-test="firstname-field">
         <label for="firstname">{{ $t("app.firstname") }}</label>

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -48,77 +48,87 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="room-recordings-edit-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <!-- description -->
-    <div class="flex flex-col gap-2" data-test="description-field">
-      <label for="description">{{ $t("rooms.recordings.description") }}</label>
-      <Textarea
-        id="description"
-        v-model="newDescription"
-        autofocus
-        :disabled="isLoadingAction"
-        :invalid="formErrors.fieldInvalid('description')"
-        :maxlength="
-          settingsStore.getSetting('recording.recording_description_limit')
-        "
-      />
-      <FormError :errors="formErrors.fieldError('description')" />
-      <small>
-        {{ $t("app.char_counter", { chars: charactersLeftDescription }) }}
-      </small>
-    </div>
-
-    <!-- available formats -->
-    <div class="mt-6 flex flex-col gap-2" data-test="available-formats-field">
-      <label>{{ $t("rooms.recordings.available_formats") }}</label>
-      <div
-        v-for="format in newFormats"
-        :key="format.id"
-        class="flex items-center"
-        :data-test="'format-' + format.id + '-field'"
-      >
-        <ToggleSwitch
-          v-model="format.disabled"
-          :input-id="'format-' + format.id"
-          :disabled="isLoadingAction"
-          :true-value="false"
-          :false-value="true"
-        />
-        <label :for="'format-' + format.id" class="ml-2">{{
-          $t("rooms.recordings.format_types." + format.format)
+    <Form id="room-recordings-edit-form" @submit="save">
+      <!-- description -->
+      <div class="field flex flex-col gap-2" data-test="description-field">
+        <label for="description">{{
+          $t("rooms.recordings.description")
         }}</label>
+        <Textarea
+          id="description"
+          v-model="newDescription"
+          autofocus
+          :disabled="isLoadingAction"
+          :invalid="formErrors.fieldInvalid('description')"
+          :maxlength="
+            settingsStore.getSetting('recording.recording_description_limit')
+          "
+        />
+        <FormError :errors="formErrors.fieldError('description')" />
+        <small>
+          {{ $t("app.char_counter", { chars: charactersLeftDescription }) }}
+        </small>
       </div>
-      <FormError :errors="formErrors.fieldError('formats', true)" />
-    </div>
 
-    <!-- access -->
-    <div class="mt-6 flex flex-col gap-2" data-test="access-field">
-      <fieldset class="flex w-full flex-col gap-2">
-        <label>{{ $t("rooms.recordings.access") }}</label>
+      <!-- available formats -->
+      <div
+        class="field mt-6 flex flex-col gap-2"
+        data-test="available-formats-field"
+      >
+        <label>{{ $t("rooms.recordings.available_formats") }}</label>
         <div
-          v-for="accessType in accessTypes"
-          :key="accessType"
+          v-for="format in newFormats"
+          :key="format.id"
           class="flex items-center"
-          :data-test="'access-' + accessType + '-field'"
+          :data-test="'format-' + format.id + '-field'"
         >
-          <RadioButton
-            v-model="newAccess"
+          <ToggleSwitch
+            v-model="format.disabled"
+            :input-id="'format-' + format.id"
             :disabled="isLoadingAction"
-            :input-id="'access-' + accessType"
-            name="access"
-            :value="accessType"
+            :true-value="false"
+            :false-value="true"
           />
-          <label :for="'access-' + accessType" class="ml-2"
-            ><RoomRecordingAccessBadge :access="accessType"
-          /></label>
+          <label :for="'format-' + format.id" class="ml-2">{{
+            $t("rooms.recordings.format_types." + format.format)
+          }}</label>
         </div>
-        <FormError :errors="formErrors.fieldError('access')" />
-      </fieldset>
-    </div>
+        <FormError :errors="formErrors.fieldError('formats', true)" />
+      </div>
+
+      <!-- access -->
+      <div class="field mt-6 flex flex-col gap-2" data-test="access-field">
+        <fieldset class="flex w-full flex-col gap-2">
+          <label>{{ $t("rooms.recordings.access") }}</label>
+          <div
+            v-for="accessType in accessTypes"
+            :key="accessType"
+            class="flex items-center"
+            :data-test="'access-' + accessType + '-field'"
+          >
+            <RadioButton
+              v-model="newAccess"
+              :disabled="isLoadingAction"
+              pt:input:required="required"
+              :invalid="formErrors.fieldInvalid('access')"
+              :input-id="'access-' + accessType"
+              name="access"
+              :value="accessType"
+            />
+            <label :for="'access-' + accessType" class="ml-2"
+              ><RoomRecordingAccessBadge :access="accessType"
+            /></label>
+          </div>
+          <FormError :errors="formErrors.fieldError('access')" />
+        </fieldset>
+      </div>
+    </Form>
   </Dialog>
 </template>
 <script setup>

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -256,6 +256,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -256,7 +256,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -56,8 +56,8 @@
 
     <Form
       id="room-recordings-edit-form"
-      @submit="save"
       :disabled="isLoadingAction"
+      @submit="save"
     >
       <!-- description -->
       <div class="field flex flex-col gap-2" data-test="description-field">

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -54,7 +54,11 @@
       </div>
     </template>
 
-    <Form id="room-recordings-edit-form" @submit="save">
+    <Form
+      id="room-recordings-edit-form"
+      @submit="save"
+      :disabled="isLoadingAction"
+    >
       <!-- description -->
       <div class="field flex flex-col gap-2" data-test="description-field">
         <label for="description">{{

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -115,7 +115,7 @@
             <RadioButton
               v-model="newAccess"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               :invalid="formErrors.fieldInvalid('access')"
               :input-id="'access-' + accessType"
               name="access"

--- a/resources/js/components/RoomTabSettings.vue
+++ b/resources/js/components/RoomTabSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <form :aria-hidden="loadingError" @submit="save">
+    <Form :aria-hidden="loadingError" :disabled="disabled" @submit="save">
       <OverlayComponent :show="isBusy || loadingError">
         <template #overlay>
           <LoadingRetryButton :error="loadingError" @reload="load" />
@@ -106,7 +106,7 @@
           type="submit"
         />
       </div>
-    </form>
+    </Form>
   </div>
 </template>
 
@@ -356,12 +356,8 @@ const form = computed(() => {
 /**
  * Save room settings
  *
- *  @param event
  */
-function save(event) {
-  // Prevent default form submit
-  event.preventDefault();
-
+function save() {
   // Set busy indicator
   isBusy.value = true;
 

--- a/resources/js/components/RoomTabSettings.vue
+++ b/resources/js/components/RoomTabSettings.vue
@@ -400,7 +400,6 @@ function save(event) {
     .finally(() => {
       // Disable busy indicator
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabSettings.vue
+++ b/resources/js/components/RoomTabSettings.vue
@@ -131,7 +131,6 @@ import RoomTabSettingsRadioGroup from "./RoomTabSettingsRadioGroup.vue";
 import RoomTabSettingsSelectButton from "./RoomTabSettingsSelectButton.vue";
 import RoomTabSettingsRoomTypeSelect from "./RoomTabSettingsRoomTypeSelect.vue";
 import RoomTabSettingsAccessCodeInput from "./RoomTabSettingsAccessCodeInput.vue";
-import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   room: {
@@ -160,7 +159,6 @@ const userPermissions = useUserPermissions();
 const { t } = useI18n();
 const saveButton = ref(null);
 const saveButtonIsVisible = useElementVisibility(saveButton);
-const toast = useToast();
 
 const form = computed(() => {
   const sections = [
@@ -392,7 +390,7 @@ function save(event) {
       // Settings couldn't be saved
       if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
         return;
       }
       api.error(error, { redirectOnUnauthenticated: false });

--- a/resources/js/components/RoomTabSettings.vue
+++ b/resources/js/components/RoomTabSettings.vue
@@ -397,6 +397,7 @@ function save(event) {
     .finally(() => {
       // Disable busy indicator
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabSettings.vue
+++ b/resources/js/components/RoomTabSettings.vue
@@ -131,6 +131,7 @@ import RoomTabSettingsRadioGroup from "./RoomTabSettingsRadioGroup.vue";
 import RoomTabSettingsSelectButton from "./RoomTabSettingsSelectButton.vue";
 import RoomTabSettingsRoomTypeSelect from "./RoomTabSettingsRoomTypeSelect.vue";
 import RoomTabSettingsAccessCodeInput from "./RoomTabSettingsAccessCodeInput.vue";
+import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   room: {
@@ -159,6 +160,7 @@ const userPermissions = useUserPermissions();
 const { t } = useI18n();
 const saveButton = ref(null);
 const saveButtonIsVisible = useElementVisibility(saveButton);
+const toast = useToast();
 
 const form = computed(() => {
   const sections = [
@@ -390,6 +392,7 @@ function save(event) {
       // Settings couldn't be saved
       if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
         return;
       }
       api.error(error, { redirectOnUnauthenticated: false });

--- a/resources/js/components/RoomTabSettingsAccessCodeInput.vue
+++ b/resources/js/components/RoomTabSettingsAccessCodeInput.vue
@@ -3,8 +3,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">

--- a/resources/js/components/RoomTabSettingsRadioGroup.vue
+++ b/resources/js/components/RoomTabSettingsRadioGroup.vue
@@ -5,8 +5,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">

--- a/resources/js/components/RoomTabSettingsRoomTypeSelect.vue
+++ b/resources/js/components/RoomTabSettingsRoomTypeSelect.vue
@@ -3,8 +3,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">
@@ -44,20 +44,28 @@
         :draggable="false"
         :dismissable-mask="false"
       >
-        <div class="flex flex-col gap-2">
-          <label id="room-type-label">{{
-            $t("rooms.settings.general.type")
-          }}</label>
-          <RoomTypeSelect
-            ref="roomTypeSelect"
-            v-model="newRoomType"
-            :room-id="room.id"
-            aria-labelledby="room-type-label"
-            :redirect-on-unauthenticated="false"
-            @loading-error="(value) => (roomTypeSelectLoadingError = value)"
-            @busy="(value) => (roomTypeSelectBusy = value)"
-          />
-        </div>
+        <Form
+          id="room-type-change-form"
+          :disabled="
+            roomTypeSelectLoadingError || !newRoomType || roomTypeSelectBusy
+          "
+          @submit="handleOk"
+        >
+          <div class="field flex flex-col gap-2">
+            <label id="room-type-label">{{
+              $t("rooms.settings.general.type")
+            }}</label>
+            <RoomTypeSelect
+              ref="roomTypeSelect"
+              v-model="newRoomType"
+              :room-id="room.id"
+              aria-labelledby="room-type-label"
+              :redirect-on-unauthenticated="false"
+              @loading-error="(value) => (roomTypeSelectLoadingError = value)"
+              @busy="(value) => (roomTypeSelectBusy = value)"
+            />
+          </div>
+        </Form>
 
         <template #footer>
           <div class="flex justify-end gap-2">
@@ -74,7 +82,8 @@
                 roomTypeSelectLoadingError || !newRoomType || roomTypeSelectBusy
               "
               data-test="dialog-save-button"
-              @click="handleOk"
+              form="room-type-change-form"
+              type="submit"
             />
           </div>
         </template>

--- a/resources/js/components/RoomTabSettingsSelectButton.vue
+++ b/resources/js/components/RoomTabSettingsSelectButton.vue
@@ -5,8 +5,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">

--- a/resources/js/components/RoomTabSettingsTextArea.vue
+++ b/resources/js/components/RoomTabSettingsTextArea.vue
@@ -3,8 +3,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">

--- a/resources/js/components/RoomTabSettingsTextInput.vue
+++ b/resources/js/components/RoomTabSettingsTextInput.vue
@@ -3,8 +3,8 @@
     :data-test="'room-setting-' + setting"
     :class="
       fullWidth
-        ? 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
-        : 'col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
+        ? 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0'
+        : 'field col-span-12 row-span-2 grid grid-rows-subgrid gap-0 md:col-span-6 xl:col-span-3'
     "
   >
     <div class="mb-2 flex flex-col justify-end">

--- a/resources/js/components/RoomTabSettingsToggleSwitch.vue
+++ b/resources/js/components/RoomTabSettingsToggleSwitch.vue
@@ -8,7 +8,7 @@
     "
   >
     <div class="row-start-2">
-      <div class="flex items-center gap-2">
+      <div class="field flex items-center gap-2">
         <ToggleSwitch
           v-model="model[setting]"
           :input-id="'room-setting-' + setting"

--- a/resources/js/components/RoomTabStreamingConfigButton.vue
+++ b/resources/js/components/RoomTabStreamingConfigButton.vue
@@ -277,7 +277,6 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabStreamingConfigButton.vue
+++ b/resources/js/components/RoomTabStreamingConfigButton.vue
@@ -277,6 +277,7 @@ function save() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTabStreamingConfigButton.vue
+++ b/resources/js/components/RoomTabStreamingConfigButton.vue
@@ -37,7 +37,8 @@
           :label="$t('app.save')"
           :loading="isLoadingAction"
           :disabled="isLoadingAction || isLoading || modelLoadingError"
-          @click="save"
+          form="room-streaming-config-form"
+          type="submit"
         />
       </div>
     </template>
@@ -48,9 +49,14 @@
           <LoadingRetryButton :error="modelLoadingError" @click="loadConfig" />
         </div>
       </template>
-      <form class="flex flex-col gap-4" @submit.prevent="save">
+      <Form
+        id="room-streaming-config-form"
+        class="flex flex-col gap-4"
+        :disabled="isLoadingAction || isLoading || modelLoadingError"
+        @submit="save"
+      >
         <div
-          class="col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
+          class="field col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
           data-test="streaming-enabled-field"
         >
           <label for="streaming-enabled" class="flex items-center">
@@ -68,7 +74,7 @@
 
         <!-- Streaming url -->
         <div
-          class="col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
+          class="field col-span-12 flex flex-col gap-2 md:col-span-6 xl:col-span-3"
           data-test="streaming-url-field"
         >
           <label for="streaming-url" class="mb-2">{{
@@ -85,7 +91,7 @@
         </div>
 
         <fieldset
-          class="grid-rows grid gap-2"
+          class="field grid-rows grid gap-2"
           data-test="streaming-pause-image-field"
         >
           <legend
@@ -150,7 +156,7 @@
             <small>{{ $t("rooms.streaming.config.pause_image_format") }}</small>
           </div>
         </fieldset>
-      </form>
+      </Form>
     </OverlayComponent>
   </Dialog>
 </template>

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -24,8 +24,8 @@
   >
     <Form
       id="room-transfer-ownership-form"
-      @submit="transferOwnership"
       :disabled="isLoadingAction"
+      @submit="transferOwnership"
     >
       <!--select new owner-->
       <!-- select user -->

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -22,128 +22,138 @@
     :dismissable-mask="false"
     :closable="!isLoadingAction"
   >
-    <!--select new owner-->
-    <!-- select user -->
-    <div class="relative mt-2 flex flex-col gap-2 overflow-visible">
-      <label id="user-label">{{ $t("app.user") }}</label>
-      <multiselect
-        v-model="newOwner"
-        aria-labelledby="user-label"
-        autofocus
-        data-test="new-owner-dropdown"
-        :disabled="isLoadingAction"
-        label="lastname"
-        track-by="id"
-        :placeholder="$t('app.user_name')"
-        open-direction="bottom"
-        :options="users"
-        :multiple="false"
-        :searchable="true"
-        :loading="isLoadingSearch"
-        :internal-search="false"
-        :clear-on-select="false"
-        :preserve-search="true"
-        :close-on-select="true"
-        :options-limit="300"
-        :max-height="600"
-        :show-no-results="true"
-        :show-labels="false"
-        :invalid="formErrors.fieldInvalid('user')"
-        @search-change="asyncFind"
-      >
-        <template #noResult>
-          <span v-if="tooManyResults" class="whitespace-normal">
-            {{ $t("rooms.members.modals.add.too_many_results") }}
-          </span>
-          <span v-else>
-            {{ $t("rooms.members.modals.add.no_result") }}
-          </span>
-        </template>
-        <template #noOptions>
-          {{ $t("rooms.members.modals.add.no_options") }}
-        </template>
-        <template #option="{ option }">
-          {{ option.firstname }} {{ option.lastname }}<br /><small>{{
-            option.email
-          }}</small>
-        </template>
-        <template #singleLabel="{ option }">
-          {{ option.firstname }} {{ option.lastname }}
-        </template>
-      </multiselect>
-      <FormError :errors="formErrors.fieldError('user')" />
-    </div>
+    <Form id="room-transfer-ownership-form" @submit="transferOwnership">
+      <!--select new owner-->
+      <!-- select user -->
+      <div class="field relative mt-2 flex flex-col gap-2 overflow-visible">
+        <label id="user-label">{{ $t("app.user") }}</label>
+        <multiselect
+          v-model="newOwner"
+          aria-labelledby="user-label"
+          autofocus
+          data-test="new-owner-dropdown"
+          :disabled="isLoadingAction"
+          label="lastname"
+          track-by="id"
+          :placeholder="$t('app.user_name')"
+          open-direction="bottom"
+          :options="users"
+          :multiple="false"
+          :searchable="true"
+          :loading="isLoadingSearch"
+          :internal-search="false"
+          :clear-on-select="false"
+          :preserve-search="true"
+          :close-on-select="true"
+          :options-limit="300"
+          :max-height="600"
+          :show-no-results="true"
+          :show-labels="false"
+          :invalid="formErrors.fieldInvalid('user')"
+          @search-change="asyncFind"
+        >
+          <template #noResult>
+            <span v-if="tooManyResults" class="whitespace-normal">
+              {{ $t("rooms.members.modals.add.too_many_results") }}
+            </span>
+            <span v-else>
+              {{ $t("rooms.members.modals.add.no_result") }}
+            </span>
+          </template>
+          <template #noOptions>
+            {{ $t("rooms.members.modals.add.no_options") }}
+          </template>
+          <template #option="{ option }">
+            {{ option.firstname }} {{ option.lastname }}<br /><small>{{
+              option.email
+            }}</small>
+          </template>
+          <template #singleLabel="{ option }">
+            {{ option.firstname }} {{ option.lastname }}
+          </template>
+        </multiselect>
+        <FormError :errors="formErrors.fieldError('user')" />
+      </div>
 
-    <!--select new role with which the current owner should be added as a member of the room -->
-    <div class="mt-6 flex flex-col gap-2">
-      <fieldset class="flex w-full flex-col gap-2">
-        <legend>{{ $t("rooms.modals.transfer_ownership.new_role") }}</legend>
+      <!--select new role with which the current owner should be added as a member of the room -->
+      <div class="field mt-6 flex flex-col gap-2">
+        <fieldset class="flex w-full flex-col gap-2">
+          <legend>{{ $t("rooms.modals.transfer_ownership.new_role") }}</legend>
 
-        <div class="flex items-center" data-test="participant-role-group">
-          <RadioButton
-            v-model="newRoleInRoom"
-            :disabled="isLoadingAction"
-            input-id="participant-role"
-            name="role"
-            :value="1"
-          />
-          <label for="participant-role" class="ml-2"
-            ><RoomRoleBadge :role="1"
-          /></label>
-        </div>
-
-        <div class="flex items-center" data-test="moderator-role-group">
-          <RadioButton
-            v-model="newRoleInRoom"
-            :disabled="isLoadingAction"
-            input-id="moderator-role"
-            name="role"
-            :value="2"
-          />
-          <label for="moderator-role" class="ml-2"
-            ><RoomRoleBadge :role="2"
-          /></label>
-        </div>
-
-        <div class="flex items-center" data-test="co-owner-role-group">
-          <RadioButton
-            v-model="newRoleInRoom"
-            :disabled="isLoadingAction"
-            input-id="co-owner-role"
-            name="role"
-            :value="3"
-          />
-          <label for="co-owner-role" class="ml-2"
-            ><RoomRoleBadge :role="3"
-          /></label>
-        </div>
-
-        <Divider />
-        <!--option to not add the current user as a member of the room-->
-        <div data-test="no-role-group">
-          <div class="flex items-center">
+          <div class="flex items-center" data-test="participant-role-group">
             <RadioButton
               v-model="newRoleInRoom"
               :disabled="isLoadingAction"
-              input-id="no-role"
+              pt:input:required="required"
+              input-id="participant-role"
+              :invalid="formErrors.fieldInvalid('role')"
               name="role"
-              :value="-1"
-              :pt="{
-                input: {
-                  'aria-describedby': 'no-role-warning',
-                },
-              }"
+              :value="1"
             />
-            <label for="no-role" class="ml-2"><RoomRoleBadge /></label>
+            <label for="participant-role" class="ml-2"
+              ><RoomRoleBadge :role="1"
+            /></label>
           </div>
-          <small id="no-role-warning">{{
-            $t("rooms.modals.transfer_ownership.warning")
-          }}</small>
-        </div>
 
-        <FormError :errors="formErrors.fieldError('role')" />
-      </fieldset>
-    </div>
+          <div class="flex items-center" data-test="moderator-role-group">
+            <RadioButton
+              v-model="newRoleInRoom"
+              :disabled="isLoadingAction"
+              pt:input:required="required"
+              input-id="moderator-role"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="2"
+            />
+            <label for="moderator-role" class="ml-2"
+              ><RoomRoleBadge :role="2"
+            /></label>
+          </div>
+
+          <div class="flex items-center" data-test="co-owner-role-group">
+            <RadioButton
+              v-model="newRoleInRoom"
+              :disabled="isLoadingAction"
+              pt:input:required="required"
+              input-id="co-owner-role"
+              :invalid="formErrors.fieldInvalid('role')"
+              name="role"
+              :value="3"
+            />
+            <label for="co-owner-role" class="ml-2"
+              ><RoomRoleBadge :role="3"
+            /></label>
+          </div>
+
+          <Divider />
+          <!--option to not add the current user as a member of the room-->
+          <div data-test="no-role-group">
+            <div class="flex items-center">
+              <RadioButton
+                v-model="newRoleInRoom"
+                pt:input:required="required"
+                :disabled="isLoadingAction"
+                input-id="no-role"
+                :invalid="formErrors.fieldInvalid('role')"
+                name="role"
+                :value="-1"
+                :pt="{
+                  input: {
+                    'aria-describedby': 'no-role-warning',
+                  },
+                }"
+              />
+              <label for="no-role" class="ml-2"><RoomRoleBadge /></label>
+            </div>
+            <small id="no-role-warning">{{
+              $t("rooms.modals.transfer_ownership.warning")
+            }}</small>
+          </div>
+
+          <FormError :errors="formErrors.fieldError('role')" />
+        </fieldset>
+      </div>
+    </Form>
 
     <template #footer>
       <div class="flex justify-end gap-2">
@@ -159,7 +169,8 @@
           severity="danger"
           :loading="isLoadingAction"
           data-test="dialog-continue-button"
-          @click="transferOwnership"
+          form="room-transfer-ownership-form"
+          type="submit"
         />
       </div>
     </template>

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -84,7 +84,7 @@
             <RadioButton
               v-model="newRoleInRoom"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               input-id="participant-role"
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
@@ -99,7 +99,7 @@
             <RadioButton
               v-model="newRoleInRoom"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               input-id="moderator-role"
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
@@ -114,7 +114,7 @@
             <RadioButton
               v-model="newRoleInRoom"
               :disabled="isLoadingAction"
-              pt:input:required="required"
+              pt:input:required
               input-id="co-owner-role"
               :invalid="formErrors.fieldInvalid('role')"
               name="role"
@@ -131,7 +131,7 @@
             <div class="flex items-center">
               <RadioButton
                 v-model="newRoleInRoom"
-                pt:input:required="required"
+                pt:input:required
                 :disabled="isLoadingAction"
                 input-id="no-role"
                 :invalid="formErrors.fieldInvalid('role')"

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -239,7 +239,6 @@ function transferOwnership() {
     })
     .finally(() => {
       isLoadingAction.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -49,7 +49,7 @@
           :max-height="600"
           :show-no-results="true"
           :show-labels="false"
-          :invalid="formErrors.fieldInvalid('user')"
+          :class="{ 'is-invalid': formErrors.fieldInvalid('user') }"
           @search-change="asyncFind"
         >
           <template #noResult>

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -239,6 +239,7 @@ function transferOwnership() {
     })
     .finally(() => {
       isLoadingAction.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/RoomTransferOwnershipButton.vue
+++ b/resources/js/components/RoomTransferOwnershipButton.vue
@@ -22,7 +22,11 @@
     :dismissable-mask="false"
     :closable="!isLoadingAction"
   >
-    <Form id="room-transfer-ownership-form" @submit="transferOwnership">
+    <Form
+      id="room-transfer-ownership-form"
+      @submit="transferOwnership"
+      :disabled="isLoadingAction"
+    >
       <!--select new owner-->
       <!-- select user -->
       <div class="field relative mt-2 flex flex-col gap-2 overflow-visible">

--- a/resources/js/components/SettingsRoomTypesDeleteButton.vue
+++ b/resources/js/components/SettingsRoomTypesDeleteButton.vue
@@ -214,7 +214,6 @@ function deleteRoomType() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/SettingsRoomTypesDeleteButton.vue
+++ b/resources/js/components/SettingsRoomTypesDeleteButton.vue
@@ -25,7 +25,10 @@
       {{ $t("admin.room_types.delete.confirm", { name: props.name }) }}
     </span>
     <Divider />
-    <div class="flex flex-col gap-2" data-test="replacement-room-type-field">
+    <div
+      class="field flex flex-col gap-2"
+      data-test="replacement-room-type-field"
+    >
       <label for="replacement-room-type">{{
         $t("admin.room_types.delete.replacement")
       }}</label>

--- a/resources/js/components/SettingsRoomTypesDeleteButton.vue
+++ b/resources/js/components/SettingsRoomTypesDeleteButton.vue
@@ -214,6 +214,7 @@ function deleteRoomType() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/components/TipTapImage.vue
+++ b/resources/js/components/TipTapImage.vue
@@ -32,6 +32,7 @@
           id="src"
           v-model.trim="src"
           autofocus
+          required
           :invalid="srcInvalid"
         />
         <p v-if="srcInvalid" class="text-red-500" role="alert">

--- a/resources/js/components/TipTapImage.vue
+++ b/resources/js/components/TipTapImage.vue
@@ -21,28 +21,39 @@
     :draggable="false"
     data-test="tip-tap-image-dialog"
   >
-    <div class="mt-6 flex flex-col gap-2" data-test="src-field">
-      <label for="src">{{ $t("rooms.description.modals.image.src") }}</label>
-      <InputText id="src" v-model.trim="src" autofocus :invalid="srcInvalid" />
-      <p v-if="srcInvalid" class="text-red-500" role="alert">
-        {{ $t("rooms.description.modals.image.invalid_src") }}
-      </p>
-    </div>
+    <Form
+      id="tip-tap-image-form"
+      :disabled="srcInvalid !== false"
+      @submit="save"
+    >
+      <div class="field mt-6 flex flex-col gap-2" data-test="src-field">
+        <label for="src">{{ $t("rooms.description.modals.image.src") }}</label>
+        <InputText
+          id="src"
+          v-model.trim="src"
+          autofocus
+          :invalid="srcInvalid"
+        />
+        <p v-if="srcInvalid" class="text-red-500" role="alert">
+          {{ $t("rooms.description.modals.image.invalid_src") }}
+        </p>
+      </div>
 
-    <div class="mt-6 flex flex-col gap-2" data-test="width-field">
-      <label for="width">{{
-        $t("rooms.description.modals.image.width")
-      }}</label>
-      <InputText id="width" v-model="width" aria-describedby="width-help" />
-      <small id="width-help">{{
-        $t("rooms.description.modals.image.width_description")
-      }}</small>
-    </div>
+      <div class="field mt-6 flex flex-col gap-2" data-test="width-field">
+        <label for="width">{{
+          $t("rooms.description.modals.image.width")
+        }}</label>
+        <InputText id="width" v-model="width" aria-describedby="width-help" />
+        <small id="width-help">{{
+          $t("rooms.description.modals.image.width_description")
+        }}</small>
+      </div>
 
-    <div class="mt-6 flex flex-col gap-2" data-test="alt-field">
-      <label for="alt">{{ $t("rooms.description.modals.image.alt") }}</label>
-      <InputText id="alt" v-model="alt" />
-    </div>
+      <div class="field mt-6 flex flex-col gap-2" data-test="alt-field">
+        <label for="alt">{{ $t("rooms.description.modals.image.alt") }}</label>
+        <InputText id="alt" v-model="alt" />
+      </div>
+    </Form>
 
     <template #footer>
       <div class="flex w-full justify-between gap-2">
@@ -66,7 +77,8 @@
             :disabled="srcInvalid !== false"
             :label="$t('app.save')"
             data-test="dialog-save-button"
-            @click="save"
+            form="tip-tap-image-form"
+            type="submit"
           />
         </div>
       </div>

--- a/resources/js/components/TipTapLink.vue
+++ b/resources/js/components/TipTapLink.vue
@@ -32,6 +32,7 @@
           id="url"
           v-model.trim="link"
           autofocus
+          required
           :invalid="urlInvalid"
         />
         <p v-if="urlInvalid" class="text-red-500" role="alert">

--- a/resources/js/components/TipTapLink.vue
+++ b/resources/js/components/TipTapLink.vue
@@ -21,13 +21,24 @@
     :draggable="false"
     data-test="tip-tap-link-dialog"
   >
-    <div class="mt-6 flex flex-col gap-2" data-test="url-field">
-      <label for="url">{{ $t("rooms.description.modals.link.url") }}</label>
-      <InputText id="url" v-model.trim="link" autofocus :invalid="urlInvalid" />
-      <p v-if="urlInvalid" class="text-red-500" role="alert">
-        {{ $t("rooms.description.modals.link.invalid_url") }}
-      </p>
-    </div>
+    <Form
+      id="tip-tap-link-form"
+      :disabled="urlInvalid !== false"
+      @submit="save"
+    >
+      <div class="field mt-6 flex flex-col gap-2" data-test="url-field">
+        <label for="url">{{ $t("rooms.description.modals.link.url") }}</label>
+        <InputText
+          id="url"
+          v-model.trim="link"
+          autofocus
+          :invalid="urlInvalid"
+        />
+        <p v-if="urlInvalid" class="text-red-500" role="alert">
+          {{ $t("rooms.description.modals.link.invalid_url") }}
+        </p>
+      </div>
+    </Form>
 
     <template #footer>
       <div class="flex w-full justify-between gap-2">
@@ -51,7 +62,8 @@
             :disabled="urlInvalid !== false"
             :label="$t('app.save')"
             data-test="dialog-save-button"
-            @click="save"
+            form="tip-tap-link-form"
+            type="submit"
           />
         </div>
       </div>

--- a/resources/js/components/TipTapSource.vue
+++ b/resources/js/components/TipTapSource.vue
@@ -17,13 +17,15 @@
     :draggable="false"
     data-test="tip-tap-source-dialog"
   >
-    <Textarea
-      v-model="source"
-      autofocus
-      class="mt-2 w-full"
-      rows="5"
-      data-test="source-textarea"
-    />
+    <Form id="tip-tap-source-form" @submit="save">
+      <Textarea
+        v-model="source"
+        autofocus
+        class="mt-2 w-full"
+        rows="5"
+        data-test="source-textarea"
+      />
+    </Form>
 
     <template #footer>
       <div class="flex w-full justify-end gap-2">
@@ -36,7 +38,8 @@
         <Button
           :label="$t('app.save')"
           data-test="dialog-save-button"
-          @click="save"
+          form="tip-tap-source-form"
+          type="submit"
         />
       </div>
     </template>

--- a/resources/js/components/UserProfileImageSelector.vue
+++ b/resources/js/components/UserProfileImageSelector.vue
@@ -107,24 +107,20 @@
           :label="$t('admin.users.image.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          form="user-profile-image-form"
-          type="submit"
+          @click="save"
         />
       </div>
     </template>
-
-    <Form id="user-profile-image-form" @submit="save">
-      <VueCropper
-        v-show="selectedFile"
-        ref="cropperRef"
-        class="my-2"
-        :auto-crop-area="1"
-        :aspect-ratio="1"
-        :view-mode="1"
-        :src="selectedFile"
-        :alt="$t('admin.users.image.title')"
-      />
-    </Form>
+    <VueCropper
+      v-show="selectedFile"
+      ref="cropperRef"
+      class="my-2"
+      :auto-crop-area="1"
+      :aspect-ratio="1"
+      :view-mode="1"
+      :src="selectedFile"
+      :alt="$t('admin.users.image.title')"
+    />
   </Dialog>
 </template>
 

--- a/resources/js/components/UserProfileImageSelector.vue
+++ b/resources/js/components/UserProfileImageSelector.vue
@@ -107,21 +107,24 @@
           :label="$t('admin.users.image.save')"
           :loading="isLoadingAction"
           data-test="dialog-save-button"
-          @click="save"
+          form="user-profile-image-form"
+          type="submit"
         />
       </div>
     </template>
 
-    <VueCropper
-      v-show="selectedFile"
-      ref="cropperRef"
-      class="my-2"
-      :auto-crop-area="1"
-      :aspect-ratio="1"
-      :view-mode="1"
-      :src="selectedFile"
-      :alt="$t('admin.users.image.title')"
-    />
+    <Form id="user-profile-image-form" @submit="save">
+      <VueCropper
+        v-show="selectedFile"
+        ref="cropperRef"
+        class="my-2"
+        :auto-crop-area="1"
+        :aspect-ratio="1"
+        :view-mode="1"
+        :src="selectedFile"
+        :alt="$t('admin.users.image.title')"
+      />
+    </Form>
   </Dialog>
 </template>
 

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -168,7 +168,7 @@ function save(event) {
         emit("notFoundError", error);
       } else if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (error.response.status === env.HTTP_EMAIL_CHANGE_THROTTLE) {
         toast.error(t("auth.throttle_email"));
       } else {

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.email')">
-      <form class="flex flex-col gap-4" @submit.prevent="save">
+      <Form class="flex flex-col gap-4" @submit="save">
         <div
           v-if="
             !viewOnly &&
@@ -78,7 +78,7 @@
             }}
           </Message>
         </div>
-      </form>
+      </Form>
     </AdminPanel>
   </div>
 </template>

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.email')">
-      <Form class="flex flex-col gap-4" @submit="save" :disabled="isBusy">
+      <Form class="flex flex-col gap-4" :disabled="isBusy" @submit="save">
         <div
           v-if="
             !viewOnly &&

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.email')">
-      <Form class="flex flex-col gap-4" @submit="save">
+      <Form class="flex flex-col gap-4" @submit="save" :disabled="isBusy">
         <div
           v-if="
             !viewOnly &&

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -177,6 +177,7 @@ function save(event) {
     .finally(() => {
       currentPassword.value = null;
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -178,7 +178,6 @@ function save(event) {
     .finally(() => {
       currentPassword.value = null;
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabEmail.vue
+++ b/resources/js/components/UserTabEmail.vue
@@ -168,6 +168,7 @@ function save(event) {
         emit("notFoundError", error);
       } else if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (error.response.status === env.HTTP_EMAIL_CHANGE_THROTTLE) {
         toast.error(t("auth.throttle_email"));
       } else {

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -46,7 +46,6 @@ import * as _ from "lodash-es";
 import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { onBeforeMount, ref, watch } from "vue";
-import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   user: {
@@ -66,7 +65,6 @@ const isBusy = ref(false);
 
 const api = useApi();
 const formErrors = useFormErrors();
-const toast = useToast();
 
 watch(
   () => props.user,
@@ -117,7 +115,7 @@ function save(event) {
       ) {
         // Validation errors
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -131,7 +131,6 @@ function save(event) {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -124,11 +124,11 @@ function save(event) {
       } else {
         // Other errors
         api.error(error);
-        formErrors.scrollToFirstError();
       }
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.bbb')">
-      <Form v-if="model" class="flex flex-col gap-4" @submit="save">
+      <Form
+        v-if="model"
+        class="flex flex-col gap-4"
+        :disabled="isBusy"
+        @submit="save"
+      >
         <div
           class="field grid grid-cols-12 gap-4"
           data-test="bbb-skip-check-audio-field"

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -46,6 +46,7 @@ import * as _ from "lodash-es";
 import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { onBeforeMount, ref, watch } from "vue";
+import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   user: {
@@ -65,6 +66,7 @@ const isBusy = ref(false);
 
 const api = useApi();
 const formErrors = useFormErrors();
+const toast = useToast();
 
 watch(
   () => props.user,
@@ -115,6 +117,7 @@ function save(event) {
       ) {
         // Validation errors
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.bbb')">
-      <form v-if="model" class="flex flex-col gap-4" @submit="save">
+      <Form v-if="model" class="flex flex-col gap-4" @submit="save">
         <div
           class="field grid grid-cols-12 gap-4"
           data-test="bbb-skip-check-audio-field"
@@ -35,7 +35,7 @@
             data-test="user-tab-others-save-button"
           />
         </div>
-      </form>
+      </Form>
     </AdminPanel>
   </div>
 </template>

--- a/resources/js/components/UserTabOtherSettings.vue
+++ b/resources/js/components/UserTabOtherSettings.vue
@@ -124,6 +124,7 @@ function save(event) {
       } else {
         // Other errors
         api.error(error);
+        formErrors.scrollToFirstError();
       }
     })
     .finally(() => {

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -1,7 +1,16 @@
 <template>
   <div>
     <AdminPanel :title="$t('admin.users.base_data')">
-      <form class="flex flex-col gap-4" @submit.prevent="save">
+      <Form
+        class="flex flex-col gap-4"
+        :disabled="
+          isBusy ||
+          timezonesLoading ||
+          timezonesLoadingError ||
+          imageToBlobLoading
+        "
+        @submit="save"
+      >
         <div class="field grid grid-cols-12 gap-4" data-test="firstname-field">
           <label
             for="firstname"
@@ -158,7 +167,7 @@
             data-test="user-tab-profile-save-button"
           />
         </div>
-      </form>
+      </Form>
     </AdminPanel>
   </div>
 </template>

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -172,6 +172,7 @@ import { useFormErrors } from "../composables/useFormErrors.js";
 import { useApi } from "../composables/useApi.js";
 import { useUserPermissions } from "../composables/useUserPermission.js";
 import AdminPanel from "./AdminPanel.vue";
+import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   viewOnly: {
@@ -199,6 +200,7 @@ const authStore = useAuthStore();
 const formErrors = useFormErrors();
 const api = useApi();
 const userPermissions = useUserPermissions();
+const toast = useToast();
 
 watch(
   () => props.user,
@@ -284,6 +286,7 @@ function save() {
       ) {
         // Validation error
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -299,7 +299,6 @@ function save() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -292,11 +292,11 @@ function save() {
         emit("staleError", error.response.data);
       } else {
         api.error(error);
-        formErrors.scrollToFirstError();
       }
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -172,7 +172,6 @@ import { useFormErrors } from "../composables/useFormErrors.js";
 import { useApi } from "../composables/useApi.js";
 import { useUserPermissions } from "../composables/useUserPermission.js";
 import AdminPanel from "./AdminPanel.vue";
-import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   viewOnly: {
@@ -200,7 +199,6 @@ const authStore = useAuthStore();
 const formErrors = useFormErrors();
 const api = useApi();
 const userPermissions = useUserPermissions();
-const toast = useToast();
 
 watch(
   () => props.user,
@@ -286,7 +284,7 @@ function save() {
       ) {
         // Validation error
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabProfile.vue
+++ b/resources/js/components/UserTabProfile.vue
@@ -292,6 +292,7 @@ function save() {
         emit("staleError", error.response.data);
       } else {
         api.error(error);
+        formErrors.scrollToFirstError();
       }
     })
     .finally(() => {

--- a/resources/js/components/UserTabSecurityPasswordSection.vue
+++ b/resources/js/components/UserTabSecurityPasswordSection.vue
@@ -158,7 +158,7 @@ function changePassword(event) {
         emit("notFoundError", error);
       } else if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else {
         api.error(error);
       }

--- a/resources/js/components/UserTabSecurityPasswordSection.vue
+++ b/resources/js/components/UserTabSecurityPasswordSection.vue
@@ -158,6 +158,7 @@ function changePassword(event) {
         emit("notFoundError", error);
       } else if (error.response.status === env.HTTP_UNPROCESSABLE_ENTITY) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else {
         api.error(error);
       }

--- a/resources/js/components/UserTabSecurityPasswordSection.vue
+++ b/resources/js/components/UserTabSecurityPasswordSection.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <form class="flex flex-col gap-4" @submit="changePassword">
+    <Form
+      :disabled="isBusy || disabled"
+      class="flex flex-col gap-4"
+      @submit="changePassword"
+    >
       <div
         v-if="isOwnUser"
         class="field grid grid-cols-12 gap-4"
@@ -82,7 +86,7 @@
           data-test="change-password-save-button"
         />
       </div>
-    </form>
+    </Form>
   </div>
 </template>
 

--- a/resources/js/components/UserTabSecurityPasswordSection.vue
+++ b/resources/js/components/UserTabSecurityPasswordSection.vue
@@ -168,7 +168,6 @@ function changePassword(event) {
       currentPassword.value = null;
       newPassword.value = null;
       newPasswordConfirmation.value = null;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabSecurityPasswordSection.vue
+++ b/resources/js/components/UserTabSecurityPasswordSection.vue
@@ -167,6 +167,7 @@ function changePassword(event) {
       currentPassword.value = null;
       newPassword.value = null;
       newPasswordConfirmation.value = null;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
+++ b/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
@@ -49,7 +49,6 @@ import { useUserPermissions } from "../composables/useUserPermission.js";
 import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { useAuthStore } from "../stores/auth.js";
-import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   viewOnly: {
@@ -71,7 +70,6 @@ const emit = defineEmits(["staleError", "updateUser", "notFoundError", "busy"]);
 const userPermissions = useUserPermissions();
 const api = useApi();
 const formErrors = useFormErrors();
-const toast = useToast();
 
 const isBusy = ref(false);
 const model = ref(null);
@@ -139,7 +137,7 @@ function save(event) {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
+++ b/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
@@ -152,7 +152,6 @@ function save(event) {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
+++ b/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
@@ -149,6 +149,7 @@ function save(event) {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
+++ b/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
@@ -49,6 +49,7 @@ import { useUserPermissions } from "../composables/useUserPermission.js";
 import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { useAuthStore } from "../stores/auth.js";
+import { useToast } from "../composables/useToast.js";
 
 const props = defineProps({
   viewOnly: {
@@ -70,6 +71,7 @@ const emit = defineEmits(["staleError", "updateUser", "notFoundError", "busy"]);
 const userPermissions = useUserPermissions();
 const api = useApi();
 const formErrors = useFormErrors();
+const toast = useToast();
 
 const isBusy = ref(false);
 const model = ref(null);
@@ -137,6 +139,7 @@ function save(event) {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
+++ b/resources/js/components/UserTabSecurityRolesAndPermissionsSection.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <form v-if="model" class="flex flex-col gap-4" @submit="save">
+    <Form
+      v-if="model"
+      :disabled="isBusy || rolesLoadingError || rolesLoading || disabled"
+      class="flex flex-col gap-4"
+      @submit="save"
+    >
       <div class="field grid grid-cols-12 gap-4" data-test="roles-field">
         <label
           id="roles-label"
@@ -23,7 +28,7 @@
             @loading-error="(value) => (rolesLoadingError = value)"
             @busy="(value) => (rolesLoading = value)"
           />
-          <FormError :errors="formErrors.fieldError('roles')" />
+          <FormError :errors="formErrors.fieldError('roles', true)" />
         </div>
       </div>
       <div class="flex justify-end">
@@ -37,7 +42,7 @@
           data-test="users-roles-save-button"
         />
       </div>
-    </form>
+    </Form>
   </div>
 </template>
 

--- a/resources/js/composables/useFormErrors.js
+++ b/resources/js/composables/useFormErrors.js
@@ -1,7 +1,6 @@
 /**
  * Mixin that provides methods to get error states and error messages for form inputs in edit or create views.
  */
-import { nextTick } from "vue";
 
 class FormError {
   errors = {};

--- a/resources/js/composables/useFormErrors.js
+++ b/resources/js/composables/useFormErrors.js
@@ -14,13 +14,6 @@ class FormError {
     this.errors = {};
   }
 
-  async scrollToFirstError() {
-    await nextTick();
-    document
-      .getElementsByClassName("form-error")[0]
-      ?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
-
   /**
    * Returns the state for a field with the given name.
    *

--- a/resources/js/composables/useFormErrors.js
+++ b/resources/js/composables/useFormErrors.js
@@ -1,6 +1,7 @@
 /**
  * Mixin that provides methods to get error states and error messages for form inputs in edit or create views.
  */
+import { nextTick } from "vue";
 
 class FormError {
   errors = {};
@@ -11,6 +12,13 @@ class FormError {
 
   clear() {
     this.errors = {};
+  }
+
+  async scrollToFirstError() {
+    await nextTick();
+    document
+      .getElementsByClassName("form-error")[0]
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
   }
 
   /**

--- a/resources/js/services/Api.js
+++ b/resources/js/services/Api.js
@@ -89,6 +89,10 @@ export class Api {
     }
   }
 
+  validationError(error) {
+    this.toast.error(error.response.data.message);
+  }
+
   getErrorMessage(error) {
     return error.response && error.response.data
       ? error.response.data.message

--- a/resources/js/utils/viewport.js
+++ b/resources/js/utils/viewport.js
@@ -1,0 +1,11 @@
+export function isElementInViewport(el) {
+  const rect = el.getBoundingClientRect();
+
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -355,8 +355,6 @@ import { useI18n } from "vue-i18n";
 import * as _ from "lodash-es";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useConfirm } from "primevue/useconfirm";
-import { useToast } from "../composables/useToast.js";
-
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
 const settingsStore = useSettingsStore();
@@ -614,7 +612,7 @@ function saveRole() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -94,8 +94,8 @@
               :data-test="'room-limit-mode-' + option.value + '-field'"
             >
               <RadioButton
-                pt:input:required
                 v-model="roomLimitMode"
+                pt:input:required
                 :input-id="option.value"
                 :value="option.value"
                 :disabled="formFieldsDisabled || model.superuser"

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -630,7 +630,6 @@ function saveRole() {
     })
     .finally(() => {
       busyCounter.value--;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -46,10 +46,11 @@
         ></LoadingRetryButton>
       </template>
 
-      <form
+      <Form
         :aria-hidden="modelLoadingError || permissionsLoadingError"
+        :disabled="formFieldsDisabled"
         class="flex flex-col gap-4"
-        @submit.prevent="saveRole"
+        @submit="saveRole"
       >
         <div class="field grid grid-cols-12 gap-4" data-test="name-field">
           <label for="name" class="col-span-12 md:col-span-4">{{
@@ -61,6 +62,7 @@
               v-model="model.name"
               class="w-full"
               type="text"
+              required
               :invalid="formErrors.fieldInvalid('name')"
               :disabled="formFieldsDisabled"
             />
@@ -92,6 +94,7 @@
               :data-test="'room-limit-mode-' + option.value + '-field'"
             >
               <RadioButton
+                pt:input:required="required"
                 v-model="roomLimitMode"
                 :input-id="option.value"
                 :value="option.value"
@@ -106,6 +109,7 @@
               class="w-full"
               input-id="room-limit"
               mode="decimal"
+              required
               show-buttons
               :min="0"
               :invalid="formErrors.fieldInvalid('room_limit')"
@@ -227,7 +231,7 @@
             />
           </div>
         </div>
-      </form>
+      </Form>
     </OverlayComponent>
 
     <ConfirmDialog

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -94,7 +94,7 @@
               :data-test="'room-limit-mode-' + option.value + '-field'"
             >
               <RadioButton
-                pt:input:required="required"
+                pt:input:required
                 v-model="roomLimitMode"
                 :input-id="option.value"
                 :value="option.value"

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -628,6 +628,7 @@ function saveRole() {
     })
     .finally(() => {
       busyCounter.value--;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminRolesView.vue
+++ b/resources/js/views/AdminRolesView.vue
@@ -355,6 +355,7 @@ import { useI18n } from "vue-i18n";
 import * as _ from "lodash-es";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useConfirm } from "primevue/useconfirm";
+import { useToast } from "../composables/useToast.js";
 
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
@@ -613,6 +614,7 @@ function saveRole() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -39,7 +39,19 @@
           @reload="loadRoomType"
         ></LoadingRetryButton>
       </template>
-      <form class="flex flex-col gap-4" @submit.prevent="saveRoomType">
+      <Form
+        id="admin-room-types-form"
+        class="flex flex-col gap-4"
+        :disabled="
+          isBusy ||
+          modelLoadingError ||
+          serverPoolsLoadingError ||
+          serverPoolsLoading ||
+          rolesLoading ||
+          rolesLoadingError
+        "
+        @submit="saveRoomType"
+      >
         <!-- General room type settings -->
         <AdminPanel :title="$t('rooms.settings.general.title')">
           <!-- Room type name -->
@@ -58,6 +70,7 @@
                 v-model="model.name"
                 class="w-full"
                 type="text"
+                required
                 :invalid="formErrors.fieldInvalid('name')"
                 :disabled="isBusy || modelLoadingError || viewOnly"
               />
@@ -110,6 +123,7 @@
                 v-model="model.color"
                 class="w-full"
                 type="text"
+                required
                 :invalid="formErrors.fieldInvalid('color')"
                 :disabled="isBusy || modelLoadingError || viewOnly"
               />
@@ -156,6 +170,7 @@
                   :show-no-results="false"
                   :show-labels="false"
                   :options="serverPools"
+                  :required="true"
                   :disabled="
                     isBusy ||
                     modelLoadingError ||
@@ -258,6 +273,7 @@
               <RoleSelect
                 v-model="model.roles"
                 aria-labelledby="roles-label"
+                required
                 :invalid="formErrors.fieldInvalid('roles')"
                 :disabled="isBusy || modelLoadingError || viewOnly"
                 @busy="(value) => (rolesLoading = value)"
@@ -546,6 +562,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
+                      pt:input:required="required"
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="0"
                       name="lobby"
@@ -559,6 +576,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
+                      pt:input:required="required"
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="1"
                       name="lobby"
@@ -572,6 +590,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
+                      pt:input:required="required"
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="2"
                       name="lobby"
@@ -1492,7 +1511,7 @@
             />
           </div>
         </div>
-      </form>
+      </Form>
     </OverlayComponent>
     <ConfirmDialog
       data-test="stale-room-type-dialog"

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -40,7 +40,6 @@
         ></LoadingRetryButton>
       </template>
       <Form
-        id="admin-room-types-form"
         class="flex flex-col gap-4"
         :disabled="
           isBusy ||

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -1752,7 +1752,6 @@ function saveRoomType() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -1526,6 +1526,7 @@ import { useConfirm } from "primevue/useconfirm";
 import { useI18n } from "vue-i18n";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useColors } from "../composables/useColors.js";
+import { useToast } from "../composables/useToast.js";
 
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
@@ -1732,6 +1733,7 @@ function saveRoomType() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -1750,6 +1750,7 @@ function saveRoomType() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -561,7 +561,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
-                      pt:input:required="required"
+                      pt:input:required
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="0"
                       name="lobby"
@@ -575,7 +575,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
-                      pt:input:required="required"
+                      pt:input:required
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="1"
                       name="lobby"
@@ -589,7 +589,7 @@
                   >
                     <RadioButton
                       v-model.number="model.lobby_default"
-                      pt:input:required="required"
+                      pt:input:required
                       :disabled="isBusy || modelLoadingError || viewOnly"
                       :value="2"
                       name="lobby"

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -1526,7 +1526,6 @@ import { useConfirm } from "primevue/useconfirm";
 import { useI18n } from "vue-i18n";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useColors } from "../composables/useColors.js";
-import { useToast } from "../composables/useToast.js";
 
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
@@ -1733,7 +1732,7 @@ function saveRoomType() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminServerPoolsView.vue
+++ b/resources/js/views/AdminServerPoolsView.vue
@@ -224,6 +224,7 @@ import { inject, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useI18n } from "vue-i18n";
+import { useToast } from "../composables/useToast.js";
 
 const { t } = useI18n();
 
@@ -373,6 +374,7 @@ function saveServerPool() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminServerPoolsView.vue
+++ b/resources/js/views/AdminServerPoolsView.vue
@@ -391,7 +391,6 @@ function saveServerPool() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminServerPoolsView.vue
+++ b/resources/js/views/AdminServerPoolsView.vue
@@ -42,10 +42,13 @@
         ></LoadingRetryButton>
       </template>
 
-      <form
+      <Form
         :aria-hidden="modelLoadingError"
         class="flex flex-col gap-4"
-        @submit.prevent="saveServerPool"
+        :disabled="
+          isBusy || modelLoadingError || serversLoadingError || serversLoading
+        "
+        @submit="saveServerPool"
       >
         <div class="field grid grid-cols-12 gap-4" data-test="name-field">
           <label for="name" class="col-span-12 md:col-span-4 md:mb-0">{{
@@ -55,6 +58,7 @@
             <InputText
               id="name"
               v-model="model.name"
+              required
               class="w-full"
               type="text"
               :invalid="formErrors.fieldInvalid('name')"
@@ -191,7 +195,7 @@
             />
           </div>
         </div>
-      </form>
+      </Form>
     </OverlayComponent>
     <ConfirmDialog
       data-test="stale-server-pool-dialog"

--- a/resources/js/views/AdminServerPoolsView.vue
+++ b/resources/js/views/AdminServerPoolsView.vue
@@ -389,6 +389,7 @@ function saveServerPool() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminServerPoolsView.vue
+++ b/resources/js/views/AdminServerPoolsView.vue
@@ -224,7 +224,6 @@ import { inject, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import ConfirmDialog from "primevue/confirmdialog";
 import { useI18n } from "vue-i18n";
-import { useToast } from "../composables/useToast.js";
 
 const { t } = useI18n();
 
@@ -374,7 +373,7 @@ function saveServerPool() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -588,6 +588,7 @@ function saveServer() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -41,10 +41,11 @@
         ></LoadingRetryButton>
       </template>
 
-      <form
+      <Form
         :aria-hidden="modelLoadingError"
+        :disabled="isBusy || modelLoadingError"
         class="flex flex-col gap-4"
-        @submit.prevent="saveServer"
+        @submit="saveServer"
       >
         <div class="field grid grid-cols-12 gap-4" data-test="name-field">
           <label class="col-span-12 md:col-span-4 md:mb-0" for="name">{{
@@ -53,6 +54,7 @@
           <div class="col-span-12 md:col-span-8">
             <InputText
               id="name"
+              required
               v-model="model.name"
               :disabled="isBusy || modelLoadingError || viewOnly"
               :invalid="formErrors.fieldInvalid('name')"
@@ -103,6 +105,7 @@
             <InputText
               id="base_url"
               v-model="model.base_url"
+              required
               autocomplete="off"
               placeholder="https://bbb01.example.com/bigbluebutton/"
               :disabled="isBusy || modelLoadingError || viewOnly"
@@ -122,6 +125,7 @@
               v-model="model.secret"
               fluid
               input-id="secret"
+              required
               :input-props="{ autocomplete: 'off' }"
               :disabled="isBusy || modelLoadingError || viewOnly"
               :invalid="formErrors.fieldInvalid('secret')"
@@ -142,6 +146,7 @@
             <Rating
               v-model="model.strength"
               :cancel="false"
+              required
               :disabled="isBusy || modelLoadingError || viewOnly"
               :invalid="formErrors.fieldInvalid('strength')"
               :stars="10"
@@ -173,6 +178,7 @@
                 data-test="status-dropdown"
                 :options="serverStatusOptions"
                 option-label="name"
+                required
                 option-value="value"
                 :disabled="isBusy || modelLoadingError || viewOnly"
                 :invalid="formErrors.fieldInvalid('status')"
@@ -232,7 +238,7 @@
             />
           </div>
         </div>
-      </form>
+      </Form>
       <div
         v-if="
           !modelLoadingError && viewOnly && !isDisabled && model.id !== null

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -54,8 +54,8 @@
           <div class="col-span-12 md:col-span-8">
             <InputText
               id="name"
-              required
               v-model="model.name"
+              required
               :disabled="isBusy || modelLoadingError || viewOnly"
               :invalid="formErrors.fieldInvalid('name')"
               class="w-full"

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -588,7 +588,7 @@ function saveServer() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else if (
         error.response &&
         error.response.status === env.HTTP_STALE_MODEL

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -603,6 +603,7 @@ function saveServer() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -604,7 +604,6 @@ function saveServer() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -201,7 +201,7 @@
                   >
                     <RadioButton
                       v-model="toastLifetimeMode"
-                      pt:input:required="required"
+                      pt:input:required
                       input-id="toast-lifetime-mode-unlimited"
                       name="toast-lifetime-mode"
                       value="unlimited"
@@ -226,7 +226,7 @@
                       input-id="toast-lifetime-mode-custom"
                       name="toast-lifetime-mode"
                       value="custom"
-                      pt:input:required="required"
+                      pt:input:required
                       :disabled="disabled"
                       :pt="{
                         input: {
@@ -806,7 +806,7 @@
                     <RadioButton
                       v-model="roomLimitMode"
                       input-id="room-limit-mode-unlimited"
-                      pt:input:required="required"
+                      pt:input:required
                       name="room-limit-mode"
                       value="unlimited"
                       :disabled="disabled"
@@ -828,7 +828,7 @@
                     <RadioButton
                       v-model="roomLimitMode"
                       input-id="room-limit-mode-custom"
-                      pt:input:required="required"
+                      pt:input:required
                       name="room-limit-mode"
                       value="custom"
                       :disabled="disabled"

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <form @submit.prevent="updateSettings">
+    <Form
+      :disabled="disabled || timezonesLoadingError || timezonesLoading"
+      @submit="updateSettings"
+    >
       <OverlayComponent :show="isBusy || modelLoadingError" :no-center="true">
         <template #overlay>
           <div class="mt-6 flex justify-center">
@@ -14,7 +17,7 @@
         <div class="flex flex-col gap-6">
           <AdminPanel :title="$t('admin.settings.application')">
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="application-name-field"
             >
               <label
@@ -38,7 +41,10 @@
                 <FormError :errors="formErrors.fieldError('general_name')" />
               </div>
             </div>
-            <div class="grid grid-cols-12 gap-4" data-test="help-url-field">
+            <div
+              class="field grid grid-cols-12 gap-4"
+              data-test="help-url-field"
+            >
               <label for="help-url" class="col-span-12 md:col-span-4 md:mb-0">{{
                 $t("admin.settings.help_url.title")
               }}</label>
@@ -60,7 +66,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="legal-notice-url-field"
             >
               <label
@@ -86,7 +92,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="privacy-policy-url-field"
             >
               <label
@@ -114,7 +120,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="accessibility-statement-url-field"
             >
               <label
@@ -148,7 +154,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="pagination-page-size-field"
             >
               <label
@@ -181,7 +187,7 @@
               </div>
             </div>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="toast-lifetime-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -195,6 +201,7 @@
                   >
                     <RadioButton
                       v-model="toastLifetimeMode"
+                      pt:input:required="required"
                       input-id="toast-lifetime-mode-unlimited"
                       name="toast-lifetime-mode"
                       value="unlimited"
@@ -219,6 +226,7 @@
                       input-id="toast-lifetime-mode-custom"
                       name="toast-lifetime-mode"
                       value="custom"
+                      pt:input:required="required"
                       :disabled="disabled"
                       :pt="{
                         input: {
@@ -242,6 +250,7 @@
                   min="1"
                   max="30"
                   type="number"
+                  required
                   :invalid="formErrors.fieldInvalid('general_toast_lifetime')"
                   :disabled="disabled"
                   aria-labelledby="toast-lifetime-custom-label"
@@ -257,7 +266,7 @@
               </div>
             </fieldset>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="default-timezone-field"
             >
               <label
@@ -282,7 +291,7 @@
               </div>
             </div>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="no-welcome-page-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -309,7 +318,10 @@
           </AdminPanel>
 
           <AdminPanel :title="$t('admin.settings.theme.title')">
-            <fieldset class="grid grid-cols-12 gap-4" data-test="favicon-field">
+            <fieldset
+              class="field grid grid-cols-12 gap-4"
+              data-test="favicon-field"
+            >
               <legend
                 id="favicon-label"
                 class="col-span-12 md:col-span-4 md:mb-0"
@@ -336,7 +348,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="favicon-dark-field"
             >
               <legend
@@ -366,7 +378,10 @@
                 />
               </div>
             </fieldset>
-            <fieldset class="grid grid-cols-12 gap-4" data-test="logo-field">
+            <fieldset
+              class="field grid grid-cols-12 gap-4"
+              data-test="logo-field"
+            >
               <legend id="logo-label" class="col-span-12 md:col-span-4 md:mb-0">
                 {{ $t("admin.settings.logo.title") }}
               </legend>
@@ -390,7 +405,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="logo-dark-field"
             >
               <legend
@@ -421,7 +436,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="primary-color-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -441,6 +456,7 @@
                   id="theme-primary-color"
                   v-model="settings.theme_primary_color"
                   type="text"
+                  required
                   :invalid="formErrors.fieldInvalid('theme_primary_color')"
                   :disabled="disabled"
                 />
@@ -450,7 +466,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="theme-rounded-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -471,7 +487,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="theme-custom-css-field"
             >
               <legend
@@ -499,7 +515,7 @@
 
           <AdminPanel :title="$t('admin.settings.banner.title')">
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-enabled-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -520,7 +536,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-preview-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -541,7 +557,10 @@
                 />
               </div>
             </fieldset>
-            <div class="grid grid-cols-12 gap-4" data-test="banner-title-field">
+            <div
+              class="field grid grid-cols-12 gap-4"
+              data-test="banner-title-field"
+            >
               <label
                 for="banner-title"
                 class="col-span-12 md:col-span-4 md:mb-0"
@@ -558,7 +577,10 @@
                 <FormError :errors="formErrors.fieldError('banner_title')" />
               </div>
             </div>
-            <div class="grid grid-cols-12 gap-4" data-test="banner-icon-field">
+            <div
+              class="field grid grid-cols-12 gap-4"
+              data-test="banner-icon-field"
+            >
               <label
                 for="banner-icon"
                 class="col-span-12 md:col-span-4 md:mb-0"
@@ -580,7 +602,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-message-field"
             >
               <label
@@ -599,7 +621,10 @@
                 <FormError :errors="formErrors.fieldError('banner_message')" />
               </div>
             </div>
-            <div class="grid grid-cols-12 gap-4" data-test="banner-link-field">
+            <div
+              class="field grid grid-cols-12 gap-4"
+              data-test="banner-link-field"
+            >
               <label
                 for="banner-link"
                 class="col-span-12 md:col-span-4 md:mb-0"
@@ -617,7 +642,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-link-text-field"
             >
               <label
@@ -639,7 +664,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-link-style-field"
             >
               <label
@@ -673,7 +698,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-link-target-field"
             >
               <label
@@ -707,7 +732,7 @@
               </div>
             </div>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-color-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -734,7 +759,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="banner-background-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -766,7 +791,7 @@
 
           <AdminPanel :title="$t('app.rooms')">
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-limit-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -781,6 +806,7 @@
                     <RadioButton
                       v-model="roomLimitMode"
                       input-id="room-limit-mode-unlimited"
+                      pt:input:required="required"
                       name="room-limit-mode"
                       value="unlimited"
                       :disabled="disabled"
@@ -802,6 +828,7 @@
                     <RadioButton
                       v-model="roomLimitMode"
                       input-id="room-limit-mode-custom"
+                      pt:input:required="required"
                       name="room-limit-mode"
                       value="custom"
                       :disabled="disabled"
@@ -828,6 +855,7 @@
                   min="0"
                   max="100"
                   type="number"
+                  required
                   :invalid="formErrors.fieldInvalid('room_limit')"
                   :disabled="disabled"
                   aria-labelledby="room-limit-mode-custom-label"
@@ -840,7 +868,7 @@
               </div>
             </fieldset>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-personalized-link-expiration-field"
             >
               <label
@@ -890,7 +918,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-auto-delete-deadline-period-field"
             >
               <label
@@ -938,7 +966,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-auto-delete-inactive-period-field"
             >
               <label
@@ -986,7 +1014,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-auto-delete-never-used-period-field"
             >
               <label
@@ -1037,7 +1065,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-file-terms-of-use-field"
             >
               <label
@@ -1064,7 +1092,7 @@
               </div>
             </div>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="room-hide-owner-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -1092,7 +1120,7 @@
 
           <AdminPanel :title="$t('app.users')">
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="password-change-allowed-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -1126,7 +1154,7 @@
             :title="$t('admin.settings.recording_and_statistics_title')"
           >
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="statistics-servers-enabled-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -1155,7 +1183,7 @@
               </div>
             </fieldset>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="statistics-servers-retention-period-field"
             >
               <label
@@ -1200,7 +1228,7 @@
               </div>
             </div>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="statistics-meetings-enabled-field"
             >
               <legend class="col-span-12 md:col-span-4 md:mb-0">
@@ -1229,7 +1257,7 @@
               </div>
             </fieldset>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="statistics-meetings-retention-period-field"
             >
               <label
@@ -1276,7 +1304,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="attendance-retention-period-field"
             >
               <label
@@ -1320,7 +1348,7 @@
               </div>
             </div>
             <div
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="recording-retention-period-field"
             >
               <label
@@ -1366,7 +1394,7 @@
 
           <AdminPanel :title="$t('admin.settings.bbb.title')">
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="bbb-logo-field"
             >
               <legend
@@ -1396,7 +1424,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="bbb-logo-dark-field"
             >
               <legend
@@ -1427,7 +1455,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="bbb-style-field"
             >
               <legend
@@ -1452,7 +1480,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="default-presentation-field"
             >
               <legend
@@ -1501,7 +1529,7 @@
           />
         </div>
       </div>
-    </form>
+    </Form>
   </div>
 </template>
 

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <Form
-      :disabled="disabled || timezonesLoadingError || timezonesLoading"
+      :disabled="
+        isBusy || disabled || timezonesLoadingError || timezonesLoading
+      "
       @submit="updateSettings"
     >
       <OverlayComponent :show="isBusy || modelLoadingError" :no-center="true">

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1516,7 +1516,6 @@ import { useColors } from "../composables/useColors.js";
 import { useI18n } from "vue-i18n";
 import { updateTheme } from "../composables/useTheme";
 import AdminPanel from "../components/AdminPanel.vue";
-import { useToast } from "../composables/useToast.js";
 
 const roomLimitMode = ref("custom");
 const toastLifetimeMode = ref("custom");
@@ -1552,7 +1551,6 @@ const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
 const { t } = useI18n();
 const colors = useColors();
-const toast = useToast();
 
 /**
  * Input fields are disabled
@@ -1746,7 +1744,7 @@ function updateSettings() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1750,6 +1750,7 @@ function updateSettings() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1516,6 +1516,7 @@ import { useColors } from "../composables/useColors.js";
 import { useI18n } from "vue-i18n";
 import { updateTheme } from "../composables/useTheme";
 import AdminPanel from "../components/AdminPanel.vue";
+import { useToast } from "../composables/useToast.js";
 
 const roomLimitMode = ref("custom");
 const toastLifetimeMode = ref("custom");
@@ -1551,6 +1552,7 @@ const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
 const { t } = useI18n();
 const colors = useColors();
+const toast = useToast();
 
 /**
  * Input fields are disabled
@@ -1744,6 +1746,7 @@ function updateSettings() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1753,7 +1753,6 @@ function updateSettings() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -11,7 +11,7 @@
         <AdminPanel :title="$t('admin.streaming.general.title')">
           <Form
             class="flex flex-col gap-6"
-            :disabled="disabled"
+            :disabled="disabled || isBusy"
             @submit="updateSettings"
           >
             <fieldset

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -9,9 +9,13 @@
 
       <div class="flex flex-col gap-6">
         <AdminPanel :title="$t('admin.streaming.general.title')">
-          <form class="flex flex-col gap-6" @submit.prevent="updateSettings">
+          <Form
+            class="flex flex-col gap-6"
+            :disabled="disabled"
+            @submit="updateSettings"
+          >
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="default-pause-image-field"
             >
               <legend
@@ -39,7 +43,7 @@
               </div>
             </fieldset>
             <fieldset
-              class="grid grid-cols-12 gap-4"
+              class="field grid grid-cols-12 gap-4"
               data-test="css-file-field"
             >
               <legend
@@ -108,7 +112,7 @@
                 />
               </div>
             </div>
-          </form>
+          </Form>
         </AdminPanel>
 
         <AdminPanel :title="$t('admin.streaming.room_types.title')">

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -131,7 +131,6 @@ import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { useUserPermissions } from "../composables/useUserPermission.js";
 import AdminPanel from "../components/AdminPanel.vue";
-import { useToast } from "../composables/useToast.js";
 
 const defaultPauseImage = ref(null);
 const defaultPauseImageDeleted = ref(false);
@@ -144,7 +143,6 @@ const settings = ref({});
 const api = useApi();
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
-const toast = useToast();
 
 /**
  * Input fields are disabled
@@ -228,7 +226,7 @@ function updateSettings() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -232,6 +232,7 @@ function updateSettings() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -131,6 +131,7 @@ import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
 import { useUserPermissions } from "../composables/useUserPermission.js";
 import AdminPanel from "../components/AdminPanel.vue";
+import { useToast } from "../composables/useToast.js";
 
 const defaultPauseImage = ref(null);
 const defaultPauseImageDeleted = ref(false);
@@ -143,6 +144,7 @@ const settings = ref({});
 const api = useApi();
 const formErrors = useFormErrors();
 const userPermissions = useUserPermissions();
+const toast = useToast();
 
 /**
  * Input fields are disabled
@@ -226,6 +228,7 @@ function updateSettings() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminStreamingSettings.vue
+++ b/resources/js/views/AdminStreamingSettings.vue
@@ -235,7 +235,6 @@ function updateSettings() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -222,12 +222,14 @@ import { useSettingsStore } from "../stores/settings";
 import { onMounted, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "../stores/auth.js";
+import { useToast } from "../composables/useToast.js";
 
 const formErrors = useFormErrors();
 const api = useApi();
 const settingsStore = useSettingsStore();
 const authStore = useAuthStore();
 const router = useRouter();
+const toast = useToast();
 
 const isBusy = ref(false);
 const showPassword = ref(false);
@@ -298,6 +300,7 @@ function save() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        toast.error(error.response.data.message);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -222,15 +222,12 @@ import { useSettingsStore } from "../stores/settings";
 import { onMounted, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "../stores/auth.js";
-import { useToast } from "../composables/useToast.js";
 
 const formErrors = useFormErrors();
 const api = useApi();
 const settingsStore = useSettingsStore();
 const authStore = useAuthStore();
 const router = useRouter();
-const toast = useToast();
-
 const isBusy = ref(false);
 const showPassword = ref(false);
 const model = reactive({
@@ -300,7 +297,7 @@ function save() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
-        toast.error(error.response.data.message);
+        api.validationError(error);
       } else {
         api.error(error);
       }

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -304,6 +304,7 @@ function save() {
     })
     .finally(() => {
       isBusy.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -1,7 +1,17 @@
 <template>
   <div>
     <OverlayComponent :show="isBusy">
-      <form class="flex flex-col gap-4" @submit.prevent="save">
+      <Form
+        class="flex flex-col gap-4"
+        :disabled="
+          isBusy ||
+          rolesLoadingError ||
+          timezonesLoadingError ||
+          rolesLoading ||
+          timezonesLoading
+        "
+        @submit="save"
+      >
         <AdminPanel :title="$t('rooms.settings.general.title')">
           <div
             class="field grid grid-cols-12 gap-4"
@@ -209,7 +219,7 @@
             data-test="users-new-save-button"
           />
         </div>
-      </form>
+      </Form>
     </OverlayComponent>
   </div>
 </template>

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -307,7 +307,6 @@ function save() {
     })
     .finally(() => {
       isBusy.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -7,7 +7,7 @@
         <Card>
           <template #title> {{ $t("auth.reset_password") }} </template>
           <template #content>
-            <Form @submit="submit">
+            <Form @submit="submit" :disabled="loading">
               <div class="field flex flex-col gap-2" data-test="email-field">
                 <label for="email">{{ $t("app.email") }}</label>
                 <InputText

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -7,7 +7,7 @@
         <Card>
           <template #title> {{ $t("auth.reset_password") }} </template>
           <template #content>
-            <Form @submit="submit" :disabled="loading">
+            <Form :disabled="loading" @submit="submit">
               <div class="field flex flex-col gap-2" data-test="email-field">
                 <label for="email">{{ $t("app.email") }}</label>
                 <InputText

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -86,7 +86,6 @@ function submit() {
     })
     .finally(() => {
       loading.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -86,6 +86,7 @@ function submit() {
     })
     .finally(() => {
       loading.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -80,6 +80,7 @@ function submit() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        api.validationError(error);
         return;
       }
       api.error(error);

--- a/resources/js/views/ForgotPassword.vue
+++ b/resources/js/views/ForgotPassword.vue
@@ -7,8 +7,8 @@
         <Card>
           <template #title> {{ $t("auth.reset_password") }} </template>
           <template #content>
-            <form @submit.prevent="submit">
-              <div class="flex flex-col gap-2" data-test="email-field">
+            <Form @submit="submit">
+              <div class="field flex flex-col gap-2" data-test="email-field">
                 <label for="email">{{ $t("app.email") }}</label>
                 <InputText
                   id="email"
@@ -29,7 +29,7 @@
                 :label="$t('auth.send_password_reset_link')"
                 data-test="send-reset-link-button"
               />
-            </form>
+            </Form>
           </template>
         </Card>
       </div>

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -13,7 +13,7 @@
             }}
           </template>
           <template #content>
-            <Form @submit="submit">
+            <Form @submit="submit" :disabled="loading">
               <div
                 class="field flex flex-col gap-2"
                 data-test="new-password-field"

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -13,7 +13,7 @@
             }}
           </template>
           <template #content>
-            <Form @submit="submit" :disabled="loading">
+            <Form :disabled="loading" @submit="submit">
               <div
                 class="field flex flex-col gap-2"
                 data-test="new-password-field"

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -13,7 +13,7 @@
             }}
           </template>
           <template #content>
-            <Form id="password-reset-form" @submit="submit">
+            <Form @submit="submit">
               <div
                 class="field flex flex-col gap-2"
                 data-test="new-password-field"

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -13,8 +13,11 @@
             }}
           </template>
           <template #content>
-            <form @submit.prevent="submit">
-              <div class="flex flex-col gap-2" data-test="new-password-field">
+            <Form id="password-reset-form" @submit="submit">
+              <div
+                class="field flex flex-col gap-2"
+                data-test="new-password-field"
+              >
                 <label for="new_password">{{ $t("auth.new_password") }}</label>
                 <InputText
                   id="new_password"
@@ -60,7 +63,7 @@
                 "
                 data-test="reset-password-button"
               />
-            </form>
+            </Form>
           </template>
         </Card>
       </div>

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -143,6 +143,7 @@ function submit() {
     })
     .finally(() => {
       loading.value = false;
+      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -143,7 +143,6 @@ function submit() {
     })
     .finally(() => {
       loading.value = false;
-      formErrors.scrollToFirstError();
     });
 }
 </script>

--- a/resources/js/views/PasswordReset.vue
+++ b/resources/js/views/PasswordReset.vue
@@ -140,6 +140,7 @@ function submit() {
         error.response.status === env.HTTP_UNPROCESSABLE_ENTITY
       ) {
         formErrors.set(error.response.data.errors);
+        api.validationError(error);
       } else {
         api.error(error);
       }

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -708,7 +708,6 @@ function authenticate(type, codeOrToken) {
       })
       .finally(() => {
         authLoading.value = false;
-        formErrors.scrollToFirstError();
       });
   });
 }

--- a/resources/js/views/RoomsView.vue
+++ b/resources/js/views/RoomsView.vue
@@ -708,6 +708,7 @@ function authenticate(type, codeOrToken) {
       })
       .finally(() => {
         authLoading.value = false;
+        formErrors.scrollToFirstError();
       });
   });
 }

--- a/tests/Frontend/e2e/AdminRolesEdit.cy.js
+++ b/tests/Frontend/e2e/AdminRolesEdit.cy.js
@@ -1405,6 +1405,7 @@ describe("Admin roles edit", function () {
     cy.intercept("PUT", "api/v1/roles/2", {
       statusCode: 422,
       body: {
+        message: "The name field is required. (and 2 more errors)",
         errors: {
           name: ["The Name field is required."],
           room_limit: ["The Room limit must be at least -1."],
@@ -1420,6 +1421,8 @@ describe("Admin roles edit", function () {
     cy.wait("@saveChangesRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 2 more errors)");
+
     cy.get('[data-test="name-field"]')
       .should("be.visible")
       .and("include.text", "The Name field is required.");

--- a/tests/Frontend/e2e/AdminRolesNew.cy.js
+++ b/tests/Frontend/e2e/AdminRolesNew.cy.js
@@ -1329,6 +1329,7 @@ describe("Admin roles new", function () {
     cy.intercept("POST", "api/v1/roles", {
       statusCode: 422,
       body: {
+        message: "The name field is required. (and 2 more errors)",
         errors: {
           name: ["The Name field is required."],
           room_limit: ["The Room limit must be at least -1."],
@@ -1344,6 +1345,8 @@ describe("Admin roles new", function () {
     cy.wait("@newRoleRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 2 more errors)");
+
     cy.get('[data-test="name-field"]')
       .should("be.visible")
       .and("include.text", "The Name field is required.");

--- a/tests/Frontend/e2e/AdminRoomTypesEdit.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesEdit.cy.js
@@ -1222,7 +1222,7 @@ describe("Admin room types edit", function () {
     cy.intercept("PUT", "api/v1/roomTypes/3", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The name field is required. (and 39 more errors)",
         errors: {
           name: ["The name field is required."],
           description: ["The description field is required."],
@@ -1334,6 +1334,8 @@ describe("Admin room types edit", function () {
     cy.wait("@saveChangesRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 39 more errors)");
+
     cy.get('[data-test="room-type-name-field"]').should(
       "include.text",
       "The name field is required.",

--- a/tests/Frontend/e2e/AdminRoomTypesNew.cy.js
+++ b/tests/Frontend/e2e/AdminRoomTypesNew.cy.js
@@ -1086,7 +1086,7 @@ describe("Admin room types new", function () {
     cy.intercept("POST", "api/v1/roomTypes", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The name field is required. (and 29 more errors)",
         errors: {
           name: ["The name field is required."],
           description: ["The description field is required."],
@@ -1198,6 +1198,8 @@ describe("Admin room types new", function () {
     cy.wait("@newRoomTypeRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 29 more errors)");
+
     cy.get('[data-test="room-type-name-field"]').should(
       "include.text",
       "The name field is required.",

--- a/tests/Frontend/e2e/AdminServerPoolsEdit.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsEdit.cy.js
@@ -413,7 +413,7 @@ describe("Admin server pools edit", function () {
     cy.intercept("PUT", "api/v1/serverPools/1", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The Name field is required. (and 2 more errors)",
         errors: {
           name: ["The Name field is required."],
           description: [
@@ -429,6 +429,8 @@ describe("Admin server pools edit", function () {
     cy.wait("@saveChangesRequest");
 
     // Check that error messages are shown
+    cy.checkToastMessage("The Name field is required. (and 2 more errors)");
+
     cy.get('[data-test="name-field"]').should(
       "include.text",
       "The Name field is required.",

--- a/tests/Frontend/e2e/AdminServerPoolsNew.cy.js
+++ b/tests/Frontend/e2e/AdminServerPoolsNew.cy.js
@@ -454,7 +454,7 @@ describe("Admin server pools new", function () {
     cy.intercept("POST", "api/v1/serverPools", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The Name field is required. (and 2 more errors)",
         errors: {
           name: ["The Name field is required."],
           description: [
@@ -470,6 +470,8 @@ describe("Admin server pools new", function () {
     cy.wait("@newServerPoolRequest");
 
     // Check that error messages are shown
+    cy.checkToastMessage("The Name field is required. (and 2 more errors)");
+
     cy.get('[data-test="name-field"]').should(
       "include.text",
       "The Name field is required.",

--- a/tests/Frontend/e2e/AdminServersEdit.cy.js
+++ b/tests/Frontend/e2e/AdminServersEdit.cy.js
@@ -363,6 +363,7 @@ describe("Admin servers edit", function () {
     cy.intercept("PUT", "api/v1/servers/1", {
       statusCode: 422,
       body: {
+        message: "The name field is required. (and 5 more errors)",
         errors: {
           name: ["The name field is required."],
           description: ["The description field is required."],
@@ -379,6 +380,8 @@ describe("Admin servers edit", function () {
     cy.wait("@saveChangesRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 5 more errors)");
+
     cy.get('[data-test="name-field"]').should(
       "include.text",
       "The name field is required.",

--- a/tests/Frontend/e2e/AdminServersNew.cy.js
+++ b/tests/Frontend/e2e/AdminServersNew.cy.js
@@ -314,6 +314,7 @@ describe("Admin servers view", function () {
     cy.intercept("POST", "api/v1/servers", {
       statusCode: 422,
       body: {
+        message: "The name field is required. (and 5 more errors)",
         errors: {
           name: ["The name field is required."],
           description: ["The description field is required."],
@@ -330,6 +331,8 @@ describe("Admin servers view", function () {
     cy.wait("@newServerRequest");
 
     // Check error messages
+    cy.checkToastMessage("The name field is required. (and 5 more errors)");
+
     cy.get('[data-test="name-field"]').should(
       "include.text",
       "The name field is required.",

--- a/tests/Frontend/e2e/AdminSettingsEdit.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsEdit.cy.js
@@ -3112,7 +3112,7 @@ describe("Admin settings with edit permission", function () {
     cy.intercept("POST", "api/v1/settings", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The general name field is required. (and 49 more errors)",
         errors: {
           general_name: ["The general name field is required."],
           general_help_url: ["The selected general help url is invalid."],
@@ -3219,6 +3219,10 @@ describe("Admin settings with edit permission", function () {
     cy.wait("@saveChangesRequest");
 
     // Check that errors are shown correctly
+    cy.checkToastMessage(
+      "The general name field is required. (and 49 more errors)",
+    );
+
     cy.get('[data-test="application-name-field"]').should(
       "include.text",
       "The general name field is required.",

--- a/tests/Frontend/e2e/AdminStreamingEdit.cy.js
+++ b/tests/Frontend/e2e/AdminStreamingEdit.cy.js
@@ -282,6 +282,10 @@ describe("Admin settings with edit permission", function () {
     cy.wait("@saveStreamingRequest");
 
     // Check error messages
+    cy.checkToastMessage(
+      "The Default pause image must have a resolution of 1920x1080 pixels. (and 3 more errors)",
+    );
+
     cy.get('[data-test="default-pause-image-field"]').should(
       "include.text",
       "The Default pause image must have a resolution of 1920x1080 pixels.",

--- a/tests/Frontend/e2e/AdminUsersEditBase.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEditBase.cy.js
@@ -591,6 +591,7 @@ describe("Admin users edit base", function () {
     cy.intercept("POST", "api/v1/users/2", {
       statusCode: 422,
       body: {
+        message: "The firstname field is required. (and 3 more errors)",
         errors: {
           firstname: ["The firstname field is required."],
           lastname: ["The lastname field is required."],
@@ -605,6 +606,10 @@ describe("Admin users edit base", function () {
     cy.wait("@saveChangesRequest");
 
     // Check that error messages are shown
+    cy.checkToastMessage(
+      "The firstname field is required. (and 3 more errors)",
+    );
+
     cy.get('[data-test="firstname-field"]').should(
       "include.text",
       "The firstname field is required.",

--- a/tests/Frontend/e2e/AdminUsersEditEmail.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEditEmail.cy.js
@@ -130,6 +130,7 @@ describe("Admin users edit email", function () {
     cy.intercept("PUT", "api/v1/users/2/email", {
       statusCode: 422,
       body: {
+        message: "The email field is required",
         errors: {
           email: ["The email field is required."],
         },
@@ -139,6 +140,9 @@ describe("Admin users edit email", function () {
     cy.get('[data-test="user-tab-email-save-button"]').click();
 
     cy.wait("@saveChangesRequest");
+
+    // Check error message
+    cy.checkToastMessage("The email field is required");
 
     cy.get('[data-test="email-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/AdminUsersEditOthers.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEditOthers.cy.js
@@ -120,6 +120,7 @@ describe("Admin users edit others", function () {
     cy.intercept("POST", "api/v1/users/2", {
       statusCode: 422,
       body: {
+        message: "The bbb skip check audio field is required.",
         errors: {
           bbb_skip_check_audio: ["The bbb skip check audio field is required."],
         },
@@ -131,6 +132,9 @@ describe("Admin users edit others", function () {
     cy.wait("@saveChangesRequest");
 
     cy.get("#bbb_skip_check_audio").should("not.be.checked");
+
+    // Check error message
+    cy.checkToastMessage("The bbb skip check audio field is required.");
 
     cy.get('[data-test="bbb-skip-check-audio-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/AdminUsersEditSecurity.cy.js
+++ b/tests/Frontend/e2e/AdminUsersEditSecurity.cy.js
@@ -498,6 +498,7 @@ describe("Admin users edit email", function () {
     cy.intercept("PUT", "api/v1/users/2", {
       statusCode: 422,
       body: {
+        message: "The roles field is required.",
         errors: {
           roles: ["The roles field is required."],
         },
@@ -507,6 +508,9 @@ describe("Admin users edit email", function () {
     cy.get('[data-test="users-roles-save-button"]').click();
 
     cy.wait("@saveChangesRequest");
+
+    // Check error message
+    cy.checkToastMessage("The roles field is required.");
 
     cy.get('[data-test="roles-field"]').should(
       "include.text",
@@ -722,6 +726,7 @@ describe("Admin users edit email", function () {
     cy.intercept("PUT", "api/v1/users/2/password", {
       statusCode: 422,
       body: {
+        message: "The New password field is required. (and 1 more error)",
         errors: {
           new_password: ["The New password field is required."],
           new_password_confirmation: [
@@ -734,6 +739,11 @@ describe("Admin users edit email", function () {
     cy.get('[data-test="change-password-save-button"]').click();
 
     cy.wait("@saveChangesRequest");
+
+    // Check error messages
+    cy.checkToastMessage(
+      "The New password field is required. (and 1 more error)",
+    );
 
     cy.get('[data-test="new-password-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/AdminUsersNew.cy.js
+++ b/tests/Frontend/e2e/AdminUsersNew.cy.js
@@ -648,7 +648,7 @@ describe("Admin users new", function () {
     cy.intercept("POST", "api/v1/users", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The Firstname field is required. (and 8 more errors)",
         errors: {
           firstname: ["The Firstname field is required."],
           lastname: ["The Lastname field is required."],
@@ -670,6 +670,11 @@ describe("Admin users new", function () {
     cy.get('[data-test="users-new-save-button"]').click();
 
     cy.wait("@newUserRequest");
+
+    // Check error messages
+    cy.checkToastMessage(
+      "The Firstname field is required. (and 8 more errors)",
+    );
 
     cy.get('[data-test="firstname-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/ForgotPassword.cy.js
+++ b/tests/Frontend/e2e/ForgotPassword.cy.js
@@ -139,7 +139,7 @@ describe("Forgot password", function () {
       body: {
         message: "The email field is required",
         errors: {
-          email: ["The email fiel is required."],
+          email: ["The email field is required."],
         },
       },
     }).as("forgotPasswordRequest");
@@ -151,7 +151,10 @@ describe("Forgot password", function () {
     // Check that error message is shown
     cy.get('[data-test="email-field"]')
       .should("be.visible")
-      .and("include.text", "The email fiel is required.");
+      .and("include.text", "The email field is required.");
+
+    // Check toast
+    cy.checkToastMessage("The email field is required");
 
     // Check with 500 error
     cy.intercept("POST", "api/v1/password/email", {

--- a/tests/Frontend/e2e/ForgotPassword.cy.js
+++ b/tests/Frontend/e2e/ForgotPassword.cy.js
@@ -137,6 +137,7 @@ describe("Forgot password", function () {
     cy.intercept("POST", "api/v1/password/email", {
       statusCode: 422,
       body: {
+        message: "The email field is required",
         errors: {
           email: ["The email fiel is required."],
         },

--- a/tests/Frontend/e2e/GeneralApplication.cy.js
+++ b/tests/Frontend/e2e/GeneralApplication.cy.js
@@ -93,6 +93,7 @@ describe("General", function () {
     cy.intercept("POST", "/api/v1/locale", {
       statusCode: 422,
       body: {
+        message: "Test",
         errors: {
           locale: ["Test"],
         },

--- a/tests/Frontend/e2e/Login.cy.js
+++ b/tests/Frontend/e2e/Login.cy.js
@@ -359,6 +359,7 @@ describe("Login", function () {
     cy.intercept("POST", "api/v1/login/local", {
       statusCode: 422,
       body: {
+        message: "Password or Email wrong!",
         errors: {
           email: ["Password or Email wrong!"],
         },
@@ -386,6 +387,7 @@ describe("Login", function () {
     cy.intercept("POST", "api/v1/login/local", {
       statusCode: 422,
       body: {
+        message: "The Password field is required",
         errors: {
           password: ["The Password field is required."],
         },
@@ -489,6 +491,7 @@ describe("Login", function () {
     cy.intercept("POST", "api/v1/login/ldap", {
       statusCode: 422,
       body: {
+        message: "These credentials do not match our records.",
         errors: {
           username: ["These credentials do not match our records."],
         },
@@ -516,6 +519,7 @@ describe("Login", function () {
     cy.intercept("POST", "api/v1/login/ldap", {
       statusCode: 422,
       body: {
+        message: "The Password field is required",
         errors: {
           password: ["The Password field is required."],
         },

--- a/tests/Frontend/e2e/PasswordReset.cy.js
+++ b/tests/Frontend/e2e/PasswordReset.cy.js
@@ -178,6 +178,11 @@ describe("Password reset", function () {
       "The New password confirmation field is required.",
     );
 
+    // Check toast
+    cy.checkToastMessage(
+      "The New password field is required. (and 1 more error)",
+    );
+
     // Check with other 422 errors
     cy.intercept("POST", "api/v1/password/reset", {
       statusCode: 422,
@@ -210,6 +215,9 @@ describe("Password reset", function () {
     // Check that new error messages are shown
     cy.contains("The Email field is required.").should("be.visible");
     cy.contains("The Token field is required.").should("be.visible");
+
+    // Check toast
+    cy.checkToastMessage("The Email field is required. (and 1 more error)");
 
     // Check with 500 error
     cy.intercept("POST", "api/v1/password/reset", {

--- a/tests/Frontend/e2e/PasswordReset.cy.js
+++ b/tests/Frontend/e2e/PasswordReset.cy.js
@@ -153,6 +153,7 @@ describe("Password reset", function () {
     cy.intercept("POST", "api/v1/password/reset", {
       statusCode: 422,
       body: {
+        message: "The New password field is required. (and 1 more error)",
         errors: {
           password: ["The New password field is required."],
           password_confirmation: [
@@ -181,6 +182,7 @@ describe("Password reset", function () {
     cy.intercept("POST", "api/v1/password/reset", {
       statusCode: 422,
       body: {
+        message: "The Email field is required. (and 1 more error)",
         errors: {
           email: ["The Email field is required."],
           token: ["The Token field is required."],

--- a/tests/Frontend/e2e/RoomsIndexCreateNewRoom.cy.js
+++ b/tests/Frontend/e2e/RoomsIndexCreateNewRoom.cy.js
@@ -629,7 +629,7 @@ describe("Rooms index create new room", function () {
     cy.intercept("POST", "api/v1/rooms", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid",
+        message: "The Room type field is required.",
         errors: {
           room_type: ["The Room type field is required."],
         },
@@ -729,7 +729,7 @@ describe("Rooms index create new room", function () {
     cy.intercept("POST", "api/v1/rooms", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid",
+        message: "The Name field is required.",
         errors: {
           name: ["The Name field is required."],
         },

--- a/tests/Frontend/e2e/RoomsViewDescription.cy.js
+++ b/tests/Frontend/e2e/RoomsViewDescription.cy.js
@@ -420,6 +420,11 @@ describe("Rooms view description", function () {
       "The Description must not be greater than 65000 characters.",
     ).should("be.visible");
 
+    // Check toast
+    cy.checkToastMessage(
+      "The Description must not be greater than 65000 characters",
+    );
+
     // Check saving with 500 error
     cy.intercept("PUT", "api/v1/rooms/abc-def-123/description", {
       statusCode: 500,

--- a/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewFilesFileActions.cy.js
@@ -267,7 +267,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/files", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The File must be a file of type: pdf, doc.",
         errors: {
           file: ["The File must be a file of type: pdf, doc."],
         },
@@ -731,6 +731,7 @@ describe("Rooms view files file actions", function () {
     cy.intercept("PUT", "/api/v1/rooms/abc-def-123/files/2", {
       statusCode: 422,
       body: {
+        message: "The Downloadable field is required. (and 2 more errors)",
         errors: {
           download: ["The Downloadable field is required."],
           use_in_meeting: ["The Use in the next meeting field is required."],

--- a/tests/Frontend/e2e/RoomsViewGeneral.cy.js
+++ b/tests/Frontend/e2e/RoomsViewGeneral.cy.js
@@ -540,7 +540,7 @@ describe("Room View general", function () {
     cy.intercept("POST", "api/v1/rooms/abc-def-123/auth", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The Access code field is required.",
         errors: {
           access_code: ["The Access code field is required."],
         },
@@ -1521,7 +1521,7 @@ describe("Room View general", function () {
     cy.intercept("POST", "api/v1/rooms/abc-def-123/auth", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The Access token field is required.",
         errors: {
           personalized_link_token: ["The Access token field is required."],
         },

--- a/tests/Frontend/e2e/RoomsViewMeetings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMeetings.cy.js
@@ -526,7 +526,8 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/join*", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid",
+        message:
+          "The name contains the following non-permitted characters: 123!",
         errors: {
           name: [
             "The name contains the following non-permitted characters: 123!",
@@ -2162,7 +2163,8 @@ describe("Rooms view meetings", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/start*", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid",
+        message:
+          "The name contains the following non-permitted characters: 123!",
         errors: {
           name: [
             "The name contains the following non-permitted characters: 123!",

--- a/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
@@ -801,11 +801,12 @@ describe("Rooms view members bulk actions", function () {
       .should("be.visible")
       .within(() => {
         cy.contains("rooms.members.bulk_import_users");
+        // Check continue button
+        cy.get('[data-test="dialog-continue-button"]').should(
+          "have.text",
+          "rooms.members.modals.add.add",
+        );
 
-        // Check that continue button is disabled and shows the correct text
-        cy.get('[data-test="dialog-continue-button"]')
-          .should("have.text", "rooms.members.modals.add.add")
-          .and("be.disabled");
         // Check that textarea is empty and enter users
         cy.get("#user-emails")
           .should("have.value", "")
@@ -816,15 +817,12 @@ describe("Rooms view members bulk actions", function () {
           )
           .type("LauraWRivera@domain.tld\nLauraMWalter@domain.tld");
 
-        // Check that button is enabled
-        cy.get('[data-test="dialog-continue-button"]').should(
-          "not.be.disabled",
-        );
-
         // Check that roles are shown correctly
         cy.get('[data-test="participant-role-group"]').within(() => {
           cy.contains("rooms.roles.participant");
-          cy.get("#participant-role").should("be.checked").and("have.value", 1);
+          cy.get("#participant-role")
+            .should("not.be.checked")
+            .and("have.value", 1);
         });
 
         cy.get('[data-test="moderator-role-group"]').within(() => {

--- a/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersBulkActions.cy.js
@@ -1386,6 +1386,7 @@ describe("Rooms view members bulk actions", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/member/bulk", {
       statusCode: 422,
       body: {
+        message: "The user emails field is required.",
         errors: {
           user_emails: ["The user emails field is required."],
         },
@@ -1408,6 +1409,7 @@ describe("Rooms view members bulk actions", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/member/bulk", {
       statusCode: 422,
       body: {
+        message: "The selected role is invalid.",
         errors: {
           role: ["The selected role is invalid."],
         },

--- a/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewMembersMemberActions.cy.js
@@ -372,7 +372,7 @@ describe("Rooms view members member actions", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/member", {
       statusCode: 422,
       body: {
-        message: "The given data was invalid.",
+        message: "The user is already member of the room.",
         errors: {
           user: ["The user is already member of the room."],
         },
@@ -624,6 +624,7 @@ describe("Rooms view members member actions", function () {
     cy.intercept("PUT", "/api/v1/rooms/abc-def-123/member/6", {
       statusCode: 422,
       body: {
+        message: "The selected role is invalid.",
         errors: {
           role: ["The selected role is invalid."],
         },

--- a/tests/Frontend/e2e/RoomsViewPersonalizedLinksTokenActions.cy.js
+++ b/tests/Frontend/e2e/RoomsViewPersonalizedLinksTokenActions.cy.js
@@ -157,6 +157,7 @@ describe("Rooms view personalized links actions", function () {
     cy.intercept("POST", "/api/v1/rooms/abc-def-123/personalizedLinks/", {
       statusCode: 422,
       body: {
+        message: "The firstname field is required. (and 2 more errors)",
         errors: {
           firstname: ["The firstname field is required."],
           lastname: ["The lastname field is required."],
@@ -481,6 +482,7 @@ describe("Rooms view personalized links actions", function () {
     cy.intercept("PUT", "/api/v1/rooms/abc-def-123/personalizedLinks/1", {
       statusCode: 422,
       body: {
+        message: "The firstname field is required. (and 2 more errors)",
         errors: {
           firstname: ["The firstname field is required."],
           lastname: ["The lastname field is required."],

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -1365,6 +1365,8 @@ describe("Rooms view settings", function () {
     cy.intercept("PUT", "api/v1/rooms/abc-def-123", {
       statusCode: 422,
       body: {
+        message:
+          "The room requires an access code because of its room type. (and 17 more errors)",
         errors: {
           access_code: [
             "The room requires an access code because of its room type.",
@@ -1405,6 +1407,10 @@ describe("Rooms view settings", function () {
     cy.wait("@roomSettingsSaveRequest");
 
     // Check that error messages are set
+    cy.checkToastMessage(
+      "The room requires an access code because of its room type. (and 17 more errors)",
+    );
+
     cy.get('[data-test="room-setting-access_code"]').should(
       "include.text",
       "The room requires an access code because of its room type.",
@@ -1590,6 +1596,8 @@ describe("Rooms view settings", function () {
     cy.intercept("PUT", "api/v1/rooms/abc-def-123", {
       statusCode: 422,
       body: {
+        message:
+          "The room requires an access code because of its room type. (and 4 more errors)",
         errors: {
           access_code: [
             "The room requires an access code because of its room type.",
@@ -1609,6 +1617,10 @@ describe("Rooms view settings", function () {
     cy.wait("@roomSettingsSaveRequest");
 
     // Check that error messages are set
+    cy.checkToastMessage(
+      "The room requires an access code because of its room type. (and 4 more errors)",
+    );
+
     cy.get('[data-test="room-setting-access_code"]').should(
       "include.text",
       "The room requires an access code because of its room type.",
@@ -2268,6 +2280,7 @@ describe("Rooms view settings", function () {
     cy.intercept("POST", "api/v1/rooms/abc-def-123/transfer", {
       statusCode: 422,
       body: {
+        message: "The selected role is invalid.",
         errors: {
           role: ["The selected role is invalid."],
         },
@@ -2290,6 +2303,7 @@ describe("Rooms view settings", function () {
     cy.intercept("POST", "api/v1/rooms/abc-def-123/transfer", {
       statusCode: 422,
       body: {
+        message: "The selected user can not own rooms.",
         errors: {
           user: ["The selected user can not own rooms."],
         },

--- a/tests/Frontend/e2e/UserProfileBase.cy.js
+++ b/tests/Frontend/e2e/UserProfileBase.cy.js
@@ -506,6 +506,7 @@ describe("User Profile Base", function () {
     cy.intercept("POST", "api/v1/users/1", {
       statusCode: 422,
       body: {
+        message: "The firstname field is required. (and 3 more errors)",
         errors: {
           firstname: ["The firstname field is required."],
           lastname: ["The lastname field is required."],
@@ -520,6 +521,10 @@ describe("User Profile Base", function () {
     cy.wait("@saveChangesRequest");
 
     // Check that error messages are shown
+    cy.checkToastMessage(
+      "The firstname field is required. (and 3 more errors)",
+    );
+
     cy.get('[data-test="firstname-field"]').should(
       "include.text",
       "The firstname field is required.",

--- a/tests/Frontend/e2e/UserProfileEmail.cy.js
+++ b/tests/Frontend/e2e/UserProfileEmail.cy.js
@@ -128,6 +128,7 @@ describe("User Profile Email", function () {
     cy.intercept("PUT", "api/v1/users/1/email", {
       statusCode: 422,
       body: {
+        message: "The email field is required. (and 1 more error)",
         errors: {
           email: ["The email field is required."],
           current_password: ["The current password is incorrect."],
@@ -137,6 +138,9 @@ describe("User Profile Email", function () {
 
     cy.get("#current_password").type("secretPassword123#");
     cy.get('[data-test="user-tab-email-save-button"]').click();
+
+    // Check error messages
+    cy.checkToastMessage("The email field is required. (and 1 more error)");
 
     cy.get('[data-test="email-tab-current-password-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/UserProfileOthers.cy.js
+++ b/tests/Frontend/e2e/UserProfileOthers.cy.js
@@ -68,6 +68,7 @@ describe("User Profile Others", function () {
     cy.intercept("POST", "api/v1/users/1", {
       statusCode: 422,
       body: {
+        message: "The bbb skip check audio field is required.",
         errors: {
           bbb_skip_check_audio: ["The bbb skip check audio field is required."],
         },
@@ -79,6 +80,9 @@ describe("User Profile Others", function () {
     cy.wait("@saveChangesRequest");
 
     cy.get("#bbb_skip_check_audio").should("not.be.checked");
+
+    // Check error message
+    cy.checkToastMessage("The bbb skip check audio field is required.");
 
     cy.get('[data-test="bbb-skip-check-audio-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/UserProfileSecurity.cy.js
+++ b/tests/Frontend/e2e/UserProfileSecurity.cy.js
@@ -340,6 +340,7 @@ describe("User Profile Security", function () {
     cy.intercept("PUT", "api/v1/users/1/password", {
       statusCode: 422,
       body: {
+        message: "The Current password field is required. (and 2 more errors)",
         errors: {
           current_password: ["The Current password field is required."],
           new_password: ["The New password field is required."],
@@ -353,6 +354,11 @@ describe("User Profile Security", function () {
     cy.get('[data-test="change-password-save-button"]').click();
 
     cy.wait("@saveChangesRequest");
+
+    // Check error messages
+    cy.checkToastMessage(
+      "The Current password field is required. (and 2 more errors)",
+    );
 
     cy.get('[data-test="security-tab-current-password-field"]').should(
       "include.text",

--- a/tests/Frontend/e2e/VerifyEmail.cy.js
+++ b/tests/Frontend/e2e/VerifyEmail.cy.js
@@ -77,6 +77,7 @@ describe("Verify email", function () {
     cy.intercept("POST", "api/v1/email/verify", {
       statusCode: 422,
       body: {
+        message: "The email field is required. (and 1 more error)",
         errors: {
           email: ["The email field is required."],
           token: ["The token field is required."],


### PR DESCRIPTION
# Closes #3038

## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **UX**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Added toast notification for form validation errors in non-dialog forms
- Added auto-scroll to the first form validation error
- A11y: Add required to more fields that are always required
- Changed bulk add room members to not have role preselected and save button disabled by default
- Added novalidate to all forms via a new Form component to only have backend generated validation messages

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic scrolling and focus to the first form validation error for improved visibility and accessibility
  * Toast notifications displaying validation error summaries across all forms
  * Enhanced field-level error rendering with better visual organization

* **Style**
  * Smooth scrolling behavior (respecting user motion preferences) when navigating to validation errors
  * Reduced spacing in error message displays

* **Tests**
  * Updated test validation assertions to reflect improved error messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/THM-Health/PILOS/pull/3056)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->