### PR TITLE
Adjust login url handling for authenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improved error handling when a room requires an access code but none was provided ([#3035])
+- Login URL and external login redirect URLs now support authenticated users and honor the redirect query parameter ([#3078], [#3079])
 
 ### Fixed
 
@@ -781,6 +782,8 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3035]: https://github.com/THM-Health/PILOS/pull/3035
 [#3039]: https://github.com/THM-Health/PILOS/issues/3039
 [#3040]: https://github.com/THM-Health/PILOS/pull/3040
+[#3078]: https://github.com/THM-Health/PILOS/issues/3078
+[#3079]: https://github.com/THM-Health/PILOS/pull/3079
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.14.2...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Auth/OIDC/OIDCCallbackRequest.php
+++ b/app/Auth/OIDC/OIDCCallbackRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\OIDC;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+class OIDCCallbackRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'code' => ['string'],
+            'state' => ['string'],
+            'error' => ['string'],
+            'error_description' => ['string'],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        abort(400);
+    }
+}

--- a/app/Auth/OIDC/OIDCCallbackRequest.php
+++ b/app/Auth/OIDC/OIDCCallbackRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Auth\OIDC;
 
+use App\Prometheus\Counter;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 
 class OIDCCallbackRequest extends FormRequest
 {
@@ -19,8 +21,16 @@ class OIDCCallbackRequest extends FormRequest
         ];
     }
 
+    protected $redirect = '/external_login?error=invalid_request';
+
     protected function failedValidation(Validator $validator): void
     {
-        abort(400);
+        $keys = $validator->errors()->keys();
+        $message = 'invalid request parameter(s): '.implode(',', $keys);
+
+        Counter::get('login_failed_total')->inc('oidc');
+        Log::error('OIDC login callback failed: '.$message);
+
+        parent::failedValidation($validator);
     }
 }

--- a/app/Auth/OIDC/OIDCController.php
+++ b/app/Auth/OIDC/OIDCController.php
@@ -15,9 +15,11 @@ use Illuminate\Support\Uri;
 
 class OIDCController extends Controller
 {
+    protected const string REDIRECT_URL = '/external_login';
+
     public function __construct(protected OIDCProvider $provider)
     {
-        $this->middleware('guest');
+        $this->middleware('guest')->except('redirect');
     }
 
     /**
@@ -25,6 +27,17 @@ class OIDCController extends Controller
      */
     public function redirect(Request $request)
     {
+        if (Auth()->check()) {
+            $uri = Uri::of(self::REDIRECT_URL)->withQuery(['no_message' => true]);
+            if ($request->query('redirect')) {
+                return redirect($uri
+                    ->withQuery(['redirect' => $request->query('redirect')])
+                    ->value());
+            }
+
+            return redirect($uri->value());
+        }
+
         try {
             return $this->provider->redirect($request->query('redirect'));
         } catch (OpenIDConnectNetworkException $e) {
@@ -76,15 +89,13 @@ class OIDCController extends Controller
         $user->last_login = now();
         $user->save();
 
-        $url = '/external_login';
-
         if (session()->has('redirect_url')) {
-            return redirect(Uri::of($url)
+            return redirect(Uri::of(self::REDIRECT_URL)
                 ->withQuery(['redirect' => session()->get('redirect_url')])
                 ->value());
         }
 
-        return redirect($url);
+        return redirect(self::REDIRECT_URL);
     }
 
     /**

--- a/app/Auth/OIDC/OIDCController.php
+++ b/app/Auth/OIDC/OIDCController.php
@@ -25,11 +25,11 @@ class OIDCController extends Controller
     /**
      * Redirect to the OpenID Provider for authentication with an optional redirect back to a specific URL
      */
-    public function redirect(Request $request)
+    public function redirect(OIDCRedirectRequest $request)
     {
         if (Auth()->check()) {
             $uri = Uri::of(self::REDIRECT_URL)->withQuery(['no_message' => true]);
-            if ($request->query('redirect')) {
+            if ($request->has('redirect')) {
                 return redirect($uri
                     ->withQuery(['redirect' => $request->query('redirect')])
                     ->value());
@@ -56,7 +56,7 @@ class OIDCController extends Controller
     /**
      * Handle Authorization Code Flow redirect back from the OpenID Provider with an Authorization Code
      */
-    public function callback(Request $request): RedirectResponse
+    public function callback(OIDCCallbackRequest $request): RedirectResponse
     {
         try {
             $user = $this->provider->login($request);

--- a/app/Auth/OIDC/OIDCProvider.php
+++ b/app/Auth/OIDC/OIDCProvider.php
@@ -76,10 +76,7 @@ class OIDCProvider
      */
     public function login(Request $request): User
     {
-        if (! $this->openIDConnectClient->authenticate($request)) {
-            // Response is missing the code parameters
-            throw new OpenIDConnectCodeMissingException("Response is missing 'code' parameter.");
-        }
+        $this->openIDConnectClient->authenticate($request);
 
         $claims = $this->openIDConnectClient->getVerifiedClaims();
 

--- a/app/Auth/OIDC/OIDCRedirectRequest.php
+++ b/app/Auth/OIDC/OIDCRedirectRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\OIDC;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+class OIDCRedirectRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'redirect' => ['string'],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        abort(400);
+    }
+}

--- a/app/Auth/OIDC/OIDCRedirectRequest.php
+++ b/app/Auth/OIDC/OIDCRedirectRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Auth\OIDC;
 
+use App\Prometheus\Counter;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 
 class OIDCRedirectRequest extends FormRequest
 {
@@ -16,8 +18,16 @@ class OIDCRedirectRequest extends FormRequest
         ];
     }
 
+    protected $redirect = '/external_login?error=invalid_request';
+
     protected function failedValidation(Validator $validator): void
     {
-        abort(400);
+        $keys = $validator->errors()->keys();
+        $message = 'invalid request parameter(s): '.implode(',', $keys);
+
+        Counter::get('login_failed_total')->inc('oidc');
+        Log::error('OIDC login redirect failed: '.$message);
+
+        parent::failedValidation($validator);
     }
 }

--- a/app/Auth/OIDC/OpenIDConnectClient.php
+++ b/app/Auth/OIDC/OpenIDConnectClient.php
@@ -181,20 +181,17 @@ class OpenIDConnectClient
      * Authenticate the user with the OpenID Connect provider using the authorization code
      *
      * @param  Request  $request  The request object containing the authorization code and state
-     * @return bool Returns true if authentication is successful, false if the code is missing
      *
-     * @throws OpenIDConnectClientException
-     * @throws OpenIDConnectNetworkException
      * @throws ConnectionException
-     * @throws OpenIDConnectClientException
-     * @throws OpenIDConnectNetworkException
-     * @throws RequestException
-     * @throws OpenIDConnectValidationException
-     * @throws OpenIDConnectProviderException
-     * @throws JsonException
      * @throws InvalidClaimException
+     * @throws JsonException
      * @throws MissingMandatoryClaimException
+     * @throws OpenIDConnectClientException
      * @throws OpenIDConnectCodeMissingException
+     * @throws OpenIDConnectNetworkException
+     * @throws OpenIDConnectProviderException
+     * @throws OpenIDConnectValidationException
+     * @throws RequestException
      */
     public function authenticate(Request $request): void
     {

--- a/app/Auth/OIDC/OpenIDConnectClient.php
+++ b/app/Auth/OIDC/OpenIDConnectClient.php
@@ -194,8 +194,9 @@ class OpenIDConnectClient
      * @throws JsonException
      * @throws InvalidClaimException
      * @throws MissingMandatoryClaimException
+     * @throws OpenIDConnectCodeMissingException
      */
-    public function authenticate(Request $request): bool
+    public function authenticate(Request $request): void
     {
         // Do a preemptive check to see if the provider has thrown an error from a previous redirect
         if ($request->has('error')) {
@@ -206,7 +207,7 @@ class OpenIDConnectClient
         // If the authorization code is missing, the authentication has failed
         // User might have called the authentication URL directly
         if (! $request->has('code')) {
-            return false;
+            throw new OpenIDConnectCodeMissingException("Response is missing 'code' parameter.");
         }
 
         // Check OpenID Connect session
@@ -264,7 +265,7 @@ class OpenIDConnectClient
         $this->verifiedClaims = $claims;
 
         // Success!
-        return true;
+
     }
 
     /**

--- a/app/Auth/Shibboleth/ShibbolethCallbackRequest.php
+++ b/app/Auth/Shibboleth/ShibbolethCallbackRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Auth\Shibboleth;
 
+use App\Prometheus\Counter;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 
 class ShibbolethCallbackRequest extends FormRequest
 {
@@ -16,8 +18,16 @@ class ShibbolethCallbackRequest extends FormRequest
         ];
     }
 
+    protected $redirect = '/external_login?error=invalid_request';
+
     protected function failedValidation(Validator $validator): void
     {
-        abort(400);
+        $keys = $validator->errors()->keys();
+        $message = 'invalid request parameter(s): '.implode(',', $keys);
+
+        Counter::get('login_failed_total')->inc('shibboleth');
+        Log::error('Shibboleth login callback failed: '.$message);
+
+        parent::failedValidation($validator);
     }
 }

--- a/app/Auth/Shibboleth/ShibbolethCallbackRequest.php
+++ b/app/Auth/Shibboleth/ShibbolethCallbackRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shibboleth;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShibbolethCallbackRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'redirect' => ['string'],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        abort(400);
+    }
+}

--- a/app/Auth/Shibboleth/ShibbolethController.php
+++ b/app/Auth/Shibboleth/ShibbolethController.php
@@ -23,11 +23,11 @@ class ShibbolethController extends Controller
     /**
      * Redirect to the Shibboleth for authentication with an optional redirect back to a specific URL
      */
-    public function redirect(Request $request)
+    public function redirect(ShibbolethRedirectRequest $request)
     {
         if (Auth()->check()) {
             $uri = Uri::of(self::REDIRECT_URL)->withQuery(['no_message' => true]);
-            if ($request->query('redirect')) {
+            if ($request->has('redirect')) {
                 return redirect($uri
                     ->withQuery(['redirect' => $request->query('redirect')])
                     ->value());
@@ -58,7 +58,7 @@ class ShibbolethController extends Controller
     /**
      * Request to login with shibboleth, route is protected by mod-shibb of the reverse proxy
      */
-    public function callback(Request $request)
+    public function callback(ShibbolethCallbackRequest $request)
     {
         try {
             $user = $this->provider->login($request);
@@ -79,7 +79,7 @@ class ShibbolethController extends Controller
         $user->save();
 
         // Redirect to the external login page in the frontend, optionally with a redirect back to a specific URL
-        if ($request->query('redirect')) {
+        if ($request->has('redirect')) {
             return redirect(Uri::of(self::REDIRECT_URL)
                 ->withQuery(['redirect' => $request->query('redirect')])
                 ->value());

--- a/app/Auth/Shibboleth/ShibbolethController.php
+++ b/app/Auth/Shibboleth/ShibbolethController.php
@@ -9,12 +9,15 @@ use App\Http\Controllers\Controller;
 use App\Prometheus\Counter;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Uri;
 
 class ShibbolethController extends Controller
 {
+    protected const string REDIRECT_URL = '/external_login';
+
     public function __construct(protected ShibbolethProvider $provider)
     {
-        $this->middleware('guest')->except(['logout']);
+        $this->middleware('guest')->except(['logout', 'redirect']);
     }
 
     /**
@@ -22,6 +25,17 @@ class ShibbolethController extends Controller
      */
     public function redirect(Request $request)
     {
+        if (Auth()->check()) {
+            $uri = Uri::of(self::REDIRECT_URL)->withQuery(['no_message' => true]);
+            if ($request->query('redirect')) {
+                return redirect($uri
+                    ->withQuery(['redirect' => $request->query('redirect')])
+                    ->value());
+            }
+
+            return redirect($uri->value());
+        }
+
         return $this->provider->redirect($request->query('redirect'));
     }
 
@@ -65,9 +79,12 @@ class ShibbolethController extends Controller
         $user->save();
 
         // Redirect to the external login page in the frontend, optionally with a redirect back to a specific URL
-        $url = '/external_login';
-        $redirectUrl = $request->query('redirect');
+        if ($request->query('redirect')) {
+            return redirect(Uri::of(self::REDIRECT_URL)
+                ->withQuery(['redirect' => $request->query('redirect')])
+                ->value());
+        }
 
-        return redirect($redirectUrl ? ($url.'?redirect='.urlencode($redirectUrl)) : $url);
+        return redirect(self::REDIRECT_URL);
     }
 }

--- a/app/Auth/Shibboleth/ShibbolethRedirectRequest.php
+++ b/app/Auth/Shibboleth/ShibbolethRedirectRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Auth\Shibboleth;
 
+use App\Prometheus\Counter;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 
 class ShibbolethRedirectRequest extends FormRequest
 {
@@ -16,8 +18,16 @@ class ShibbolethRedirectRequest extends FormRequest
         ];
     }
 
+    protected $redirect = '/external_login?error=invalid_request';
+
     protected function failedValidation(Validator $validator): void
     {
-        abort(400);
+        $keys = $validator->errors()->keys();
+        $message = 'invalid request parameter(s): '.implode(',', $keys);
+
+        Counter::get('login_failed_total')->inc('shibboleth');
+        Log::error('Shibboleth login redirect failed: '.$message);
+
+        parent::failedValidation($validator);
     }
 }

--- a/app/Auth/Shibboleth/ShibbolethRedirectRequest.php
+++ b/app/Auth/Shibboleth/ShibbolethRedirectRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Auth\Shibboleth;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShibbolethRedirectRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'redirect' => ['string'],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        abort(400);
+    }
+}

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -12,6 +12,7 @@ return [
     ],
     'error' => [
         'login_failed' => 'Login failed',
+        'invalid_request' => 'Authentication failed due to an invalid request.',
         'missing_attributes' => 'Attributes for authentication are missing.',
         'openid_connect_exception' => 'Authentication failed due to an error.',
         'openid_connect_network_exception' => 'Failed to connect to the authentication provider.',

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -62,7 +62,6 @@ export const routes = [
     path: "/login",
     name: "login",
     component: Login,
-    meta: { guestsOnly: true },
   },
   {
     path: "/external_login",

--- a/resources/js/router.js
+++ b/resources/js/router.js
@@ -71,6 +71,7 @@ export const routes = [
     props: (route) => {
       return {
         error: route.query.error,
+        noMessage: route.query.no_message === "1",
       };
     },
   },

--- a/resources/js/views/ExternalLogin.vue
+++ b/resources/js/views/ExternalLogin.vue
@@ -15,6 +15,13 @@
               {{ $t("auth.error.try_again") }}</Message
             >
             <Message
+              v-if="props.error === 'invalid_request'"
+              severity="error"
+              :closable="false"
+              >{{ $t("auth.error.invalid_request") }}
+              {{ $t("auth.error.try_again") }}</Message
+            >
+            <Message
               v-if="props.error === 'shibboleth_session_duplicate_exception'"
               severity="error"
               :closable="false"
@@ -38,9 +45,10 @@
           </template>
           <template #footer>
             <Button
+              data-test="login-button"
               as="router-link"
-              :to="{ name: 'home' }"
-              :label="$t('app.home')"
+              :to="{ name: 'login' }"
+              :label="$t('auth.login')"
             />
           </template>
         </Card>

--- a/resources/js/views/ExternalLogin.vue
+++ b/resources/js/views/ExternalLogin.vue
@@ -60,6 +60,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  noMessage: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const toast = useToast();
@@ -70,8 +74,11 @@ const route = useRoute();
 onMounted(() => {
   // Successfully login via external provider
   if (!props.error) {
-    // show toast message
-    toast.success(t("auth.flash.login"));
+    if (!props.noMessage) {
+      // show toast message
+      toast.success(t("auth.flash.login"));
+    }
+
     // check if user should be redirected back after login,
     // otherwise redirect to own rooms (dashboard)
     if (route.query.redirect !== undefined) {

--- a/resources/js/views/ExternalLogin.vue
+++ b/resources/js/views/ExternalLogin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container" v-if="!authStore.isAuthenticated">
+  <div v-if="!authStore.isAuthenticated" class="container">
     <div class="mt-6 mb-8 grid grid-cols-12 gap-4">
       <div
         class="col-span-12 md:col-span-8 md:col-start-3 lg:col-span-6 lg:col-start-4"

--- a/resources/js/views/ExternalLogin.vue
+++ b/resources/js/views/ExternalLogin.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup>
-import { onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import { useToast } from "../composables/useToast.js";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -71,6 +71,12 @@ const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 
+const normalizedRedirect = computed(() => {
+  const value = route.query.redirect;
+  const redirectValue = Array.isArray(value) ? value[0] : value;
+  return redirectValue || undefined;
+});
+
 onMounted(() => {
   // Successfully login via external provider
   if (!props.error) {
@@ -81,8 +87,8 @@ onMounted(() => {
 
     // check if user should be redirected back after login,
     // otherwise redirect to own rooms (dashboard)
-    if (route.query.redirect !== undefined) {
-      router.push(route.query.redirect);
+    if (normalizedRedirect.value !== undefined) {
+      router.push(normalizedRedirect.value);
     } else {
       router.push({ name: "rooms.index" });
     }

--- a/resources/js/views/ExternalLogin.vue
+++ b/resources/js/views/ExternalLogin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container" v-if="!authStore.isAuthenticated">
     <div class="mt-6 mb-8 grid grid-cols-12 gap-4">
       <div
         class="col-span-12 md:col-span-8 md:col-start-3 lg:col-span-6 lg:col-start-4"
@@ -62,6 +62,7 @@ import { computed, onMounted } from "vue";
 import { useToast } from "../composables/useToast.js";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
+import { useAuthStore } from "../stores/auth";
 
 const props = defineProps({
   error: {
@@ -78,6 +79,7 @@ const toast = useToast();
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
+const authStore = useAuthStore();
 
 const normalizedRedirect = computed(() => {
   const value = route.query.redirect;
@@ -98,6 +100,12 @@ onMounted(() => {
     if (normalizedRedirect.value !== undefined) {
       router.push(normalizedRedirect.value);
     } else {
+      router.push({ name: "rooms.index" });
+    }
+  } else {
+    // an error occurred during an external authentication
+    // however the user is logged in, redirect to rooms overview
+    if (authStore.isAuthenticated) {
       router.push({ name: "rooms.index" });
     }
   }

--- a/resources/js/views/Login.vue
+++ b/resources/js/views/Login.vue
@@ -120,13 +120,20 @@ const errors = reactive({
 });
 
 const activeTab = ref("");
+
+const normalizedRedirect = computed(() => {
+  const value = route.query.redirect;
+  const redirectValue = Array.isArray(value) ? value[0] : value;
+  return redirectValue || undefined;
+});
+
 onMounted(() => {
   // Redirect already authenticated users
-  // to their prefered redirect route
+  // to their preferred redirect route
   // fallback to room overview
   if (authStore.isAuthenticated) {
-    if (route.query.redirect !== undefined) {
-      router.push(route.query.redirect);
+    if (normalizedRedirect.value !== undefined) {
+      router.push(normalizedRedirect.value);
     } else {
       router.push({ name: "rooms.index" });
     }
@@ -146,15 +153,15 @@ onMounted(() => {
 
 const oidcRedirectUrl = computed(() => {
   const url = "/auth/oidc/redirect";
-  return route.query.redirect
-    ? url + "?redirect=" + encodeURIComponent(route.query.redirect)
+  return normalizedRedirect.value
+    ? url + "?redirect=" + encodeURIComponent(normalizedRedirect.value)
     : url;
 });
 
 const shibbolethRedirectUrl = computed(() => {
   const url = "/auth/shibboleth/redirect";
-  return route.query.redirect
-    ? url + "?redirect=" + encodeURIComponent(route.query.redirect)
+  return normalizedRedirect.value
+    ? url + "?redirect=" + encodeURIComponent(normalizedRedirect.value)
     : url;
 });
 

--- a/resources/js/views/Login.vue
+++ b/resources/js/views/Login.vue
@@ -121,6 +121,18 @@ const errors = reactive({
 
 const activeTab = ref("");
 onMounted(() => {
+  // Redirect already authenticated users
+  // to their prefered redirect route
+  // fallback to room overview
+  if (authStore.isAuthenticated) {
+    if (route.query.redirect !== undefined) {
+      router.push(route.query.redirect);
+    } else {
+      router.push({ name: "rooms.index" });
+    }
+    return;
+  }
+
   if (settingsStore.getSetting("auth.ldap")) {
     activeTab.value = "ldap";
   } else if (settingsStore.getSetting("auth.shibboleth")) {

--- a/tests/Backend/Feature/api/v1/OIDCTest.php
+++ b/tests/Backend/Feature/api/v1/OIDCTest.php
@@ -278,6 +278,24 @@ class OIDCTest extends TestCase
     }
 
     /**
+     * Test that the redirect route can be accessed by logged-in users
+     *
+     * @return void
+     */
+    public function test_redirect_route_as_logged_in_user()
+    {
+        $user = User::factory()->create();
+
+        // Check without redirect url
+        $response = $this->actingAs($user)->get(route('auth.oidc.redirect'));
+        $response->assertRedirect('http://localhost/external_login?no_message=1');
+
+        // Check with redirect url
+        $response = $this->actingAs($user)->get(route('auth.oidc.redirect', ['redirect' => '/rooms/abc-123-def']));
+        $response->assertRedirect('http://localhost/external_login?no_message=1&redirect=%2Frooms%2Fabc-123-def');
+    }
+
+    /**
      * Test that the callback route is disabled if disabled in env
      *
      * @return void

--- a/tests/Backend/Feature/api/v1/OIDCTest.php
+++ b/tests/Backend/Feature/api/v1/OIDCTest.php
@@ -2063,14 +2063,8 @@ class OIDCTest extends TestCase
             'code' => $code,
             'state' => $state,
         ]));
+        $response->assertRedirect('http://localhost/external_login?redirect=%2Frooms%2Fabc-123-def');
         $this->assertAuthenticated();
-
-        $redirectUrl = $response->getTargetUrl();
-
-        $redirectUrlParsed = parse_url($redirectUrl);
-        $queryParams = [];
-        parse_str($redirectUrlParsed['query'], $queryParams);
-        $this->assertEquals('/rooms/abc-123-def', $queryParams['redirect']);
     }
 
     public function test_rp_initiated_logout_missing_end_session_endpoint()

--- a/tests/Backend/Feature/api/v1/OIDCTest.php
+++ b/tests/Backend/Feature/api/v1/OIDCTest.php
@@ -295,6 +295,27 @@ class OIDCTest extends TestCase
         $response->assertRedirect('http://localhost/external_login?no_message=1&redirect=%2Frooms%2Fabc-123-def');
     }
 
+    public function test_redirect_route_invalid_parameter()
+    {
+        Log::swap(new LogFake);
+
+        // Redirect parameter empty
+        $response = $this->get(route('auth.oidc.redirect', ['redirect' => '']));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        // Redirect parameter array
+        $response = $this->get(route('auth.oidc.redirect', ['redirect' => ['foo', 'bar']]));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        Log::assertLoggedTimes(
+            fn (LogEntry $log) => $log->level == 'error'
+                && $log->message == 'OIDC login redirect failed: invalid request parameter(s): redirect'
+                && $log->context['ip'] == '127.0.0.1'
+                && $log->context['current-user'] == 'guest',
+            2
+        );
+    }
+
     /**
      * Test that the callback route is disabled if disabled in env
      *
@@ -328,6 +349,31 @@ class OIDCTest extends TestCase
         $response = $this->get(route('auth.oidc.callback'));
         $response->assertRedirect('http://localhost/auth/oidc/redirect');
         $this->assertGuest();
+    }
+
+    public function test_callback_route_invalid_parameter()
+    {
+        Log::swap(new LogFake);
+
+        $params = ['code', 'state', 'error', 'error_description'];
+
+        foreach ($params as $param) {
+            // Parameter empty
+            $response = $this->get(route('auth.oidc.callback', [$param => '']));
+            $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+            // Parameter array
+            $response = $this->get(route('auth.oidc.callback', [$param => ['foo', 'bar']]));
+            $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+            Log::assertLoggedTimes(
+                fn (LogEntry $log) => $log->level == 'error'
+                    && $log->message == 'OIDC login callback failed: invalid request parameter(s): '.$param
+                    && $log->context['ip'] == '127.0.0.1'
+                    && $log->context['current-user'] == 'guest',
+                2
+            );
+        }
     }
 
     public function test_callback_with_user_info_signed()

--- a/tests/Backend/Feature/api/v1/ShibbolethTest.php
+++ b/tests/Backend/Feature/api/v1/ShibbolethTest.php
@@ -125,6 +125,24 @@ class ShibbolethTest extends TestCase
     }
 
     /**
+     * Test that the redirect route can be accessed by logged-in users
+     *
+     * @return void
+     */
+    public function test_redirect_route_as_logged_in_user()
+    {
+        $user = User::factory()->create();
+
+        // Check without redirect url
+        $response = $this->actingAs($user)->get(route('auth.shibboleth.redirect'));
+        $response->assertRedirect('http://localhost/external_login?no_message=1');
+
+        // Check with redirect url
+        $response = $this->actingAs($user)->get(route('auth.shibboleth.redirect', ['redirect' => '/rooms/abc-123-def']));
+        $response->assertRedirect('http://localhost/external_login?no_message=1&redirect=%2Frooms%2Fabc-123-def');
+    }
+
+    /**
      * Test that the callback route is disabled if disabled in env
      *
      * @return void

--- a/tests/Backend/Feature/api/v1/ShibbolethTest.php
+++ b/tests/Backend/Feature/api/v1/ShibbolethTest.php
@@ -142,6 +142,27 @@ class ShibbolethTest extends TestCase
         $response->assertRedirect('http://localhost/external_login?no_message=1&redirect=%2Frooms%2Fabc-123-def');
     }
 
+    public function test_redirect_route_invalid_redirect_parameter()
+    {
+        Log::swap(new LogFake);
+
+        // Redirect parameter empty
+        $response = $this->get(route('auth.shibboleth.redirect', ['redirect' => '']));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        // Redirect parameter array
+        $response = $this->get(route('auth.shibboleth.redirect', ['redirect' => ['foo', 'bar']]));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        Log::assertLoggedTimes(
+            fn (LogEntry $log) => $log->level == 'error'
+                && $log->message == 'Shibboleth login redirect failed: invalid request parameter(s): redirect'
+                && $log->context['ip'] == '127.0.0.1'
+                && $log->context['current-user'] == 'guest',
+            2
+        );
+    }
+
     /**
      * Test that the callback route is disabled if disabled in env
      *
@@ -215,6 +236,27 @@ class ShibbolethTest extends TestCase
         $this->assertEquals('Europe/Paris', $user->timezone);
 
         $this->assertEquals($user->roles()->pluck('name')->toArray(), ['user']);
+    }
+
+    public function test_callback_route_invalid_redirect_parameter()
+    {
+        Log::swap(new LogFake);
+
+        // Redirect parameter empty
+        $response = $this->get(route('auth.shibboleth.callback', ['redirect' => '']));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        // Redirect parameter array
+        $response = $this->get(route('auth.shibboleth.callback', ['redirect' => ['foo', 'bar']]));
+        $response->assertRedirect('http://localhost/external_login?error=invalid_request');
+
+        Log::assertLoggedTimes(
+            fn (LogEntry $log) => $log->level == 'error'
+                && $log->message == 'Shibboleth login callback failed: invalid request parameter(s): redirect'
+                && $log->context['ip'] == '127.0.0.1'
+                && $log->context['current-user'] == 'guest',
+            2
+        );
     }
 
     public function test_redirect_and_callback()

--- a/tests/Backend/Feature/api/v1/ShibbolethTest.php
+++ b/tests/Backend/Feature/api/v1/ShibbolethTest.php
@@ -217,6 +217,28 @@ class ShibbolethTest extends TestCase
         $this->assertEquals($user->roles()->pluck('name')->toArray(), ['user']);
     }
 
+    public function test_redirect_and_callback()
+    {
+        $this->generalSettings->default_timezone = 'Europe/Paris';
+        $this->generalSettings->save();
+
+        $header = [
+            'Accept-Language' => 'fr',
+            'shib-session-id' => '_855fe7fbe56c664a6fad794c65243ec6',
+            'shib-session-expires' => Carbon::now()->addHours(12)->timestamp,
+            'principalname' => 'johnd@university.org',
+            'givenname' => 'John',
+            'surname' => 'Doe',
+            'mail' => 'john.doe@domain.tld',
+            'scoped-affiliation' => 'student@university.org;staff@university.org',
+        ];
+
+        $response = $this->get(route('auth.shibboleth.callback', ['redirect' => '/rooms/abc-123-def']), $header);
+        $response->assertRedirect('http://localhost/external_login?redirect=%2Frooms%2Fabc-123-def');
+
+        $this->assertAuthenticated();
+    }
+
     public function test_set_last_login()
     {
         $this->generalSettings->default_timezone = 'Europe/Paris';

--- a/tests/Frontend/e2e/Login.cy.js
+++ b/tests/Frontend/e2e/Login.cy.js
@@ -601,12 +601,22 @@ describe("Login", function () {
   });
 
   it("visit login page with already logged in user", function () {
-    cy.intercept("GET", "api/v1/currentUser", { fixture: "currentUser.json" });
+    cy.fixture("currentUser.json").then((currentUser) => {
+      currentUser.data.permissions = ["admin.view"];
+      cy.intercept("GET", "api/v1/currentUser", {
+        statusCode: 200,
+        body: currentUser,
+      });
+    });
     cy.interceptRoomIndexRequests();
 
+    // Check without redirect query parameter
     cy.visit("/login");
-    cy.checkToastMessage("app.flash.guests_only");
-    cy.url().should("not.include", "/login");
+    cy.url().should("include", "/rooms").and("not.include", "/login");
+
+    // Check with redirect query parameter
+    cy.visit("/login?redirect=/admin");
+    cy.url().should("include", "/admin").and("not.include", "/login");
   });
 
   it("shibboleth login", function () {

--- a/tests/Frontend/e2e/Login.cy.js
+++ b/tests/Frontend/e2e/Login.cy.js
@@ -692,6 +692,10 @@ describe("Login", function () {
 
     // Check if redirect works
     cy.url().should("include", "/admin").and("not.include", "/login");
+
+    // Check admin page is shown (loading is finished) and toast message is shown
+    cy.contains("admin.title").should("be.visible");
+    cy.checkToastMessage("auth.flash.login");
   });
 
   it("external login callback missing attributes error", function () {
@@ -799,5 +803,30 @@ describe("Login", function () {
 
     // Check if redirect works
     cy.url().should("include", "/admin").and("not.include", "/login");
+
+    // Check admin page is shown (loading is finished) and toast message is shown
+    cy.contains("admin.title").should("be.visible");
+    cy.checkToastMessage("auth.flash.login");
+  });
+
+  it("external login with redirect query and no_message set", function () {
+    // Intercept user request (user that has the permission to show the config page)
+    cy.fixture("currentUser.json").then((currentUser) => {
+      currentUser.data.permissions = ["admin.view"];
+      cy.intercept("GET", "api/v1/currentUser", {
+        statusCode: 200,
+        body: currentUser,
+      });
+    });
+
+    // Visit redirect page after external login (redirect query is set)
+    cy.visit("/external_login?no_message=1&redirect=/admin");
+
+    // Check if redirect works
+    cy.url().should("include", "/admin").and("not.include", "/login");
+
+    // Check admin page is shown (loading is finished) and no toast message is shown
+    cy.contains("admin.title").should("be.visible");
+    cy.get(".p-toast-message").should("not.exist");
   });
 });

--- a/tests/Frontend/e2e/Login.cy.js
+++ b/tests/Frontend/e2e/Login.cy.js
@@ -715,6 +715,12 @@ describe("Login", function () {
     // Check if error gets displayed
     cy.contains("auth.error.login_failed").should("be.visible");
     cy.contains("auth.error.missing_attributes").should("be.visible");
+
+    // Check login button
+    cy.get('a[data-test="login-button"]')
+      .should("be.visible")
+      .should("have.text", "auth.login")
+      .should("have.attr", "href", "/login");
   });
 
   it("external login callback duplicate session error", function () {
@@ -726,6 +732,59 @@ describe("Login", function () {
     cy.contains("auth.error.shibboleth_session_duplicate_exception").should(
       "be.visible",
     );
+
+    // Check login button
+    cy.get('a[data-test="login-button"]')
+      .should("be.visible")
+      .should("have.text", "auth.login")
+      .should("have.attr", "href", "/login");
+  });
+
+  it("external login callback invalid request", function () {
+    // Visit redirect page after external login with error (invalid request)
+    cy.visit("/external_login?error=invalid_request");
+
+    // Check if error gets displayed
+    cy.contains("auth.error.login_failed").should("be.visible");
+    cy.contains("auth.error.invalid_request").should("be.visible");
+
+    // Check login button
+    cy.get('a[data-test="login-button"]')
+      .should("be.visible")
+      .should("have.text", "auth.login")
+      .should("have.attr", "href", "/login");
+  });
+
+  it("external login callback openid connect network exception", function () {
+    // Visit redirect page after external login with error (openid connect network exception)
+    cy.visit("/external_login?error=openid_connect_network_exception");
+
+    // Check if error gets displayed
+    cy.contains("auth.error.login_failed").should("be.visible");
+    cy.contains("auth.error.openid_connect_network_exception").should(
+      "be.visible",
+    );
+
+    // Check login button
+    cy.get('a[data-test="login-button"]')
+      .should("be.visible")
+      .should("have.text", "auth.login")
+      .should("have.attr", "href", "/login");
+  });
+
+  it("external login callback openid connect exception", function () {
+    // Visit redirect page after external login with error (openid connect exception)
+    cy.visit("/external_login?error=openid_connect_exception");
+
+    // Check if error gets displayed
+    cy.contains("auth.error.login_failed").should("be.visible");
+    cy.contains("auth.error.openid_connect_exception").should("be.visible");
+
+    // Check login button
+    cy.get('a[data-test="login-button"]')
+      .should("be.visible")
+      .should("have.text", "auth.login")
+      .should("have.attr", "href", "/login");
   });
 
   it("oidc login", function () {

--- a/tests/Frontend/e2e/Login.cy.js
+++ b/tests/Frontend/e2e/Login.cy.js
@@ -787,6 +787,17 @@ describe("Login", function () {
       .should("have.attr", "href", "/login");
   });
 
+  it("external login callback with error and already logged in user", function () {
+    cy.intercept("/api/v1/currentUser", { fixture: "currentUser.json" });
+    cy.interceptRoomIndexRequests();
+
+    // Visit redirect page after external login with error
+    cy.visit("/external_login?error=invalid_request");
+
+    // Check redirected to room overview page
+    cy.url().should("include", "/rooms").and("not.include", "/login");
+  });
+
   it("oidc login", function () {
     // Intercept config request to only show oidc login tab
     cy.fixture("config.json").then((config) => {


### PR DESCRIPTION
# Fixes #3078 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Direct OIDC / Shibboleth redirect calls with a redirect query parameter will now redirect authenticated users to the requested url
- Allow frontend login url calls, user is redirected to requested redirect route, fallback to room overview

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Skip login/external-login UI when already authenticated; redirect to rooms or provided redirect. Respect a no_message flag to suppress post-login toast. Normalized redirect handling and updated route props.

* **Validation**
  * New request validation for OIDC/Shibboleth redirect & callback endpoints that redirect to external_login?error=invalid_request and surface a localized "invalid request" message.

* **Tests**
  * Expanded backend and frontend tests for authenticated redirects, invalid parameters, and end-to-end external-login flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->