### PR TITLE
Add system wide welcome message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Environment variable `VERSION` to change the displayed version in the footer ([#3300], [#3302])
+- System-wide default welcome message ([#3301])
 
 ## [v4.17.0] - 2026-07-09
 
@@ -864,6 +865,7 @@ You can find the changelog for older versions there [here](https://github.com/TH
 [#3277]: https://github.com/THM-Health/PILOS/pull/3277
 [#3296]: https://github.com/THM-Health/PILOS/pull/3296
 [#3300]: https://github.com/THM-Health/PILOS/issues/3300
+[#3301]: https://github.com/THM-Health/PILOS/pull/3301
 [#3302]: https://github.com/THM-Health/PILOS/pull/3302
 [unreleased]: https://github.com/THM-Health/PILOS/compare/v4.17.0...develop
 [v3.0.0]: https://github.com/THM-Health/PILOS/releases/tag/v3.0.0

--- a/app/Http/Controllers/api/v1/SettingsController.php
+++ b/app/Http/Controllers/api/v1/SettingsController.php
@@ -208,6 +208,8 @@ class SettingsController extends Controller
         $recordingSettings->attendance_retention_period = $request->enum('recording_attendance_retention_period', TimePeriod::class);
         $recordingSettings->recording_retention_period = $request->enum('recording_recording_retention_period', TimePeriod::class);
 
+        $bigBlueButtonSettings->default_welcome_message = $request->input('bbb_default_welcome_message');
+
         $generalSettings->save();
         $themeSettings->save();
         $roomSettings->save();

--- a/app/Http/Requests/UpdateSettingsRequest.php
+++ b/app/Http/Requests/UpdateSettingsRequest.php
@@ -90,6 +90,7 @@ class UpdateSettingsRequest extends FormRequest
 
             'bbb_style' => ['bail', 'nullable', 'file', 'max:500', 'extensions:css', new Antivirus],
             'bbb_default_presentation' => ['bail', 'nullable', 'file', 'max:'.(config('bigbluebutton.max_filesize') * 1000), 'mimes:'.config('bigbluebutton.allowed_file_mimes'), new Antivirus],
+            'bbb_default_welcome_message' => ['bail', 'nullable', 'max:'.config('bigbluebutton.welcome_message_limit'), 'string'],
         ];
     }
 }

--- a/app/Http/Resources/SettingsResource.php
+++ b/app/Http/Resources/SettingsResource.php
@@ -80,6 +80,7 @@ class SettingsResource extends JsonResource
             'bbb_logo_dark' => $bigBlueButtonSettings->logo_dark,
             'bbb_style' => $bigBlueButtonSettings->style,
             'bbb_default_presentation' => $bigBlueButtonSettings->default_presentation,
+            'bbb_default_welcome_message' => $bigBlueButtonSettings->default_welcome_message,
         ];
     }
 }

--- a/app/Services/MeetingService.php
+++ b/app/Services/MeetingService.php
@@ -124,8 +124,11 @@ class MeetingService
             $meetingParams->addPresentation(app(BigBlueButtonSettings::class)->default_presentation);
         }
 
+        // Set default welcome message
+        $meetingParams->setWelcome(app(BigBlueButtonSettings::class)->default_welcome_message);
+
         // Set welcome message if expert mode is activated
-        if ($this->meeting->room->expert_mode) {
+        if ($this->meeting->room->expert_mode && $this->meeting->room->welcome) {
             $meetingParams->setWelcome($this->meeting->room->welcome);
         }
 

--- a/app/Settings/BigBlueButtonSettings.php
+++ b/app/Settings/BigBlueButtonSettings.php
@@ -16,6 +16,8 @@ class BigBlueButtonSettings extends Settings
 
     public ?string $default_presentation;
 
+    public ?string $default_welcome_message;
+
     public static function group(): string
     {
         return 'bbb';

--- a/database/settings/2026_06_16_153843_add_default_welcome_message.php
+++ b/database/settings/2026_06_16_153843_add_default_welcome_message.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('bbb.default_welcome_message');
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('bbb.default_welcome_message');
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -287,6 +287,9 @@ return [
             'title' => 'Banner for messages',
         ],
         'bbb' => [
+            'default_welcome_message' => [
+                'title' => 'Default Welcome Message',
+            ],
             'logo' => [
                 'alt' => 'Logo preview',
                 'hint' => 'https://domain.tld/path/logo.svg',

--- a/lang/en/app.php
+++ b/lang/en/app.php
@@ -28,7 +28,7 @@ return [
     'cancel' => 'Cancel',
     'cancel_editing' => 'Cancel editing',
     'change_locale' => 'Change language',
-    'char_counter' => 'Characters: :chars',
+    'char_counter' => 'Characters: :chars / :max',
     'close' => 'Close',
     'continue' => 'Continue',
     'dark_mode_disable' => 'Disable Dark mode',

--- a/lang/en/rooms.php
+++ b/lang/en/rooms.php
@@ -413,7 +413,6 @@ return [
             'access_code_prohibited' => 'The room type enforces the absence of an access code',
             'allow' => 'Allow',
             'allow_guests' => 'Allow guests',
-            'chars' => 'Characters: :chars',
             'delete_access_code' => 'Remove access code',
             'enforced_setting' => 'Enforced setting',
             'generate_access_code' => 'Create new access code',

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -78,7 +78,7 @@
         <small>
           {{
             $t("app.char_counter", {
-              chars: newDescription.length,
+              chars: newDescription?.length || 0,
               max: settingsStore.getSetting(
                 "recording.recording_description_limit",
               ),

--- a/resources/js/components/RoomTabRecordingsEditButton.vue
+++ b/resources/js/components/RoomTabRecordingsEditButton.vue
@@ -76,7 +76,14 @@
         />
         <FormError :errors="formErrors.fieldError('description')" />
         <small>
-          {{ $t("app.char_counter", { chars: charactersLeftDescription }) }}
+          {{
+            $t("app.char_counter", {
+              chars: newDescription.length,
+              max: settingsStore.getSetting(
+                "recording.recording_description_limit",
+              ),
+            })
+          }}
         </small>
       </div>
 
@@ -138,7 +145,7 @@
 <script setup>
 import { useApi } from "../composables/useApi.js";
 import { useFormErrors } from "../composables/useFormErrors.js";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import * as _ from "lodash-es";
 import { useSettingsStore } from "../stores/settings.js";
 import { useToast } from "../composables/useToast.js";
@@ -198,18 +205,6 @@ const newFormats = ref([]);
 const newAccess = ref(null);
 const isLoadingAction = ref(false);
 const accessTypes = ref([0, 1, 2, 3]);
-
-/**
- * Count the chars of the description
- * @returns {string} amount of chars in comparison to the limit
- */
-const charactersLeftDescription = computed(() => {
-  return (
-    newDescription.value.length +
-    " / " +
-    settingsStore.getSetting("recording.recording_description_limit")
-  );
-});
 
 /**
  * show modal to edit recording

--- a/resources/js/components/RoomTabSettingsTextArea.vue
+++ b/resources/js/components/RoomTabSettingsTextArea.vue
@@ -24,8 +24,9 @@
       />
       <small v-if="max">
         {{
-          $t("rooms.settings.general.chars", {
-            chars: charactersLeft,
+          $t("app.char_counter", {
+            chars: model[props.setting]?.length || 0,
+            max: props.max,
           })
         }}
       </small>
@@ -39,7 +40,6 @@
 
 <script setup>
 import FormError from "./FormError.vue";
-import { computed } from "vue";
 
 const model = defineModel({ type: Object });
 
@@ -94,16 +94,5 @@ const props = defineProps({
     required: false,
     default: null,
   },
-});
-
-/**
- * Count the chars of the short description
- * @returns {string} amount of chars in comparison to the limit
- */
-const charactersLeft = computed(() => {
-  const char = model.value[props.setting]
-    ? model.value[props.setting].length
-    : 0;
-  return char + " / " + props.max;
 });
 </script>

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1522,7 +1522,7 @@
               data-test="bbb-default-welcome-message-field"
             >
               <label
-                for="bbb-client-settings"
+                for="bbb-default-welcome-message"
                 class="col-span-12 md:col-span-4 md:mb-0"
                 >{{
                   $t("admin.settings.bbb.default_welcome_message.title")

--- a/resources/js/views/AdminSettings.vue
+++ b/resources/js/views/AdminSettings.vue
@@ -1080,6 +1080,7 @@
                   id="room-file-terms-of-use"
                   v-model="settings.room_file_terms_of_use"
                   rows="3"
+                  auto-resize
                   :invalid="formErrors.fieldInvalid('room_file_terms_of_use')"
                   :disabled="disabled"
                   aria-describedby="room-file-terms-of-use-help"
@@ -1516,6 +1517,46 @@
                 />
               </div>
             </fieldset>
+            <div
+              class="field grid grid-cols-12 gap-4"
+              data-test="bbb-default-welcome-message-field"
+            >
+              <label
+                for="bbb-client-settings"
+                class="col-span-12 md:col-span-4 md:mb-0"
+                >{{
+                  $t("admin.settings.bbb.default_welcome_message.title")
+                }}</label
+              >
+              <div class="col-span-12 flex flex-col gap-1 md:col-span-8">
+                <Textarea
+                  id="bbb-default-welcome-message"
+                  v-model="settings.bbb_default_welcome_message"
+                  rows="3"
+                  auto-resize
+                  :invalid="
+                    formErrors.fieldInvalid('bbb_default_welcome_message')
+                  "
+                  :maxlength="
+                    settingsStore.getSetting('bbb.welcome_message_limit')
+                  "
+                  :disabled="disabled"
+                />
+                <small>
+                  {{
+                    $t("app.char_counter", {
+                      chars: settings.bbb_default_welcome_message?.length || 0,
+                      max: settingsStore.getSetting(
+                        "bbb.welcome_message_limit",
+                      ),
+                    })
+                  }}
+                </small>
+                <FormError
+                  :errors="formErrors.fieldError('bbb_default_welcome_message')"
+                />
+              </div>
+            </div>
           </AdminPanel>
         </div>
       </OverlayComponent>

--- a/tests/Backend/Feature/api/v1/SettingsTest.php
+++ b/tests/Backend/Feature/api/v1/SettingsTest.php
@@ -103,6 +103,7 @@ class SettingsTest extends TestCase
         $this->bigBlueButtonSettings->logo = url('logo.png');
         $this->bigBlueButtonSettings->logo_dark = url('logo_dark.png');
         $this->bigBlueButtonSettings->default_presentation = url('presentation.pdf');
+        $this->bigBlueButtonSettings->default_welcome_message = 'Welcome Text';
         $this->bigBlueButtonSettings->save();
 
         config(['recording.max_retention_period' => 90]);
@@ -175,6 +176,7 @@ class SettingsTest extends TestCase
                     'bbb_logo' => url('logo.png'),
                     'bbb_logo_dark' => url('logo_dark.png'),
                     'bbb_default_presentation' => url('presentation.pdf'),
+                    'bbb_default_welcome_message' => 'Welcome Text',
                 ],
                 'meta' => [
                     'link_btn_styles' => array_column($linkStyles, 'value'),
@@ -236,6 +238,7 @@ class SettingsTest extends TestCase
 
             'bbb_logo' => 'bbblogo.png',
             'bbb_logo_dark' => 'bbblogo_dark.png',
+            'bbb_default_welcome_message' => 'Welcome Demo',
         ];
 
         // Unauthorized Test
@@ -299,6 +302,7 @@ class SettingsTest extends TestCase
 
                     'bbb_logo' => 'bbblogo.png',
                     'bbb_logo_dark' => 'bbblogo_dark.png',
+                    'bbb_default_welcome_message' => 'Welcome Demo',
                 ],
             ]);
         $this->assertEquals('http://localhost', app(GeneralSettings::class)->help_url);
@@ -311,6 +315,7 @@ class SettingsTest extends TestCase
         $payload['general_privacy_policy_url'] = '';
         $payload['general_accessibility_statement_url'] = '';
         $payload['room_file_terms_of_use'] = '';
+        $payload['bbb_default_welcome_message'] = '';
 
         $this->putJson(route('api.v1.settings.update'), $payload)
             ->assertSuccessful();
@@ -320,6 +325,7 @@ class SettingsTest extends TestCase
         $this->assertNull(app(GeneralSettings::class)->privacy_policy_url);
         $this->assertNull(app(GeneralSettings::class)->accessibility_statement_url);
         $this->assertNull(app(RoomSettings::class)->file_terms_of_use);
+        $this->assertNull(app(BigBlueButtonSettings::class)->default_welcome_message);
     }
 
     /**
@@ -742,6 +748,7 @@ class SettingsTest extends TestCase
         $this->user->roles()->attach($role);
 
         config(['recording.max_retention_period' => -1]);
+        config(['bigbluebutton.welcome_message_limit' => 100]);
 
         // inputs lower than allowed minimum
         $this->actingAs($this->user)->putJson(route('api.v1.settings.update'), [
@@ -835,6 +842,8 @@ class SettingsTest extends TestCase
             'recording_meeting_usage_retention_period' => 366,
             'recording_attendance_retention_period' => 366,
             'recording_recording_retention_period' => 90,
+
+            'bbb_default_welcome_message' => str_repeat('a', 101),
         ])
             ->assertUnprocessable()
             ->assertJsonValidationErrors([
@@ -849,6 +858,7 @@ class SettingsTest extends TestCase
                 'recording_meeting_usage_retention_period',
                 'recording_attendance_retention_period',
                 'recording_recording_retention_period',
+                'bbb_default_welcome_message',
             ]);
 
         // test setting recording retention period to a value higher than max allowed retention period

--- a/tests/Backend/Unit/MeetingTest.php
+++ b/tests/Backend/Unit/MeetingTest.php
@@ -352,6 +352,69 @@ class MeetingTest extends TestCase
     }
 
     /**
+     * Test welcome message
+     */
+    public function test_start_parameters_welcome_message()
+    {
+        $meeting = $this->meeting;
+
+        Http::fake([
+            'test.notld/bigbluebutton/api/create*' => Http::response(file_get_contents(__DIR__.'/../Fixtures/Success.xml')),
+        ]);
+
+        $server = Server::factory()->create();
+        $meeting->server()->associate($server);
+
+        $serverService = new ServerService($server);
+
+        // Test without welcome message configured in the room
+        // and without a global welcome message
+
+        $meetingService = new MeetingService($meeting);
+        $meetingService->setServerService($serverService)->start();
+        $request = Http::recorded()[0][0];
+        $data = $request->data();
+        $this->assertArrayNotHasKey('welcome', $data);
+
+        // Test without welcome message configured in the room
+        // and with a global welcome message
+
+        $this->bigBlueButtonSettings->default_welcome_message = 'Demo';
+        $this->bigBlueButtonSettings->save();
+
+        $meetingService = new MeetingService($meeting);
+        $meetingService->setServerService($serverService)->start();
+        $request = Http::recorded()[1][0];
+        $data = $request->data();
+        $this->assertEquals('Demo', $data['welcome']);
+
+        // Test with welcome message configured in the room
+        // but expert mode is disabled and with a global welcome message
+
+        $this->meeting->room->welcome = 'Hello';
+        $this->meeting->room->expert_mode = false;
+        $this->meeting->room->save();
+
+        $meetingService = new MeetingService($meeting);
+        $meetingService->setServerService($serverService)->start();
+        $request = Http::recorded()[2][0];
+        $data = $request->data();
+        $this->assertEquals('Demo', $data['welcome']);
+
+        // Test with welcome message configured in the room
+        // but expert mode is enabled and with a global welcome message
+
+        $this->meeting->room->expert_mode = true;
+        $this->meeting->room->save();
+
+        $meetingService = new MeetingService($meeting);
+        $meetingService->setServerService($serverService)->start();
+        $request = Http::recorded()[3][0];
+        $data = $request->data();
+        $this->assertEquals('Hello', $data['welcome']);
+    }
+
+    /**
      * Test room start without own presentations but global presentation
      */
     public function test_start_parameters_without_own_presentation()

--- a/tests/Frontend/e2e/AdminSettingsEdit.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsEdit.cy.js
@@ -2760,12 +2760,28 @@ describe("Admin settings with edit permission", function () {
         cy.checkSettingsFileSelector("", "testFile.txt", true);
       });
 
+    cy.get('[data-test="bbb-default-welcome-message-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.bbb.default_welcome_message.title")
+      .and("include.text", 'app.char_counter_{"chars":0,"max":500}')
+      .within(() => {
+        cy.get("#bbb-default-welcome-message")
+          .should("have.value", "")
+          .and("be.not.disabled")
+          .type("Welcome to BBB");
+      });
+    cy.get('[data-test="bbb-default-welcome-message-field"]').should(
+      "include.text",
+      'app.char_counter_{"chars":14,"max":500}',
+    );
+
     // Save changes
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = "/images/logo.svg";
       settings.data.bbb_logo_dark = "/images/logo-dark.svg";
       settings.data.bbb_style = "/files/bbb_style.css";
       settings.data.bbb_default_presentation = "/files/testFile.txt";
+      settings.data.bbb_default_welcome_message = "Welcome to BigBlueButton";
 
       const saveChangesRequest = interceptIndefinitely(
         "POST",
@@ -2843,6 +2859,10 @@ describe("Admin settings with edit permission", function () {
           expect(content).to.eql(base64);
         });
       });
+
+      expect(formData.get("bbb_default_welcome_message")).to.equal(
+        "Welcome to BBB",
+      );
     });
 
     // Check that config is loaded
@@ -2994,12 +3014,28 @@ describe("Admin settings with edit permission", function () {
         .click();
     });
 
+    cy.get('[data-test="bbb-default-welcome-message-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.bbb.default_welcome_message.title")
+      .and("include.text", 'app.char_counter_{"chars":24,"max":500}')
+      .within(() => {
+        cy.get("#bbb-default-welcome-message")
+          .should("have.value", "Welcome to BigBlueButton")
+          .and("be.not.disabled")
+          .clear();
+      });
+    cy.get('[data-test="bbb-default-welcome-message-field"]').should(
+      "include.text",
+      'app.char_counter_{"chars":0,"max":500}',
+    );
+
     // Save changes
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = null;
       settings.data.bbb_logo_dark = null;
       settings.data.bbb_style = null;
       settings.data.bbb_default_presentation = null;
+      settings.data.bbb_default_welcome_message = null;
 
       cy.intercept("POST", "api/v1/settings", {
         statusCode: 200,
@@ -3022,6 +3058,7 @@ describe("Admin settings with edit permission", function () {
       expect(formData.get("bbb_logo_dark")).to.eql("");
       expect(formData.get("bbb_style")).to.eql("");
       expect(formData.get("bbb_default_presentation")).to.be.eql("");
+      expect(formData.get("bbb_default_welcome_message")).to.be.eql("");
     });
 
     // Check that config is loaded
@@ -3209,6 +3246,9 @@ describe("Admin settings with edit permission", function () {
           bbb_style: ["The bbb style field is required."],
           bbb_default_presentation: [
             "The bbb default presentation field is required.",
+          ],
+          bbb_default_welcome_message: [
+            "The bbb default welcome message must not be greater than 500 characters.",
           ],
         },
       },
@@ -3401,6 +3441,11 @@ describe("Admin settings with edit permission", function () {
       "The bbb default presentation field is required.",
     );
 
+    cy.get('[data-test="bbb-default-welcome-message-field"]').should(
+      "include.text",
+      "The bbb default welcome message must not be greater than 500 characters.",
+    );
+
     // Check with 500 error
     cy.intercept("POST", "api/v1/settings", {
       statusCode: 500,
@@ -3590,6 +3635,10 @@ describe("Admin settings with edit permission", function () {
     cy.get('[data-test="default-presentation-field"]').should(
       "not.include.text",
       "The bbb default presentation field is required.",
+    );
+    cy.get('[data-test="bbb-default-welcome-message-field"]').should(
+      "not.include.text",
+      "The bbb default welcome message must not be greater than 500 characters.",
     );
 
     // Check with 413 error (payload too large)

--- a/tests/Frontend/e2e/AdminSettingsView.cy.js
+++ b/tests/Frontend/e2e/AdminSettingsView.cy.js
@@ -867,12 +867,24 @@ describe("Admin settings with edit permission", function () {
         cy.checkSettingsFileSelectorOnlyView("");
       });
 
+    cy.get('[data-test="bbb-default-welcome-message-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.bbb.default_welcome_message.title")
+      .and("include.text", 'app.char_counter_{"chars":0,"max":500}')
+      .within(() => {
+        cy.get("#bbb-default-welcome-message")
+          .should("have.value", "")
+          .and("be.disabled");
+      });
+
     // Reload with different settings
     cy.fixture("settings.json").then((settings) => {
       settings.data.bbb_logo = null;
       settings.data.bbb_logo_dark = null;
       settings.data.bbb_style = "/files/bbb_style.css";
       settings.data.bbb_default_presentation = "/files/testFile.txt";
+      settings.data.bbb_default_welcome_message =
+        "Welcome to our BigBlueButton meetings!";
 
       cy.intercept("GET", "api/v1/settings", {
         statusCode: 200,
@@ -910,6 +922,16 @@ describe("Admin settings with edit permission", function () {
       .and("include.text", "admin.settings.default_presentation")
       .within(() => {
         cy.checkSettingsFileSelectorOnlyView("/files/testFile.txt");
+      });
+
+    cy.get('[data-test="bbb-default-welcome-message-field"]')
+      .should("be.visible")
+      .and("include.text", "admin.settings.bbb.default_welcome_message.title")
+      .and("include.text", 'app.char_counter_{"chars":38,"max":500}')
+      .within(() => {
+        cy.get("#bbb-default-welcome-message")
+          .should("have.value", "Welcome to our BigBlueButton meetings!")
+          .and("be.disabled");
       });
   });
 });

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -100,10 +100,7 @@ describe("Rooms view settings", function () {
     cy.get('[data-test="room-setting-short_description"]')
       .should("be.visible")
       .should("include.text", "rooms.settings.general.short_description")
-      .should(
-        "include.text",
-        'app.char_counter_{"chars":17,"max":300}',
-      )
+      .should("include.text", 'app.char_counter_{"chars":17,"max":300}')
       .find("#room-setting-short_description")
       .should("have.value", "Short description");
 
@@ -179,10 +176,7 @@ describe("Rooms view settings", function () {
     cy.get('[data-test="room-setting-welcome"]')
       .should("be.visible")
       .should("include.text", "rooms.settings.video_conference.welcome_message")
-      .should(
-        "include.text",
-        'app.char_counter_{"chars":0,"max":500}',
-      )
+      .should("include.text", 'app.char_counter_{"chars":0,"max":500}')
       .find("#room-setting-welcome")
       .should("have.value", "");
 

--- a/tests/Frontend/e2e/RoomsViewSettings.cy.js
+++ b/tests/Frontend/e2e/RoomsViewSettings.cy.js
@@ -102,7 +102,7 @@ describe("Rooms view settings", function () {
       .should("include.text", "rooms.settings.general.short_description")
       .should(
         "include.text",
-        'rooms.settings.general.chars_{"chars":"17 / 300"}',
+        'app.char_counter_{"chars":17,"max":300}',
       )
       .find("#room-setting-short_description")
       .should("have.value", "Short description");
@@ -181,7 +181,7 @@ describe("Rooms view settings", function () {
       .should("include.text", "rooms.settings.video_conference.welcome_message")
       .should(
         "include.text",
-        'rooms.settings.general.chars_{"chars":"0 / 500"}',
+        'app.char_counter_{"chars":0,"max":500}',
       )
       .find("#room-setting-welcome")
       .should("have.value", "");

--- a/tests/Frontend/fixtures/settings.json
+++ b/tests/Frontend/fixtures/settings.json
@@ -42,7 +42,8 @@
     "bbb_logo": "/images/logo.svg",
     "bbb_logo_dark": "/images/logo-dark.svg",
     "bbb_style": null,
-    "bbb_default_presentation": null
+    "bbb_default_presentation": null,
+    "bbb_default_welcome_message": null
   },
   "meta": {
     "link_btn_styles": ["primary", "secondary", "link"],


### PR DESCRIPTION
## Type

- Bugfix
- **Feature**
- Documentation
- Refactoring (e.g. Style updates, Test implementation, etc.)
- Other (please describe):

<!-- Please complete the checklist as best as possible, not all points are always applicable, but they can help to not forget something -->

## Checklist

- [x] Code updated to current develop branch head
- [x] Passes CI checks
- [ ] Is a part of an issue
- [x] Tests added for the bugfix or newly implemented feature, describe below why if not
- [x] Changelog is updated
- [x] Documentation of code and features exists

<!-- A brief bullet point list of each change being made with this pull request. -->

## Changes

- Add system-wide default welcome message

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an administrator setting for a system-wide BigBlueButton default welcome message.
  * Applied the default message to meetings, with room-specific messages taking precedence in expert mode.
  * Added validation, character limits, counters, and API support for the setting.

* **Improvements**
  * Updated character counters to display current and maximum limits consistently.
  * Enabled automatic resizing for relevant settings text areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->