### PR TITLE
Fix access code button visibility in room settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UX: Buttons in start/join dialog not immediately visible on small screens ([#2333])
 - UX: Cropped dialog content on small screens (illusion of completeness) ([#2333])
 - Styling inconsistencies in the room share popover ([#3145], [#3198])
+- Clear / Generate access code buttons not hidden in room settings when access code is enforced or prohibited ([#3130], [#3215])
 
 ## [v4.15.0] - 2026-05-15
 
@@ -824,11 +825,13 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3078]: https://github.com/THM-Health/PILOS/issues/3078
 [#3079]: https://github.com/THM-Health/PILOS/pull/3079
 [#3128]: https://github.com/THM-Health/PILOS/pull/3128
+[#3130]: https://github.com/THM-Health/PILOS/issues/3130
 [#3145]: https://github.com/THM-Health/PILOS/issues/3145
 [#3169]: https://github.com/THM-Health/PILOS/issues/3169
 [#3194]: https://github.com/THM-Health/PILOS/pull/3194
 [#3196]: https://github.com/THM-Health/PILOS/pull/3196
 [#3198]: https://github.com/THM-Health/PILOS/pull/3198
+[#3215]: https://github.com/THM-Health/PILOS/pull/3215
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.15.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/components/RoomTabSettingsAccessCodeInput.vue
+++ b/resources/js/components/RoomTabSettingsAccessCodeInput.vue
@@ -19,7 +19,13 @@
       <InputGroup>
         <!-- Generate random access code -->
         <Button
-          v-if="!disabled"
+          v-if="
+            !disabled &&
+            !(
+              model.room_type.has_access_code_enforced &&
+              !model.room_type.has_access_code_default
+            )
+          "
           v-tooltip="$t('rooms.settings.general.generate_access_code')"
           data-test="generate-access-code-button"
           :aria-label="$t('rooms.settings.general.generate_access_code')"
@@ -37,7 +43,14 @@
         />
         <!-- Clear access code -->
         <Button
-          v-if="model[setting] && !disabled"
+          v-if="
+            model[setting] &&
+            !disabled &&
+            !(
+              model.room_type.has_access_code_enforced &&
+              model.room_type.has_access_code_default
+            )
+          "
           v-tooltip="$t('rooms.settings.general.delete_access_code')"
           :aria-label="$t('rooms.settings.general.delete_access_code')"
           icon="fa-solid fa-trash"

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -79,6 +79,12 @@ describe("Rooms view settings", function () {
       .within(() => {
         cy.get('[data-test="room-setting-enforced-icon"]').should("not.exist");
         cy.get("#room-setting-access_code").should("have.value", "123456789");
+
+        // Check that buttons are shown correctly
+        cy.get('[data-test="clear-access-code-button"]').should("be.visible");
+        cy.get('[data-test="generate-access-code-button"]').should(
+          "be.visible",
+        );
       });
 
     cy.get('[data-test="room-setting-allow_guests"]')
@@ -1359,6 +1365,12 @@ describe("Rooms view settings", function () {
       .within(() => {
         cy.get('[data-test="room-setting-enforced-icon"]');
         cy.get("#room-setting-access_code").should("have.value", "");
+
+        // Check that buttons are shown / hidden correctly (access code is enforced)
+        cy.get('[data-test="clear-access-code-button"]').should("not.exist");
+        cy.get('[data-test="generate-access-code-button"]').should(
+          "be.visible",
+        );
       });
 
     // Save settings and respond with 422 errors
@@ -1516,6 +1528,15 @@ describe("Rooms view settings", function () {
       .within(() => {
         cy.get('[data-test="room-setting-enforced-icon"]');
         cy.get("#room-setting-access_code").should("have.value", "123456789");
+
+        // Check that buttons are shown / hidden correctly (access code is prohibited)
+        cy.get('[data-test="clear-access-code-button"]').should("be.visible");
+        cy.get('[data-test="generate-access-code-button"]').should("not.exist");
+
+        cy.get('[data-test="clear-access-code-button"]').click();
+        cy.get("#room-setting-access_code").should("have.value", "");
+        cy.get('[data-test="clear-access-code-button"]').should("not.exist");
+        cy.get('[data-test="generate-access-code-button"]').should("not.exist");
       });
 
     // Check that 422 error messages are hidden


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code works and all tests pass
- Write useful descriptions and titles.
- Address review comments with additional commits, do not rewrite commit / force push
- Read and follow the developer docs: https://thm-health.github.io/PILOS/docs/next/development/workflow

-->

<!--
List here all the issues closed by this pull request.
Use keyword `fixes`  or `closes` before each issue number, e.g. Fixes #123456 or Closes #123456
-->

# Fixes #3130 

<!-- Type of the Pull Request, please highlight the corresponding type -->

## Type

- **Bugfix**
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [x] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Hide clear access code button if access code is enforced
- Hide generate access code button if access code is prohibited


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed visibility of "Clear" and "Generate access code" buttons in room settings. The buttons now display correctly based on access code enforcement configuration, instead of being unexpectedly hidden in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->