### PR TITLE
A11y: Honor reduced-motion for flipping words on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accessibility: Converted room names on the room index page to `<h2>` anchor links to improve screen reader navigation ([#2970])
 - Accessibility: Move focus automatically back to the main `<h1>` heading when filters change on the room index page ([#2970])
 - Accessibility: Announcement order to read the room name before the room type on screen readers ([#2970])
-- Accessibility: Flipping words animation on loading page for browsers with reduced-motion set ([#3277])
+- Accessibility: Reduced flipping words animation on loading page for browsers with reduced-motion set ([#3277])
 
 ## [v4.16.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accessibility: Converted room names on the room index page to `<h2>` anchor links to improve screen reader navigation ([#2970])
 - Accessibility: Move focus automatically back to the main `<h1>` heading when filters change on the room index page ([#2970])
 - Accessibility: Announcement order to read the room name before the room type on screen readers ([#2970])
+- Accessibility: Flipping words animation on loading page for browsers with reduced-motion set ([#3277])
 
 ## [v4.16.0] - 2026-06-12
 
@@ -848,6 +849,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3196]: https://github.com/THM-Health/PILOS/pull/3196
 [#3198]: https://github.com/THM-Health/PILOS/pull/3198
 [#3215]: https://github.com/THM-Health/PILOS/pull/3215
+[#3277]: https://github.com/THM-Health/PILOS/pull/3277
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.16.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0
 [v3.0.1]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.1

--- a/resources/js/components/LandingHeroTitleFlipWords.vue
+++ b/resources/js/components/LandingHeroTitleFlipWords.vue
@@ -84,4 +84,11 @@ watch(
   filter: blur(8px);
   position: absolute;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .flip-enter-active,
+  .flip-leave-active {
+    transition: none;
+  }
+}
 </style>


### PR DESCRIPTION
## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **Accessibility**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Changed flipping words animation on loading page for browsers with reduced-motion set 

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Reduced-motion settings now disable the “Flipping words” animation on the loading page for users who prefer less motion.
  * The changelog was updated to reflect this accessibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->