### PR TITLE
Accessibility: Fix aria descriptions and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Environment variable `VERSION` to change the displayed version in the footer ([#3300], [#3302])
 - System-wide default welcome message ([#3301])
+- Accessibility: Aria-labels for filter and sort select elements in room tabs ([#3298])
 
 ### Fixed
 
 - Select dropdown border styles ([#3314], [#3315])
+- Accessibility: Aria-describedby for select and toggle switch input fields ([#3298])
 
 ## [v4.17.0] - 2026-07-09
 
@@ -868,6 +870,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3264]: https://github.com/THM-Health/PILOS/pull/3264
 [#3277]: https://github.com/THM-Health/PILOS/pull/3277
 [#3296]: https://github.com/THM-Health/PILOS/pull/3296
+[#3298]: https://github.com/THM-Health/PILOS/pull/3298
 [#3300]: https://github.com/THM-Health/PILOS/issues/3300
 [#3301]: https://github.com/THM-Health/PILOS/pull/3301
 [#3302]: https://github.com/THM-Health/PILOS/pull/3302

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -69,6 +69,7 @@ return [
         'streaming_meeting_not_running' => 'The meeting is not running.',
         'streaming_not_enabled_for_current_meeting_error' => 'Streaming is not enabled for the current meeting.',
     ],
+    'filter' => 'Filter',
     'filter_no_results' => 'No results found',
     'firstname' => 'Firstname',
     'flash' => [
@@ -143,6 +144,9 @@ return [
     'server_pool' => 'Server pool',
     'server_pools' => 'Server pools',
     'servers' => 'Server',
+    'sort_by' => 'Sort by',
+    'sort_ascending' => 'Sort ascending',
+    'sort_descending' => 'Sort descending',
     'streaming' => 'Streaming',
     'time_formats' => [
         'day' => 'Day',

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -157,6 +157,7 @@ return [
     ],
     'index' => [
         'filter' => 'Filter',
+        'filter_by_room_type' => 'Filter by room type',
         'no_favorites' => 'No rooms marked as favorites',
         'no_rooms_selected' => 'No rooms selected',
         'only_favorites' => 'Only show favorites',

--- a/resources/js/components/LoginTabLocal.vue
+++ b/resources/js/components/LoginTabLocal.vue
@@ -11,7 +11,6 @@
           :disabled="props.loading"
           autocomplete="email"
           :placeholder="props.emailLabel"
-          aria-describedby="email-help-block"
           :invalid="
             props.errors !== null &&
             props.errors.email &&
@@ -34,7 +33,6 @@
           fluid
           :disabled="props.loading"
           :placeholder="props.passwordLabel"
-          aria-describedby="password-help-block"
           :invalid="
             props.errors !== null &&
             props.errors.password &&
@@ -43,7 +41,6 @@
         />
         <Button
           v-if="settingsStore.getSetting('user.password_change_allowed')"
-          id="password-help-block"
           as="router-link"
           link
           class="self-start p-0"

--- a/resources/js/components/RoomTabFiles.vue
+++ b/resources/js/components/RoomTabFiles.vue
@@ -65,7 +65,7 @@
         </search>
         <div class="flex flex-col gap-2 lg:flex-row">
           <InputGroup v-if="userPermissions.can('manageSettings', props.room)">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-filter"></i>
             </InputGroupAddon>
             <Select
@@ -75,6 +75,7 @@
               option-label="name"
               option-value="value"
               data-test="filter-dropdown"
+              :aria-label="$t('app.filter')"
               :pt="{
                 listContainer: {
                   'data-test': 'filter-dropdown-items',
@@ -88,7 +89,7 @@
           </InputGroup>
 
           <InputGroup data-test="sorting-type-inputgroup">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-sort"></i>
             </InputGroupAddon>
             <Select
@@ -98,6 +99,7 @@
               option-label="name"
               option-value="value"
               data-test="sorting-type-dropdown"
+              :aria-label="$t('app.sort_by')"
               :pt="{
                 listContainer: {
                   'data-test': 'sorting-type-dropdown-items',
@@ -115,6 +117,11 @@
                   sortOrder === 1
                     ? 'fa-solid fa-arrow-up-short-wide'
                     : 'fa-solid fa-arrow-down-wide-short'
+                "
+                :aria-label="
+                  sortOrder === 1
+                    ? $t('app.sort_ascending')
+                    : $t('app.sort_descending')
                 "
                 severity="secondary"
                 text

--- a/resources/js/components/RoomTabHistory.vue
+++ b/resources/js/components/RoomTabHistory.vue
@@ -11,7 +11,7 @@
       >
         <div class="flex gap-2">
           <InputGroup class="w-auto" data-test="sorting-type-inputgroup">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-sort"></i>
             </InputGroupAddon>
             <Select
@@ -21,6 +21,7 @@
               :options="sortFields"
               option-label="name"
               option-value="value"
+              :aria-label="$t('app.sort_by')"
               :pt="{
                 listContainer: {
                   'data-test': 'sorting-type-dropdown-items',
@@ -38,6 +39,11 @@
                   sortOrder === 1
                     ? 'fa-solid fa-arrow-up-short-wide'
                     : 'fa-solid fa-arrow-down-wide-short'
+                "
+                :aria-label="
+                  sortOrder === 1
+                    ? $t('app.sort_ascending')
+                    : $t('app.sort_descending')
                 "
                 severity="secondary"
                 text

--- a/resources/js/components/RoomTabMembers.vue
+++ b/resources/js/components/RoomTabMembers.vue
@@ -22,7 +22,7 @@
         </search>
         <div class="flex flex-col gap-2 lg:flex-row">
           <InputGroup>
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-filter"></i>
             </InputGroupAddon>
             <Select
@@ -32,6 +32,7 @@
               :options="filterOptions"
               option-label="name"
               option-value="value"
+              :aria-label="$t('app.filter')"
               :pt="{
                 listContainer: {
                   'data-test': 'filter-dropdown-items',
@@ -45,7 +46,7 @@
           </InputGroup>
 
           <InputGroup data-test="sorting-type-inputgroup">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-sort"></i>
             </InputGroupAddon>
             <Select
@@ -55,6 +56,7 @@
               :options="sortFields"
               option-label="name"
               option-value="value"
+              :aria-label="$t('app.sort_by')"
               :pt="{
                 listContainer: {
                   'data-test': 'sorting-type-dropdown-items',
@@ -72,6 +74,11 @@
                   sortOrder === 1
                     ? 'fa-solid fa-arrow-up-short-wide'
                     : 'fa-solid fa-arrow-down-wide-short'
+                "
+                :aria-label="
+                  sortOrder === 1
+                    ? $t('app.sort_ascending')
+                    : $t('app.sort_descending')
                 "
                 severity="secondary"
                 text

--- a/resources/js/components/RoomTabPersonalizedLinks.vue
+++ b/resources/js/components/RoomTabPersonalizedLinks.vue
@@ -22,7 +22,7 @@
         </search>
         <div class="flex flex-col gap-2 lg:flex-row">
           <InputGroup>
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-filter"></i>
             </InputGroupAddon>
             <Select
@@ -32,6 +32,7 @@
               :options="filterOptions"
               option-label="name"
               option-value="value"
+              :aria-label="$t('app.filter')"
               :pt="{
                 listContainer: {
                   'data-test': 'filter-dropdown-items',
@@ -45,7 +46,7 @@
           </InputGroup>
 
           <InputGroup data-test="sorting-type-inputgroup">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-sort"></i>
             </InputGroupAddon>
             <Select
@@ -55,6 +56,7 @@
               :options="sortFields"
               option-label="name"
               option-value="value"
+              :aria-label="$t('app.sort_by')"
               :pt="{
                 listContainer: {
                   'data-test': 'sorting-type-dropdown-items',
@@ -72,6 +74,11 @@
                   sortOrder === 1
                     ? 'fa-solid fa-arrow-up-short-wide'
                     : 'fa-solid fa-arrow-down-wide-short'
+                "
+                :aria-label="
+                  sortOrder === 1
+                    ? $t('app.sort_ascending')
+                    : $t('app.sort_descending')
                 "
                 severity="secondary"
                 text

--- a/resources/js/components/RoomTabRecordings.vue
+++ b/resources/js/components/RoomTabRecordings.vue
@@ -22,7 +22,7 @@
         </search>
         <div class="flex flex-col gap-2 lg:flex-row">
           <InputGroup v-if="userPermissions.can('manageSettings', props.room)">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-filter"></i>
             </InputGroupAddon>
             <Select
@@ -32,6 +32,7 @@
               option-label="name"
               option-value="value"
               data-test="filter-dropdown"
+              :aria-label="$t('app.filter')"
               :pt="{
                 listContainer: {
                   'data-test': 'filter-dropdown-items',
@@ -45,7 +46,7 @@
           </InputGroup>
 
           <InputGroup data-test="sorting-type-inputgroup">
-            <InputGroupAddon>
+            <InputGroupAddon aria-hidden="true">
               <i class="fa-solid fa-sort"></i>
             </InputGroupAddon>
             <Select
@@ -55,6 +56,7 @@
               option-label="name"
               option-value="value"
               data-test="sorting-type-dropdown"
+              :aria-label="$t('app.sort_by')"
               :pt="{
                 listContainer: {
                   'data-test': 'sorting-type-dropdown-items',
@@ -72,6 +74,11 @@
                   sortOrder === 1
                     ? 'fa-solid fa-arrow-up-short-wide'
                     : 'fa-solid fa-arrow-down-wide-short'
+                "
+                :aria-label="
+                  sortOrder === 1
+                    ? $t('app.sort_ascending')
+                    : $t('app.sort_descending')
                 "
                 severity="secondary"
                 text

--- a/resources/js/components/SettingsRoomTypesDeleteButton.vue
+++ b/resources/js/components/SettingsRoomTypesDeleteButton.vue
@@ -29,12 +29,11 @@
       class="field flex flex-col gap-2"
       data-test="replacement-room-type-field"
     >
-      <label for="replacement-room-type">{{
+      <label id="replacement-room-type-label">{{
         $t("admin.room_types.delete.replacement")
       }}</label>
       <InputGroup>
         <Select
-          id="replacement-room-type"
           v-model.number="replacement"
           data-test="replacement-room-type-dropdown"
           :disabled="
@@ -49,6 +48,7 @@
           option-group-children="items"
           option-value="value"
           option-label="text"
+          aria-labelledby="replacement-room-type-label"
           :pt="{
             listContainer: {
               'data-test': 'replacement-room-type-dropdown-items',

--- a/resources/js/components/SettingsRoomTypesDeleteButton.vue
+++ b/resources/js/components/SettingsRoomTypesDeleteButton.vue
@@ -49,7 +49,6 @@
           option-group-children="items"
           option-value="value"
           option-label="text"
-          aria-describedby="replacement-help"
           :pt="{
             listContainer: {
               'data-test': 'replacement-room-type-dropdown-items',
@@ -59,6 +58,7 @@
             },
             optionGroup: 'p-0',
             label: {
+              'aria-describedby': 'replacement-help',
               autofocus: true,
             },
           }"

--- a/resources/js/views/AdminRoomTypesView.vue
+++ b/resources/js/views/AdminRoomTypesView.vue
@@ -249,7 +249,11 @@
                   input-id="restrict"
                   :invalid="formErrors.fieldInvalid('restrict')"
                   :disabled="isBusy || modelLoadingError || viewOnly"
-                  aria-describedby="restrict-help"
+                  :pt="{
+                    input: {
+                      'aria-describedby': 'restrict-help',
+                    },
+                  }"
                 />
               </div>
               <FormError :errors="formErrors.fieldError('restrict')" />

--- a/resources/js/views/AdminServersView.vue
+++ b/resources/js/views/AdminServersView.vue
@@ -138,6 +138,7 @@
         <fieldset
           class="field grid grid-cols-12 gap-4"
           data-test="strength-field"
+          aria-describedby="strength-help"
         >
           <legend class="col-span-12 md:col-span-4 md:mb-0">
             {{ $t("admin.servers.strength") }}
@@ -150,7 +151,6 @@
               :disabled="isBusy || modelLoadingError || viewOnly"
               :invalid="formErrors.fieldInvalid('strength')"
               :stars="10"
-              aria-describedby="strength-help"
               class="flex justify-between rounded-border border border-surface-300 px-6 py-3 dark:border-surface-600"
               data-test="strength-rating"
               :pt="{

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -893,7 +893,7 @@
                   :disabled="disabled"
                   aria-labelledby="room-personalized-link-expiration-label"
                   :pt="{
-                    input: {
+                    label: {
                       'aria-describedby':
                         'room-personalized-link-expiration-help',
                     },
@@ -943,7 +943,7 @@
                   :disabled="disabled"
                   aria-labelledby="room-auto-delete-deadline-period-label"
                   :pt="{
-                    input: {
+                    label: {
                       'aria-describedby':
                         'room-auto-delete-deadline-period-help',
                     },
@@ -991,7 +991,7 @@
                   :disabled="disabled"
                   aria-labelledby="room-auto-delete-inactive-period-label"
                   :pt="{
-                    input: {
+                    label: {
                       'aria-describedby':
                         'room-auto-delete-inactive-period-help',
                     },
@@ -1041,7 +1041,7 @@
                   :disabled="disabled"
                   aria-labelledby="room-auto-delete-never-used-period-label"
                   :pt="{
-                    input: {
+                    label: {
                       'aria-describedby':
                         'room-auto-delete-never-used-period-help',
                     },

--- a/resources/js/views/AdminUsersNew.vue
+++ b/resources/js/views/AdminUsersNew.vue
@@ -141,7 +141,11 @@
                   input-id="generate_password"
                   :invalid="formErrors.fieldInvalid('generate_password')"
                   :disabled="isBusy"
-                  aria-describedby="generate_password-help"
+                  :pt="{
+                    input: {
+                      'aria-describedby': 'generate_password-help',
+                    },
+                  }"
                 />
               </div>
               <FormError :errors="formErrors.fieldError('generate_password')" />

--- a/resources/js/views/RoomsIndex.vue
+++ b/resources/js/views/RoomsIndex.vue
@@ -126,7 +126,7 @@
               v-if="!onlyShowFavorites"
               data-test="room-type-inputgroup"
             >
-              <InputGroupAddon>
+              <InputGroupAddon aria-hidden="true">
                 <i class="fa-solid fa-tag"></i>
               </InputGroupAddon>
               <InputGroupAddon
@@ -150,6 +150,7 @@
                 option-group-label="index"
                 option-group-children="items"
                 option-value="id"
+                :aria-label="$t('rooms.index.filter_by_room_type')"
                 :pt="{
                   listContainer: {
                     'data-test': 'room-type-dropdown-items',
@@ -187,7 +188,7 @@
 
             <!--dropdown for sorting type (on small devices only shown, when filter menu is open)-->
             <InputGroup>
-              <InputGroupAddon>
+              <InputGroupAddon aria-hidden="true">
                 <i class="fa-solid fa-sort"></i>
               </InputGroupAddon>
               <Select
@@ -197,6 +198,7 @@
                 :options="sortingTypes"
                 option-label="label"
                 option-value="type"
+                :aria-label="$t('app.sort_by')"
                 :pt="{
                   listContainer: {
                     'data-test': 'sorting-type-dropdown-items',


### PR DESCRIPTION
# Fixes #2315 

## Type

- Bugfix
- Feature
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe): **Accessibility**

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [ ] Tests added for the bugfix or newly implemented feature, describe below why if not
- [ ] Changelog is updated
- [ ] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Accessibility: Removed unused aria-describedby
- Accessibility: Fixed aria-describedby in Admin UI
- Accessibility: Add aria-labels to filter and sort select elements in room tabs

## Other information
VueMultiselect `<Multiselect/>` is still **not** accessible and cannot be fixed easily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized labels for filtering and sorting controls across room lists and room management screens.
  * Added clear ascending and descending labels for sort controls.

* **Bug Fixes**
  * Improved screen reader support by correctly labeling controls and hiding decorative icons.
  * Improved accessibility for form fields, toggles, selectors, and confirmation dialogs by associating help text and descriptions more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->