### PR TITLE
Enable laravel-settings cache in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toast notification for form validation errors in non-dialog forms ([#3056])
 - Auto-scroll to the first form validation error ([#3038], [#3056])
 - Required attribute to more form fields to improve accessibility ([#3056])
+- Settings cache in production environments ([#3196])
 
 ### Changed
 
@@ -815,6 +816,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3078]: https://github.com/THM-Health/PILOS/issues/3078
 [#3079]: https://github.com/THM-Health/PILOS/pull/3079
 [#3128]: https://github.com/THM-Health/PILOS/pull/3128
+[#3196]: https://github.com/THM-Health/PILOS/pull/3196
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.15.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/app/Console/Commands/ProvisionCommand.php
+++ b/app/Console/Commands/ProvisionCommand.php
@@ -27,15 +27,10 @@ class ProvisionCommand extends Command
      */
     protected $description = 'Provision this PILOS instance';
 
-    public function __construct(protected ProvisioningService $provision)
-    {
-        parent::__construct();
-    }
-
     /**
      * Execute the console command.
      */
-    public function handle()
+    public function handle(ProvisioningService $provision)
     {
         $data = json_decode(file_get_contents($this->argument('path')));
 
@@ -44,19 +39,19 @@ class ProvisionCommand extends Command
 
             // Wipe existing data (order is important!)
             if ($data?->room_types?->wipe ?? false) {
-                $this->provision->roomType->destroy();
+                $provision->roomType->destroy();
             }
             if ($data?->server_pools?->wipe ?? false) {
-                $this->provision->serverPool->destroy();
+                $provision->serverPool->destroy();
             }
             if ($data?->servers?->wipe ?? false) {
-                $this->provision->server->destroy();
+                $provision->server->destroy();
             }
             if ($data?->roles?->wipe ?? false) {
-                $this->provision->role->destroy();
+                $provision->role->destroy();
             }
             if ($data?->users?->wipe ?? false) {
-                $this->provision->user->destroy();
+                $provision->user->destroy();
             }
 
             // Add new instances
@@ -65,7 +60,7 @@ class ProvisionCommand extends Command
                 $n = count($data->servers->add ?? []);
                 info("Provisioning $n servers");
                 foreach ($data->servers->add ?? [] as $item) {
-                    $this->provision->server->create($item);
+                    $provision->server->create($item);
                 }
             }
 
@@ -73,7 +68,7 @@ class ProvisionCommand extends Command
                 $n = count($data->server_pools->add ?? []);
                 info("Provisioning $n server pools");
                 foreach ($data->server_pools->add ?? [] as $item) {
-                    $this->provision->serverPool->create($item);
+                    $provision->serverPool->create($item);
                 }
             }
 
@@ -81,7 +76,7 @@ class ProvisionCommand extends Command
                 $n = count($data->room_types->add ?? []);
                 info("Provisioning $n room types");
                 foreach ($data->room_types->add ?? [] as $item) {
-                    $this->provision->roomType->create($item);
+                    $provision->roomType->create($item);
                 }
             }
 
@@ -90,7 +85,7 @@ class ProvisionCommand extends Command
                 info("Provisioning $n roles");
                 foreach ($data->roles->add ?? [] as $item) {
                     $item->permissions = (array) $item->permissions;
-                    $this->provision->role->create($item);
+                    $provision->role->create($item);
                 }
             }
 
@@ -98,7 +93,7 @@ class ProvisionCommand extends Command
                 $n = count($data->users->add ?? []);
                 info("Provisioning $n users");
                 foreach ($data->users->add ?? [] as $item) {
-                    $this->provision->user->create($item);
+                    $provision->user->create($item);
                 }
             }
 
@@ -108,7 +103,7 @@ class ProvisionCommand extends Command
                 foreach (get_object_vars($data->settings) as $section => $settings) {
                     $data->settings->{$section} = (array) $settings;
                 }
-                $this->provision->settings->set($data->settings);
+                $provision->settings->set($data->settings);
             }
 
             DB::commit();

--- a/app/Listeners/ClearSettingsCacheOnMigrationsEnded.php
+++ b/app/Listeners/ClearSettingsCacheOnMigrationsEnded.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Support\Facades\Artisan;
+
+class ClearSettingsCacheOnMigrationsEnded
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(MigrationsEnded $event): void
+    {
+        // Clear spatie/laravel-settings cache
+        Artisan::call('settings:clear-cache');
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Events\RoomEnded;
 use App\Events\RoomStarted;
+use App\Listeners\ClearSettingsCacheOnMigrationsEnded;
 use App\Listeners\ConfigureStreamingOnRoomStart;
 use App\Listeners\FailedLoginAttempt;
 use App\Listeners\ResetStreamingOnRoomStop;
@@ -14,6 +15,7 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
+use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -38,6 +40,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         Login::class => [
             SuccessfulLogin::class,
+        ],
+        MigrationsEnded::class => [
+            ClearSettingsCacheOnMigrationsEnded::class,
         ],
     ];
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -96,7 +96,7 @@ return [
      * additional prefix.
      */
     'cache' => [
-        'enabled' => env('APP_ENV', 'production') === "production",
+        'enabled' => env('APP_ENV', 'production') === 'production',
         'store' => null,
         'prefix' => null,
         'ttl' => null,

--- a/config/settings.php
+++ b/config/settings.php
@@ -96,7 +96,7 @@ return [
      * additional prefix.
      */
     'cache' => [
-        'enabled' => env('SETTINGS_CACHE_ENABLED', false),
+        'enabled' => env('APP_ENV', 'production') === "production",
         'store' => null,
         'prefix' => null,
         'ttl' => null,


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **Performance**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Added settings cache in production environments

## Other information
This PR enables spatie/laravel-settings cache in prod. During the first request the settings are cached. On all following requests the data from the cache is served, resulting in no db-queries and saves +10ms per request. The cache is cleared once settings are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings caching is now enabled in production environments for improved performance.
  * Settings cache automatically clears upon completion of database migrations to ensure data consistency.

* **Chores**
  * Updated changelog with settings cache updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->