### PR TITLE
Cypress config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -46,7 +46,6 @@ export default defineConfig({
       return config;
     },
     baseUrl: baseUrl,
-    experimentalStudio: true,
     supportFile: "tests/Frontend/support/e2e.{js,jsx,ts,tsx}",
     specPattern: "tests/Frontend/e2e/**/*.cy.{js,jsx,ts,tsx}",
   },

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,6 +10,8 @@ export default defineConfig({
   screenshotsFolder: "tests/Frontend/screenshots",
   videosFolder: "tests/Frontend/videos",
 
+  allowCypressEnv: false,
+
   expose: {
     redirectBaseUrl: "https://thm-health.github.io/PILOS-Redirect_Test_Pages",
   },

--- a/tests/System/cypress.config.js
+++ b/tests/System/cypress.config.js
@@ -13,7 +13,6 @@ export default defineConfig({
 
   e2e: {
     baseUrl: "http://localhost:9080",
-    experimentalStudio: true,
     supportFile: "support/e2e.{js,jsx,ts,tsx}",
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
   },

--- a/tests/System/cypress.config.js
+++ b/tests/System/cypress.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
   screenshotsFolder: "screenshots",
   videosFolder: "videos",
 
+  allowCypressEnv: false,
+
   e2e: {
     baseUrl: "http://localhost:9080",
     supportFile: "support/e2e.{js,jsx,ts,tsx}",

--- a/tests/Visual/cypress.config.js
+++ b/tests/Visual/cypress.config.js
@@ -9,6 +9,8 @@ export default defineConfig({
   screenshotsFolder: "screenshots",
   videosFolder: "videos",
 
+  allowCypressEnv: false,
+
   e2e: {
     setupNodeEvents(on, config) {
       happoTask.register(on);

--- a/tests/Visual/cypress.config.js
+++ b/tests/Visual/cypress.config.js
@@ -19,7 +19,6 @@ export default defineConfig({
     },
 
     baseUrl: baseUrl,
-    experimentalStudio: true,
     supportFile: "support/e2e.{js,jsx,ts,tsx}",
     specPattern: "e2e/**/*.cy.{js,jsx,ts,tsx}",
   },


### PR DESCRIPTION
Fixes these warnings before each cypress run

> The experimentalStudio option was removed in Cypress version 15.4.0.
> 
> Cypress Studio is now available for all users.
> 
> You can safely remove this option from your config.
> Warning: The allowCypressEnv configuration option is enabled. This allows any browser code to read values from Cypress.env(). This is insecure and will be removed in a future major version.
> 
> 1. Replace Cypress.env() calls with cy.env() (for sensitive values) or Cypress.expose() (for public configuration)
> 2. Set allowCypressEnv: false in your Cypress configuration to disable Cypress.env()
> 
> Learn more: https://on.cypress.io/cypress-env-migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated end-to-end and visual test configuration to prevent Cypress from automatically loading environment variables.
  - Removed the deprecated experimental test-authoring option from Cypress settings.
  - Standardized Cypress behavior across test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->